### PR TITLE
fix exceptions on PutCompareExchangeValueOperation

### DIFF
--- a/src/Documents/Operations/CompareExchange/PutCompareExchangeValueOperation.ts
+++ b/src/Documents/Operations/CompareExchange/PutCompareExchangeValueOperation.ts
@@ -72,7 +72,7 @@ export class PutCompareExchangeValueCommand<T> extends RavenCommand<CompareExcha
     }
 
     public createRequest(node: ServerNode): HttpRequestParameters {
-        const uri = node.url + "/databases/" + node.database + "/cmpxchg?key=" + this._key + "&index=" + this._index;
+        const uri = node.url + "/databases/" + node.database + "/cmpxchg?key=" + encodeURIComponent(this._key) + "&index=" + this._index;
 
         const tuple = {};
         tuple["Object"] = TypeUtil.isPrimitive(this._value)


### PR DESCRIPTION
Hello everyone. We are having some problems on our project when trying to PutCompareExchangeValueOperation which contains some special characters.
Something like: "permissões" (it means permissions in portuguese).
It's important to note that if I create the key using the web studio, everything works fine.
However when using the nodejs API an exception is thrown.

So this commit adds the support for encoding the key property of
PutCompareExchangeValueOperation, thus allowing it to be used
with special characters which would break the URL otherwise.
This function is already used on all other operations, like
GetCompareExchange so it's safe to use in here too.