### PR TITLE
RDBC-509 SaveChanges after query modifies the change vector

### DIFF
--- a/src/Documents/Session/EntityToJson.ts
+++ b/src/Documents/Session/EntityToJson.ts
@@ -112,15 +112,16 @@ export class EntityToJson {
                 documentInfo.metadata[CONSTANTS.Documents.Metadata.RAVEN_JS_TYPE] || typeInfo.typeName;
         }
 
-        function differentNestedTypes() {
-            const existing =
-                documentInfo.metadataInstance[CONSTANTS.Documents.Metadata.NESTED_OBJECT_TYPES];
-            if(existing == null)
+        function differentNestedTypes(): boolean {
+            const existing = documentInfo.metadataInstance[CONSTANTS.Documents.Metadata.NESTED_OBJECT_TYPES];
+            if (!existing) {
                 return true;
-            if(Object.keys(existing).length != Object.keys(typeInfo.nestedTypes).length)
+            }
+            if (Object.keys(existing).length !== Object.keys(typeInfo.nestedTypes).length) {
                 return true;
-            for (const key in typeInfo.nestedTypes){
-                if(typeInfo.nestedTypes[key] != existing[key]) {
+            }
+            for (const key in typeInfo.nestedTypes) {
+                if (typeInfo.nestedTypes[key] !== existing[key]) {
                     return true;
                 }
             }
@@ -128,11 +129,11 @@ export class EntityToJson {
         }
 
         if (documentInfo.metadataInstance) {
-            if(differentNestedTypes()){
+            if (differentNestedTypes()) {
                 documentInfo.metadataInstance[CONSTANTS.Documents.Metadata.NESTED_OBJECT_TYPES] = typeInfo.nestedTypes;
             }
-            var nodeType = documentInfo.metadataInstance[CONSTANTS.Documents.Metadata.RAVEN_JS_TYPE] || typeInfo.typeName;
-            if(documentInfo.metadataInstance[CONSTANTS.Documents.Metadata.RAVEN_JS_TYPE] !== nodeType){
+            const nodeType = documentInfo.metadataInstance[CONSTANTS.Documents.Metadata.RAVEN_JS_TYPE] || typeInfo.typeName;
+            if (documentInfo.metadataInstance[CONSTANTS.Documents.Metadata.RAVEN_JS_TYPE] !== nodeType) {
                 documentInfo.metadataInstance[CONSTANTS.Documents.Metadata.RAVEN_JS_TYPE] = nodeType;
             }
         }

--- a/src/Documents/Session/EntityToJson.ts
+++ b/src/Documents/Session/EntityToJson.ts
@@ -112,10 +112,29 @@ export class EntityToJson {
                 documentInfo.metadata[CONSTANTS.Documents.Metadata.RAVEN_JS_TYPE] || typeInfo.typeName;
         }
 
+        function differentNestedTypes() {
+            const existing =
+                documentInfo.metadataInstance[CONSTANTS.Documents.Metadata.NESTED_OBJECT_TYPES];
+            if(existing == null)
+                return true;
+            if(Object.keys(existing).length != Object.keys(typeInfo.nestedTypes).length)
+                return true;
+            for (const key in typeInfo.nestedTypes){
+                if(typeInfo.nestedTypes[key] != existing[key]) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
         if (documentInfo.metadataInstance) {
-            documentInfo.metadataInstance[CONSTANTS.Documents.Metadata.NESTED_OBJECT_TYPES] = typeInfo.nestedTypes;
-            documentInfo.metadataInstance[CONSTANTS.Documents.Metadata.RAVEN_JS_TYPE] =
-               documentInfo.metadataInstance["Raven-Node-Type"] || typeInfo.typeName;
+            if(differentNestedTypes()){
+                documentInfo.metadataInstance[CONSTANTS.Documents.Metadata.NESTED_OBJECT_TYPES] = typeInfo.nestedTypes;
+            }
+            var nodeType = documentInfo.metadataInstance[CONSTANTS.Documents.Metadata.RAVEN_JS_TYPE] || typeInfo.typeName;
+            if(documentInfo.metadataInstance[CONSTANTS.Documents.Metadata.RAVEN_JS_TYPE] !== nodeType){
+                documentInfo.metadataInstance[CONSTANTS.Documents.Metadata.RAVEN_JS_TYPE] = nodeType;
+            }
         }
 
         let setMetadata: boolean = false;

--- a/test/Ported/MailingList/SpuriousSaveChanges.ts
+++ b/test/Ported/MailingList/SpuriousSaveChanges.ts
@@ -1,0 +1,48 @@
+import * as assert from "assert";
+import { testContext, disposeTestDocumentStore } from "../../Utils/TestUtil";
+
+import {
+    IDocumentStore,
+} from "../../../src";
+
+class item{
+
+    constructor(v : string){
+        this.v = v;
+    }
+
+    v : string;
+}
+describe("SpuriousSaveChanges", function () {
+
+    let store: IDocumentStore;
+
+    beforeEach(async function () {
+        store = await testContext.getDocumentStore();
+    });
+
+    afterEach(async () =>
+        await disposeTestDocumentStore(store)
+    );
+
+    it("willNotSaveUnmodifiedDocuments", async () => {
+
+        await createData(store);
+        {
+            const session = store.openSession();
+            const result = await session.query<item>({ collection: "items" })
+                .all();
+            assert.ok(!session.advanced.hasChanged(result[0]));
+            var old = session.advanced.numberOfRequests;
+            await session.saveChanges();
+            assert.strictEqual(old, session.advanced.numberOfRequests);
+        }
+    });
+
+    async function createData(store: IDocumentStore): Promise<void> {
+        const session = store.openSession();
+        await session.store(new item("f"), "items/1");
+        await session.saveChanges();
+    }
+
+});

--- a/test/Ported/MailingList/SpuriousSaveChanges.ts
+++ b/test/Ported/MailingList/SpuriousSaveChanges.ts
@@ -1,18 +1,18 @@
-import * as assert from "assert";
 import { testContext, disposeTestDocumentStore } from "../../Utils/TestUtil";
 
 import {
     IDocumentStore,
 } from "../../../src";
+import { assertThat } from "../../Utils/AssertExtensions";
 
-class item{
+class Item {
+    v: string;
 
-    constructor(v : string){
+    constructor(v: string) {
         this.v = v;
     }
-
-    v : string;
 }
+
 describe("SpuriousSaveChanges", function () {
 
     let store: IDocumentStore;
@@ -28,21 +28,23 @@ describe("SpuriousSaveChanges", function () {
     it("willNotSaveUnmodifiedDocuments", async () => {
 
         await createData(store);
+
         {
             const session = store.openSession();
-            const result = await session.query<item>({ collection: "items" })
+            const result = await session.query<Item>({ collection: "items" })
                 .all();
-            assert.ok(!session.advanced.hasChanged(result[0]));
-            var old = session.advanced.numberOfRequests;
+            assertThat(session.advanced.hasChanged(result[0]))
+                .isFalse();
+            const old = session.advanced.numberOfRequests;
             await session.saveChanges();
-            assert.strictEqual(old, session.advanced.numberOfRequests);
+            assertThat(session.advanced.numberOfRequests)
+                .isEqualTo(old);
         }
     });
 
     async function createData(store: IDocumentStore): Promise<void> {
         const session = store.openSession();
-        await session.store(new item("f"), "items/1");
+        await session.store(new Item("f"), "items/1");
         await session.saveChanges();
     }
-
 });


### PR DESCRIPTION
- We need to avoid changing the metadataInstance if the changes we want to make are already there. This will cause us to save the document even though it wasnt changed.