### PR TITLE
fix-RDBC-63 'super' keyword unexpected here

### DIFF
--- a/src/Database/Operations/OperationExecutor.ts
+++ b/src/Database/Operations/OperationExecutor.ts
@@ -149,12 +149,16 @@ export class ServerOperationExecutor extends AbstractOperationExecutor implement
       : ClusterRequestExecutor.create(store.urls);
   }
 
+  private sendOperation(operation: IOperation){
+        return super.send(operation);
+  }
+
   public async send(operation: IOperation): Promise<IRavenResponse | IRavenResponse[] | void> {
     if (!(operation instanceof ServerOperation)) {
       return BluebirdPromise.reject(new InvalidOperationException('Invalid operation passed. It should be derived from ServerOperation'));
     }
 
-    return super.send(operation);
+    return this.sendOperation(operation);
   }
 
   public dispose(): void {
@@ -173,11 +177,15 @@ export class AdminOperationExecutor extends AbstractDatabaseOperationExecutor {
     return this._server;
   }
 
+  private sendOperation(operation: IOperation){
+        return super.send(operation);
+  }
+
   public async send(operation: IOperation): Promise<IRavenResponse | IRavenResponse[] | void> {
     if (!(operation instanceof AdminOperation)) {
       return BluebirdPromise.reject(new InvalidOperationException('Invalid operation passed. It should be derived from ServerOperation'));
     }
-    
-    return super.send(operation);
+
+      return this.sendOperation(operation);
   }
 }


### PR DESCRIPTION
On the newest version of typescript compiler, have been changed behavior for compiled ts code, this affects context for 'super' keyword. Please consider example:
```javascript
//class foo{
//async function send(){} 

//output from older compiler version - good
send(someValue){
const s = e => super[e];
return e(function(){s("send").call(this, someValue)});
}	
// output from newer compiler version - 'super' bug
send(someValue){
return e(function(){(e=>super[e])("send").call(this, someValue)});
//as you see there's no "s" const, and compiler decides to run all inline context
}
```

to avoid this bug, please keep in mind, calling 'super' (for example in async function) have to be protected by calling method that shares 'super' context itself
