### PR TITLE
Typed JavaScriptIndexCreationTask API

### DIFF
--- a/src/Documents/Indexes/AbstractJavaScriptIndexCreationTask.ts
+++ b/src/Documents/Indexes/AbstractJavaScriptIndexCreationTask.ts
@@ -114,22 +114,41 @@ export class AbstractJavaScriptIndexCreationTask extends AbstractIndexCreationTa
 }
 
 type LoadDocument<T> = (id: string | string[], collection: string) => T;
+
 type CreateSpatialField = (lat: number, lng: number) => void;
 
 interface MapUtils<T>
 {
+    /**
+     * Loads the specified document(s) during the indexing process
+     */
     load: LoadDocument<T>,
+    /**
+     * Generates a spatial field in the index, generating a Point from the provided lat/lng coordinates
+     */
     createSpatialField: CreateSpatialField
 }
 
+/**
+ * This class is provided solely to allow typed definition of the index map 
+ */
 class StubMapUtils<T> implements MapUtils<T>
 {
     load: LoadDocument<T>;
     createSpatialField: CreateSpatialField;
 }
 
+/**
+ * Helper types and classes to facilitate the creation of typed groupBy and aggregate defintion for the maps reduce. 
+ * For ex:
+ * ```
+ * r.groupBy(f => f.foo).aggregate(g => ({ key: g.key }))
+ * ```
+ */
 type MapDefinition<T> = (document: T) => object;
+
 type ReduceDefinition<T> = (result: GroupResults<T>) => MapReduceFormatter<T>;
+
 type KeySelector<T> = (document: T) => string;
 
 interface Group<TValue>

--- a/src/Documents/Indexes/AbstractJavaScriptIndexCreationTask.ts
+++ b/src/Documents/Indexes/AbstractJavaScriptIndexCreationTask.ts
@@ -78,7 +78,7 @@ export class AbstractJavaScriptIndexCreationTask extends AbstractIndexCreationTa
      * @param mapReduce Map reduce defintion provided by groupBy and aggregate operation 
      */
     protected reduce<T>(mapReduce: ReduceDefinition<T>): void {
-        this._definition.reduce = mapReduce(null).format()
+        this._definition.reduce = mapReduce(new GroupResults<T>()).format()
     }
 
     /**

--- a/src/Documents/Indexes/AbstractJavaScriptIndexCreationTask.ts
+++ b/src/Documents/Indexes/AbstractJavaScriptIndexCreationTask.ts
@@ -70,7 +70,7 @@ export class AbstractJavaScriptIndexCreationTask extends AbstractIndexCreationTa
      * @param definition Index definition that maps to the indexed properties  
      */
     protected map<T>(collection: string, definition: MapDefinition<T>): void {
-        this._definition.maps.add(`map(${collection}, ${definition.toString()}`);
+        this._definition.maps.add(`map(\'${collection}\', ${definition.toString()})`);
     }
 
     /**
@@ -94,10 +94,10 @@ export class AbstractJavaScriptIndexCreationTask extends AbstractIndexCreationTa
 
     /**
      * No implementation is required here, the interface is purely meant to expose map helper methods such as `load(id, collection)` etc
-     * @returns None 
+     * @returns Empty MapUtils object 
      */
     protected getMapUtils<T>() : MapUtils<T> {
-        return null;
+        return new StubMapUtils<T>();
     }
 
     public createIndexDefinition(): IndexDefinition {
@@ -115,10 +115,17 @@ export class AbstractJavaScriptIndexCreationTask extends AbstractIndexCreationTa
 
 type LoadDocument<T> = (id: string | string[], collection: string) => T;
 type CreateSpatialField = (lat: number, lng: number) => void;
+
 interface MapUtils<T>
 {
     load: LoadDocument<T>,
     createSpatialField: CreateSpatialField
+}
+
+class StubMapUtils<T> implements MapUtils<T>
+{
+    load: LoadDocument<T>;
+    createSpatialField: CreateSpatialField;
 }
 
 type MapDefinition<T> = (document: T) => object;
@@ -159,7 +166,7 @@ class MapReduceFormatter<T> {
     }
 
     public format(): string {
-        let fmt = `groupBy(${this._groupBy}.${this._aggregate}`;
+        let fmt = `groupBy(${this._groupBy}).aggregate(${this._aggregate})`;
 
         return fmt;
     } 

--- a/src/Documents/Indexes/AbstractRawJavaScriptIndexCreationTask.ts
+++ b/src/Documents/Indexes/AbstractRawJavaScriptIndexCreationTask.ts
@@ -82,7 +82,7 @@ export class AbstractRawJavaScriptIndexCreationTask extends AbstractIndexCreatio
     }
 
     public createIndexDefinition(): IndexDefinition {
-        this._definition.type = this.isMapReduce ?  "JavaScriptMapReduce" : "JavaScriptMap";
+        this._definition.type = this.isMapReduce ? "JavaScriptMapReduce" : "JavaScriptMap";
 
         if (this.additionalSources) {
             this._definition.additionalSources = this.additionalSources;

--- a/src/Documents/Indexes/AbstractRawJavaScriptIndexCreationTask.ts
+++ b/src/Documents/Indexes/AbstractRawJavaScriptIndexCreationTask.ts
@@ -1,0 +1,95 @@
+import { IndexDefinition } from "./IndexDefinition";
+import { AbstractIndexCreationTaskBase } from "./AbstractIndexCreationTaskBase";
+
+export class AbstractRawJavaScriptIndexCreationTask extends AbstractIndexCreationTaskBase {
+
+    private readonly _definition: IndexDefinition = new IndexDefinition();
+
+    protected constructor() {
+        super();
+        this._definition.lockMode = "Unlock";
+        this._definition.priority = "Normal";
+    }
+
+    public get maps() {
+        return this._definition.maps;
+    }
+
+    public set maps(value) {
+        this._definition.maps = value;
+    }
+
+    public get fields() {
+        return this._definition.fields;
+    }
+
+    public set fields(value) {
+        this._definition.fields = value;
+    }
+
+    public get reduce() {
+        return this._definition.reduce;
+    }
+
+    public set reduce(value) {
+        this._definition.reduce = value;
+    }
+
+    public get isMapReduce(): boolean {
+        return !!this.reduce;
+    }
+
+    /**
+     * @return Gets the collection name of the documents to which each reduce result output to 
+     */
+    public get outputReduceToCollection() {
+        return this._definition.outputReduceToCollection;
+    }
+
+    /**
+     * @param value If not null then each reduce result will be created as a document in the specified collection name.
+     */
+    public set outputReduceToCollection(value) {
+        this._definition.outputReduceToCollection = value;
+    }
+
+    /**
+     * @return Gets the collection name of the reference documents created based on provided pattern
+     */
+    public get patternReferencesCollectionName() {
+        return this._definition.patternReferencesCollectionName;
+    }
+
+    /**
+     * @param value Defines a collection name for reference documents created based on provided pattern
+     */
+    public set patternReferencesCollectionName(value: string) {
+        this._definition.patternReferencesCollectionName = value;
+    }
+
+    /**
+     * @return Gets the collection name for reference documents created based on provided pattern
+     */
+    public get patternForOutputReduceToCollectionReferences() {
+        return this._definition.patternForOutputReduceToCollectionReferences;
+    }
+
+    /**
+     * @value Defines a collection name for reference documents created based on provided pattern
+     */
+    public set patternForOutputReduceToCollectionReferences(value: string) {
+        this._definition.patternForOutputReduceToCollectionReferences = value;
+    }
+
+    public createIndexDefinition(): IndexDefinition {
+        this._definition.type = this.isMapReduce ?  "JavaScriptMapReduce" : "JavaScriptMap";
+
+        if (this.additionalSources) {
+            this._definition.additionalSources = this.additionalSources;
+        } else {
+            this._definition.additionalSources = {};
+        }
+
+        return this._definition;
+    }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -296,6 +296,7 @@ export * from "./Documents/Indexes";
 export * from "./Documents/Indexes/AbstractIndexCreationTask";
 export * from "./Documents/Indexes/AbstractMultiMapIndexCreationTask";
 export * from "./Documents/Indexes/AbstractJavaScriptIndexCreationTask";
+export * from "./Documents/Indexes/AbstractRawJavaScriptIndexCreationTask";
 export * from "./Documents/Indexes/AutoIndexDefinition";
 export * from "./Documents/Indexes/AutoIndexFieldOptions";
 export * from "./Documents/Indexes/Spatial/AutoSpatialOptions";

--- a/test/Ported/Indexing/JavaScriptIndexTest.ts
+++ b/test/Ported/Indexing/JavaScriptIndexTest.ts
@@ -208,7 +208,8 @@ describe("JavaScriptIndexTest", function () {
         class UsersByName extends AbstractJavaScriptIndexCreationTask {
             public constructor() {
                 super();
-                this.maps = new Set(["map('Users', u => ({ name: u.name, count: 1 }))"]);
+
+                this.map<User>('Users', u => ({ name: u.name, count: 1 }));
             }
         }
             

--- a/test/Ported/Indexing/JavaScriptIndexTest.ts
+++ b/test/Ported/Indexing/JavaScriptIndexTest.ts
@@ -76,12 +76,13 @@ class FanoutByNumbersWithReduce extends AbstractJavaScriptIndexCreationTask {
             return results;
         });
 
-        this.reduce = this.groupBy<FanoutByNumbersWithReduceResult>(f => f.foo)
-            .aggregate(g => ({
+        this.reduce<FanoutByNumbersWithReduceResult>(
+            r => r.groupBy(f => f.foo).aggregate(g => ({
                 foo: g.key,
                 sum: g.values.reduce((total, val) => 
                     val.sum + total, 0)
             }))
+        );
     }
 }
 
@@ -146,11 +147,11 @@ class UsersAndProductsByNameAndCount extends AbstractJavaScriptIndexCreationTask
             count: 1
         }));
 
-        this.reduce = this.groupBy<Entity>(x => x.name)
+        this.reduce<Entity>(r => r.groupBy(x => x.name)
             .aggregate(g => ({
-                name: g.key,
-                count: g.values.reduce((total, val) => val.count + total, 0)
-            }));
+                name: g.key
+            }))
+        );
     }
 }
 
@@ -163,18 +164,19 @@ class ProductsByCategory extends AbstractJavaScriptIndexCreationTask {
     public constructor() {
         super();
 
-        var { load } = this.getMapUtils<Product2>();
+        let { load } = this.getMapUtils<Product2>();
 
         this.map<Product2>('Product2s', p => ({
-            category: load(p.category, 'categories').name,
+            category: load(p.category, 'categories'),
             count: 1
         }));
 
-        this.reduce = this.groupBy<ProductsByCategoryResult>(x => x.category)
+        this.reduce<ProductsByCategoryResult>(r => r.groupBy(p => p.category)
             .aggregate(g => ({
                 category: g.key,
                 count: g.values.reduce((count, val) => val.count + count, 0)
-            }));
+            }))
+        );
     }
 }
 
@@ -346,6 +348,5 @@ describe("JavaScriptIndexTest", function () {
             assertThat(res.length)
                 .isGreaterThan(0);
         }
-
     });
 });

--- a/test/Ported/Indexing/RawJavaScriptIndexTest.ts
+++ b/test/Ported/Indexing/RawJavaScriptIndexTest.ts
@@ -49,10 +49,10 @@ interface FanoutByNumbersWithReduceResult {
     sum: number;
 }
 class FanoutByNumbersWithReduce extends AbstractRawJavaScriptIndexCreationTask {
-        public constructor() {
-            super();
-            this.maps = new Set([
-                `map('Fanouts', function (f) {
+    public constructor() {
+        super();
+        this.maps = new Set([
+            `map('Fanouts', function (f) {
                         var result = [];
                         for(var i = 0; i < f.numbers.length; i++)
                         {
@@ -63,15 +63,15 @@ class FanoutByNumbersWithReduce extends AbstractRawJavaScriptIndexCreationTask {
                         }
                         return result;
                         })`]);
-            this.reduce =
-                `groupBy(f => f.foo)
+        this.reduce =
+            `groupBy(f => f.foo)
                     .aggregate(g => ({  
                         foo: g.key, 
                         sum: g.values.reduce((total, val) => 
                             val.sum + total,0) 
                     }))`;
-        }
     }
+}
 
 class UsersByNameAndAnalyzedNameResult {
     public analyzedName: string;
@@ -136,9 +136,9 @@ class ProductsByCategory extends AbstractRawJavaScriptIndexCreationTask {
         this.maps = new Set(["map('product2s', function(p){\n" +
             "                        return {\n" +
             "                            category:\n" +
-                "                            load(p.category, 'categories').name,\n" +
+            "                            load(p.category, 'categories').name,\n" +
             "                            count:\n" +
-                "                            1\n" +
+            "                            1\n" +
             "                        }\n" +
             "                    })"]);
         this.reduce = "groupBy( x => x.category )\n" +
@@ -163,7 +163,7 @@ describe("JavaScriptIndexTest", function () {
         store = await testContext.getDocumentStore();
     });
 
-    afterEach(async () => 
+    afterEach(async () =>
         await disposeTestDocumentStore(store));
 
     async function storeBrendan(store) {
@@ -181,7 +181,7 @@ describe("JavaScriptIndexTest", function () {
                 this.maps = new Set(["map('Users', u => ({ name: u.name, count: 1 }))"]);
             }
         }
-            
+
         await store.executeIndex(new UsersByName());
         await storeBrendan(store);
         await testContext.waitForIndexing(store);
@@ -215,8 +215,8 @@ describe("JavaScriptIndexTest", function () {
         await store.executeIndex(index);
         {
             const session = store.openSession();
-            await storeNewDoc(session, { foo: "Foo", numbers: [ 4, 6, 11, 9 ] }, null, Fanout);
-            await storeNewDoc(session, { foo: "Bar", numbers: [ 3, 8, 5, 17 ] }, null, Fanout);
+            await storeNewDoc(session, { foo: "Foo", numbers: [4, 6, 11, 9] }, null, Fanout);
+            await storeNewDoc(session, { foo: "Bar", numbers: [3, 8, 5, 17] }, null, Fanout);
             await session.saveChanges();
         }
 
@@ -228,7 +228,7 @@ describe("JavaScriptIndexTest", function () {
                 .whereEquals("sum", 33)
                 .selectFields("sum")
                 .single();
-            
+
             assert.ok(result);
         }
     });
@@ -241,13 +241,13 @@ describe("JavaScriptIndexTest", function () {
         await testContext.waitForIndexing(store);
         {
             const session = store.openSession();
-            const result = await session.query({ 
+            const result = await session.query({
                 indexName: index.getIndexName()
             })
-            .search("analyzedName", "Brendan")
-            .selectFields<UsersByNameAndAnalyzedNameResult>("analyzedName", UsersByNameAndAnalyzedNameResult)
-            .single();
-            
+                .search("analyzedName", "Brendan")
+                .selectFields<UsersByNameAndAnalyzedNameResult>("analyzedName", UsersByNameAndAnalyzedNameResult)
+                .single();
+
             assert.ok(result);
             assert.strictEqual(result.analyzedName, "Brendan Eich");
         }
@@ -258,8 +258,8 @@ describe("JavaScriptIndexTest", function () {
         await store.executeIndex(index);
         {
             const session = store.openSession();
-            await storeNewDoc(session, { name: "Brendan Eich" }, "users/1", User);   
-            await storeNewDoc(session, { name: "Shampoo", available: true }, "products/1", Product);   
+            await storeNewDoc(session, { name: "Brendan Eich" }, "users/1", User);
+            await storeNewDoc(session, { name: "Shampoo", available: true }, "products/1", Product);
             await session.saveChanges();
 
             await testContext.waitForIndexing(store);
@@ -277,8 +277,8 @@ describe("JavaScriptIndexTest", function () {
 
         {
             const session = store.openSession();
-            await storeNewDoc(session, { name: "Brendan Eich" }, "users/1", User);   
-            await storeNewDoc(session, { name: "Shampoo", available: true }, "products/1", Product);   
+            await storeNewDoc(session, { name: "Brendan Eich" }, "users/1", User);
+            await storeNewDoc(session, { name: "Shampoo", available: true }, "products/1", Product);
             await session.saveChanges();
 
             await testContext.waitForIndexing(store);
@@ -296,8 +296,8 @@ describe("JavaScriptIndexTest", function () {
         await store.executeIndex(index);
         {
             const session = store.openSession();
-            await storeNewDoc(session, { name: "Beverages" }, "categories/1-A", Category);   
-            await storeNewDoc(session, { name: "Seafood" }, "categories/2-A", Category);   
+            await storeNewDoc(session, { name: "Beverages" }, "categories/1-A", Category);
+            await storeNewDoc(session, { name: "Seafood" }, "categories/2-A", Category);
             await session.store(Product2.create("categories/1-A", "Lakkalikööri", 13));
             await session.store(Product2.create("categories/1-A", "Original Frankfurter", 16));
             await session.store(Product2.create("categories/2-A", "Röd Kaviar", 18));

--- a/test/Ported/Indexing/RawJavaScriptIndexTest.ts
+++ b/test/Ported/Indexing/RawJavaScriptIndexTest.ts
@@ -155,7 +155,7 @@ class Fanout {
     public numbers: number[];
 }
 
-describe("JavaScriptIndexTest", function () {
+describe("RawJavaScriptIndexTest", function () {
 
     let store: IDocumentStore;
 
@@ -318,6 +318,5 @@ describe("JavaScriptIndexTest", function () {
             assertThat(res.length)
                 .isGreaterThan(0);
         }
-
     });
 });

--- a/test/Ported/Indexing/RawJavaScriptIndexTest.ts
+++ b/test/Ported/Indexing/RawJavaScriptIndexTest.ts
@@ -1,0 +1,323 @@
+import * as assert from "assert";
+import { testContext, disposeTestDocumentStore, storeNewDoc } from "../../Utils/TestUtil";
+
+import {
+    IDocumentStore,
+    AbstractRawJavaScriptIndexCreationTask,
+    IndexFieldOptions,
+} from "../../../src";
+import { CONSTANTS } from "../../../src/Constants";
+import { User } from "../../Assets/Entities";
+import { assertThat } from "../../Utils/AssertExtensions";
+
+class Category {
+    public description: string;
+    public name: string;
+}
+
+class Product2 {
+    public category: string;
+    public name: string;
+    public pricePerUnit: number;
+
+    public static create(category: string, name: string, pricePerUnit: number): Product2 {
+        return Object.assign(new Product2(), {
+            category, name, pricePerUnit
+        });
+    }
+}
+interface CategoryCount {
+    category: string;
+    count: number;
+}
+
+class Product {
+    public name: string;
+    public available: boolean;
+}
+
+class UsersByNameWithAdditionalSources extends AbstractRawJavaScriptIndexCreationTask {
+    public constructor() {
+        super();
+        this.maps = new Set(["map('Users', function(u) { return { name: mr(u.name)}; })"]);
+        this.additionalSources = { "The Script": "function mr(x) { return 'Mr. ' + x; }" };
+    }
+}
+
+interface FanoutByNumbersWithReduceResult {
+    foo: string;
+    sum: number;
+}
+class FanoutByNumbersWithReduce extends AbstractRawJavaScriptIndexCreationTask {
+        public constructor() {
+            super();
+            this.maps = new Set([
+                `map('Fanouts', function (f) {
+                        var result = [];
+                        for(var i = 0; i < f.numbers.length; i++)
+                        {
+                            result.push({
+                                foo: f.foo,
+                                sum: f.numbers[i]
+                            });
+                        }
+                        return result;
+                        })`]);
+            this.reduce =
+                `groupBy(f => f.foo)
+                    .aggregate(g => ({  
+                        foo: g.key, 
+                        sum: g.values.reduce((total, val) => 
+                            val.sum + total,0) 
+                    }))`;
+        }
+    }
+
+class UsersByNameAndAnalyzedNameResult {
+    public analyzedName: string;
+}
+class UsersByNameAndAnalyzedName extends AbstractRawJavaScriptIndexCreationTask {
+    public constructor() {
+        super();
+        this.maps = new Set([`map('Users', function (u){
+                                    return {
+                                        name: u.name,
+                                        _: {
+                                            $value: u.name, 
+                                            $name:'analyzedName', 
+                                            $options:{ indexing: 'Search', storage: true }
+                                        }
+                                    };
+                                })`]);
+
+        const fieldOptions = this.fields = {};
+        const indexFieldOptions = new IndexFieldOptions();
+        indexFieldOptions.indexing = "Search";
+        indexFieldOptions.analyzer = "StandardAnalyzer";
+        fieldOptions[CONSTANTS.Documents.Indexing.Fields.ALL_FIELDS] = indexFieldOptions;
+    }
+}
+
+class UsersAndProductsByName extends AbstractRawJavaScriptIndexCreationTask {
+    public constructor() {
+        super();
+        this.maps = new Set([
+            "map('Users', function (u) { return { name: u.name, count: 1}; })",
+            "map('Products', function (p) { return { name: p.name, count: 1}; })"
+        ]);
+    }
+}
+
+class UsersAndProductsByNameAndCount extends AbstractRawJavaScriptIndexCreationTask {
+    public constructor() {
+        super();
+        this.maps = new Set([
+            "map('Users', function (u){ return { name: u.name, count: 1};})",
+            "map('Products', function (p){ return { name: p.name, count: 1};})"
+        ]);
+        this.reduce = `groupBy(x => x.name)
+                            .aggregate(g => {
+                                return {
+                                    name: g.key,
+                                    count: g.values.reduce((total, val) => val.count + total,0)
+                                };
+                        })`;
+    }
+}
+
+interface ProductsByCategoryResult {
+    category: string;
+    count: number;
+}
+
+class ProductsByCategory extends AbstractRawJavaScriptIndexCreationTask {
+    public constructor() {
+        super();
+        this.maps = new Set(["map('product2s', function(p){\n" +
+            "                        return {\n" +
+            "                            category:\n" +
+                "                            load(p.category, 'categories').name,\n" +
+            "                            count:\n" +
+                "                            1\n" +
+            "                        }\n" +
+            "                    })"]);
+        this.reduce = "groupBy( x => x.category )\n" +
+            "                            .aggregate(g => {\n" +
+            "                                return {\n" +
+            "                                    category: g.key,\n" +
+            "                                    count: g.values.reduce((count, val) => val.count + count, 0)\n" +
+            "                               };})";
+        this.outputReduceToCollection = "CategoryCounts";
+    }
+}
+class Fanout {
+    public foo: string;
+    public numbers: number[];
+}
+
+describe("JavaScriptIndexTest", function () {
+
+    let store: IDocumentStore;
+
+    beforeEach(async function () {
+        store = await testContext.getDocumentStore();
+    });
+
+    afterEach(async () => 
+        await disposeTestDocumentStore(store));
+
+    async function storeBrendan(store) {
+        const session = store.openSession();
+        const user = Object.assign(new User(), { name: "Brendan Eich" });
+        await session.store(user);
+        await session.saveChanges();
+    }
+
+    it("canUseJavaScriptIndex", async () => {
+
+        class UsersByName extends AbstractRawJavaScriptIndexCreationTask {
+            public constructor() {
+                super();
+                this.maps = new Set(["map('Users', u => ({ name: u.name, count: 1 }))"]);
+            }
+        }
+            
+        await store.executeIndex(new UsersByName());
+        await storeBrendan(store);
+        await testContext.waitForIndexing(store);
+        {
+            const session = store.openSession();
+            const single = await session.query({ collection: "users" })
+                .whereEquals("name", "Brendan Eich")
+                .single();
+            assert.ok(single);
+        }
+    });
+
+    it("canUseJavaScriptIndexWithAdditionalSources", async function () {
+        const index = new UsersByNameWithAdditionalSources();
+        await store.executeIndex(index);
+        await storeBrendan(store);
+        await testContext.waitForIndexing(store);
+        {
+            const session = store.openSession();
+            const single = await session.query({ indexName: index.getIndexName() })
+                .whereEquals("name", "Mr. Brendan Eich")
+                .selectFields("name")
+                .single();
+            assert.ok(single);
+        }
+
+    });
+
+    it("canIndexMapReduceWithFanout", async function () {
+        const index = new FanoutByNumbersWithReduce();
+        await store.executeIndex(index);
+        {
+            const session = store.openSession();
+            await storeNewDoc(session, { foo: "Foo", numbers: [ 4, 6, 11, 9 ] }, null, Fanout);
+            await storeNewDoc(session, { foo: "Bar", numbers: [ 3, 8, 5, 17 ] }, null, Fanout);
+            await session.saveChanges();
+        }
+
+        await testContext.waitForIndexing(store);
+
+        {
+            const session = store.openSession();
+            const result = await session.query({ indexName: index.getIndexName() })
+                .whereEquals("sum", 33)
+                .selectFields("sum")
+                .single();
+            
+            assert.ok(result);
+        }
+    });
+
+    it("canUseJavaScriptIndexWithDynamicFields", async function () {
+        const index = new UsersByNameAndAnalyzedName();
+        await store.executeIndex(index);
+
+        await storeBrendan(store);
+        await testContext.waitForIndexing(store);
+        {
+            const session = store.openSession();
+            const result = await session.query({ 
+                indexName: index.getIndexName()
+            })
+            .search("analyzedName", "Brendan")
+            .selectFields<UsersByNameAndAnalyzedNameResult>("analyzedName", UsersByNameAndAnalyzedNameResult)
+            .single();
+            
+            assert.ok(result);
+            assert.strictEqual(result.analyzedName, "Brendan Eich");
+        }
+    });
+
+    it("canUseJavaScriptMultiMapIndex", async function () {
+        const index = new UsersAndProductsByName();
+        await store.executeIndex(index);
+        {
+            const session = store.openSession();
+            await storeNewDoc(session, { name: "Brendan Eich" }, "users/1", User);   
+            await storeNewDoc(session, { name: "Shampoo", available: true }, "products/1", Product);   
+            await session.saveChanges();
+
+            await testContext.waitForIndexing(store);
+
+            await session.query({ indexName: "UsersAndProductsByName" })
+                .whereEquals("name", "Brendan Eich")
+                .single();
+        }
+
+    });
+
+    it("canUseJavaScriptMapReduceIndex", async function () {
+        const index = new UsersAndProductsByNameAndCount();
+        await store.executeIndex(index);
+
+        {
+            const session = store.openSession();
+            await storeNewDoc(session, { name: "Brendan Eich" }, "users/1", User);   
+            await storeNewDoc(session, { name: "Shampoo", available: true }, "products/1", Product);   
+            await session.saveChanges();
+
+            await testContext.waitForIndexing(store);
+            const result = await session.query({ indexName: index.getIndexName() })
+                .whereEquals("name", "Brendan Eich")
+                .single() as any;
+
+            assert.strictEqual(result.count, 1);
+            assert.strictEqual(result.name, "Brendan Eich");
+        }
+    });
+
+    it("outputReduceToCollection", async function () {
+        const index = new ProductsByCategory();
+        await store.executeIndex(index);
+        {
+            const session = store.openSession();
+            await storeNewDoc(session, { name: "Beverages" }, "categories/1-A", Category);   
+            await storeNewDoc(session, { name: "Seafood" }, "categories/2-A", Category);   
+            await session.store(Product2.create("categories/1-A", "Lakkalikööri", 13));
+            await session.store(Product2.create("categories/1-A", "Original Frankfurter", 16));
+            await session.store(Product2.create("categories/2-A", "Röd Kaviar", 18));
+            await session.saveChanges();
+
+            await testContext.waitForIndexing(store);
+            const res = await session.query({ indexName: index.getIndexName() })
+                .all();
+
+            const res2 = await session.query({ collection: "CategoryCounts" })
+                .all();
+
+            assert.ok(res.length && res2.length);
+            assertThat(res2.length)
+                .isEqualTo(res.length);
+            assertThat(res2.length)
+                .isGreaterThan(0);
+            assertThat(res.length)
+                .isGreaterThan(0);
+        }
+
+    });
+});


### PR DESCRIPTION
- Moved old AbstractJavaScriptIndexCreationTask into AbstractRawJavaScriptIndexCreationTask
- Added Typed JS API under AbstractJavaScriptIndexCreationTask
- Added typed Map interface that takes in Map definition as input
- Added typed Reduce interface that takes the groupBy and aggregate definition from the user vs.  setting `this.reduce` so that its more natural.

TODO: 
- [x] a bit more cleanup
- [x] few more test cases (such as for `createSpatialField` etc)
- [x] make sure prod build minification doesn't break anything, don't think it would unless we're obfuscating the build

closes #208 