### PR TITLE
Prevent hash collisions

### DIFF
--- a/src/Documents/Queries/HashCalculator.ts
+++ b/src/Documents/Queries/HashCalculator.ts
@@ -19,7 +19,7 @@ export class HashCalculator {
         }
 
         if (typeof o === "number") {
-            this._buffers.push(Buffer.from([o]));
+            this._buffers.push(Buffer.from(String(o)));
         } else if (typeof o === "string") {
             this._buffers.push(Buffer.from(o));
         } else if (typeof o === "boolean") {

--- a/src/Documents/Queries/HashCalculator.ts
+++ b/src/Documents/Queries/HashCalculator.ts
@@ -2,6 +2,17 @@ import * as md5 from "md5";
 import { TypeUtil } from "../../Utility/TypeUtil";
 import { TypesAwareObjectMapper } from "../../Mapping/ObjectMapper";
 
+const typeSignatures = {
+    bigint: Buffer.from([1]),
+    boolean: Buffer.from([2]),
+    function: Buffer.from([3]),
+    number: Buffer.from([4]),
+    object: Buffer.from([5]),
+    string: Buffer.from([6]),
+    symbol: Buffer.from([7]),
+    undefined: Buffer.from([8]),
+};
+
 export class HashCalculator {
 
     private _buffers: Buffer[] = [];
@@ -17,6 +28,9 @@ export class HashCalculator {
             this._buffers.push(Buffer.from("null"));
             return;
         }
+        
+        // Push a byte that identifies the type, to differentiate strings, numbers, and bools
+        this._buffers.push(typeSignatures[typeof o] || typeSignatures.undefined);
 
         if (typeof o === "number") {
             this._buffers.push(Buffer.from([o]));

--- a/test/Documents/Queries/HashCalculatorTest.ts
+++ b/test/Documents/Queries/HashCalculatorTest.ts
@@ -1,0 +1,46 @@
+import * as assert from "assert";
+
+import { HashCalculator } from "../../../src/Documents/Queries/HashCalculator";
+import { TypesAwareObjectMapper } from "../../../src/Mapping/ObjectMapper";
+
+const mockObjectMapper = {
+    toObjectLiteral: obj => obj.toString()
+} as TypesAwareObjectMapper;
+
+const hash = data => {
+    const calculator = new HashCalculator();
+    calculator.write(data, mockObjectMapper);
+    return calculator.getHash();
+}
+
+describe('Hash calculator tests', () => {
+    it('Calculates the same hash for the same object', async () => {
+        const obj = {
+            boolean: true,
+            function: () => {
+                console.log('No-op')
+            },
+            number: 4,
+            object: {
+                property: 'value'
+            },
+            string: 'hello',
+            symbol: Symbol('world'),
+            undefined: undefined,
+        };
+
+        assert.equal(hash(obj), hash(obj));
+        assert.equal(hash(obj), hash({ ...obj }));
+    });
+
+    it('Calculates different hashes for different types', async () => {
+        assert.notEqual(hash(1), hash(true))
+        assert.notEqual(hash('1'), hash(true))
+        assert.notEqual(hash(1), hash('1'))
+    });
+
+    it('Calculates different hashes for different numbers', async () => {
+        assert.notEqual(hash(1), hash(257));
+        assert.notEqual(hash(86400), hash(0));
+    });
+});


### PR DESCRIPTION
Fixes two collisions:
- different numbers map to the same hash if equal modulo 256
- different types hash identically; `1` and `'1'` are both equal to `true`, for example