### PR TITLE
Add "darwin" option in package json for tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "test": "cross-os _test ",
     "_test": {
       "win32": "tsc -p tsconfig.test.json && copy test\\Assets\\* .test\\test\\Assets && mocha .test\\test",
-      "linux": "tsc -p tsconfig.test.json && cp test/Assets/* .test/test/Assets && mocha .test/test"
+      "linux": "tsc -p tsconfig.test.json && cp test/Assets/* .test/test/Assets && mocha .test/test",
+      "darwin": "tsc -p tsconfig.test.json && cp test/Assets/* .test/test/Assets && mocha .test/test"
     },
     "build": "tsc",
     "build:test": "tsc -p tsconfig.test.json",


### PR DESCRIPTION
This allows running test in mac otherwise `npm run test` throws an error when running tests on macOS. 