### PR TITLE
Bugfix for TS definition

### DIFF
--- a/src/Types/index.ts
+++ b/src/Types/index.ts
@@ -1,10 +1,10 @@
 import { SuggestionResult } from "../Documents/Queries/Suggestions/SuggestionResult";
 
-export interface EntitiesCollectionObject<TEntity> extends IRavenObject<TEntity> {
+export interface EntitiesCollectionObject<TEntity> extends IRavenObject<TEntity | null> {
     [id: string]: TEntity | null;
 }
 
-export interface RevisionsCollectionObject<TEntity> extends IRavenObject<TEntity> {
+export interface RevisionsCollectionObject<TEntity> extends IRavenObject<TEntity | null> {
     [changeVector: string]: TEntity | null;
 }
 


### PR DESCRIPTION
Error:
```node_modules/ravendb/dist/Types/index.d.ts:2:18 - error TS2430: Interface 'EntitiesCollectionObject<TEntity>' incorrectly extends interface 'IRavenObject<TEntity>'.
  'string' index signatures are incompatible.
    Type 'TEntity | null' is not assignable to type 'TEntity'.
      'TEntity' could be instantiated with an arbitrary type which could be unrelated to 'TEntity | null'.

2 export interface EntitiesCollectionObject<TEntity> extends IRavenObject<TEntity> {
                   ~~~~~~~~~~~~~~~~~~~~~~~~

node_modules/ravendb/dist/Types/index.d.ts:5:18 - error TS2430: Interface 'RevisionsCollectionObject<TEntity>' incorrectly extends interface 'IRavenObject<TEntity>'.
  'string' index signatures are incompatible.
    Type 'TEntity | null' is not assignable to type 'TEntity'.
      'TEntity' could be instantiated with an arbitrary type which could be unrelated to 'TEntity | null'.

5 export interface RevisionsCollectionObject<TEntity> extends IRavenObject<TEntity> {
                   ~~~~~~~~~~~~~~~~~~~~~~~~~```