### PR TITLE
Drop support for node < 14.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "Hibernating Rhinos"
   ],
   "engines": {
-    "node": ">=6.0.0"
+    "node": ">=14.0.0"
   },
   "keywords": [
     "ravendb",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "version": "2.9.2",
   "compilerOptions": {
-    "target": "es6",
+    "target": "ES2020",
     "module": "commonjs",
     "moduleResolution": "node",
     "outDir": "dist",
@@ -9,7 +9,7 @@
     "removeComments": true,
     "sourceMap": false,
     "pretty": true,
-    "lib": [ "es2018" ],
+    "lib": [ "ES2020" ],
     "typeRoots": [
       "node_modules/@types",
       "node_modules/moment",

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,7 +1,7 @@
 {
   "version": "2.9.2",
   "compilerOptions": {
-    "target": "es6",
+    "target": "ES2020",
     "module": "commonjs",
     "allowJs": true,
     "moduleResolution": "node",
@@ -10,7 +10,7 @@
     "inlineSourceMap": true,
     "pretty": true,
     "outDir": ".test",
-    "lib": [ "es2018" ],
+    "lib": [ "ES2020" ],
     "allowSyntheticDefaultImports": true,
     "typeRoots": [
       "node_modules/@types",


### PR DESCRIPTION
Support actively maintained LTS versions only.