### PR TITLE
Correct chunk joining to attribute

### DIFF
--- a/src/Utility/StreamUtil.ts
+++ b/src/Utility/StreamUtil.ts
@@ -33,7 +33,7 @@ export async function readToEnd(readable: stream.Readable | stream.Stream): Prom
     readable.on("data", chunk => chunks.push(chunk));
 
     await finishedAsync(readable);
-    return chunks.join("");
+    return Buffer.concat(chunks).toString('utf-8');
 }
 
 export function bufferToReadable(b: Buffer) {


### PR DESCRIPTION
Array.join() implicitly converts the array items to strings, while we need to join the code points before converting to string.

This means when a character is split between two chunks, both of its parts are converted to unicode replacement characters.

This change fixes that.