### PR TITLE
RDBC-622: JSONL support

### DIFF
--- a/src/Documents/Commands/QueryStreamCommand.ts
+++ b/src/Documents/Commands/QueryStreamCommand.ts
@@ -30,9 +30,11 @@ export class QueryStreamCommand extends RavenCommand<StreamResultResponse> {
     }
 
     public createRequest(node: ServerNode): HttpRequestParameters {
+        const format = this._conventions.useJsonlStreaming ? 'jsonl' : 'json';
+
         return {
             method: "POST",
-            uri: `${node.url}/databases/${node.database}/streams/queries`,
+            uri: `${node.url}/databases/${node.database}/streams/queries?format=${format}`,
             body: writeIndexQuery(this._conventions, this._indexQuery),
             headers: this._headers().typeAppJson().build()
         };

--- a/src/Documents/Conventions/DocumentConventions.ts
+++ b/src/Documents/Conventions/DocumentConventions.ts
@@ -101,15 +101,25 @@ export class DocumentConventions {
 
     private readonly _bulkInsert: BulkInsertConventions;
 
+    private _useJsonlStreaming = false;
+
     public get bulkInsert() {
         return this._bulkInsert;
+    }
+
+    public get useJsonlStreaming() {
+        return this._useJsonlStreaming;
+    }
+
+    public set useJsonlStreaming(value) {
+        this._useJsonlStreaming = value;
     }
 
     public constructor() {
         this._readBalanceBehavior = "None";
         this._identityPartsSeparator = "/";
         this._identityProperty = CONSTANTS.Documents.Metadata.ID_PROPERTY;
-        
+
         this._findJsType = (id: string, doc: object) => {
             const metadata = doc[CONSTANTS.Documents.Metadata.KEY];
             if (metadata) {
@@ -435,7 +445,7 @@ export class DocumentConventions {
     public set storeDatesWithTimezoneInfo(value) {
         this._assertNotFrozen();
         this._dateUtilOpts.withTimezone = true;
-    } 
+    }
 
     /**
      * If set to 'true' then it will throw an exception when any query is performed (in session)

--- a/src/Http/RavenCommandResponsePipeline.ts
+++ b/src/Http/RavenCommandResponsePipeline.ts
@@ -18,21 +18,27 @@ import {
 } from "../Mapping/Json/Streams/CollectResultStream";
 import { throwError, getError } from "../Exceptions";
 import {
-    TransformJsonKeysStreamOptions, 
-    TransformKeysJsonStream } from "../Mapping/Json/Streams/TransformKeysJsonStream";
-import { 
-    TransformJsonKeysProfile, 
-    getTransformJsonKeysProfile } from "../Mapping/Json/Streams/TransformJsonKeysProfiles";
+    TransformJsonKeysStreamOptions,
+    TransformKeysJsonStream
+} from "../Mapping/Json/Streams/TransformKeysJsonStream";
+import {
+    getTransformJsonKeysProfile,
+    TransformJsonKeysProfile
+} from "../Mapping/Json/Streams/TransformJsonKeysProfiles";
 import { TypeUtil } from "../Utility/TypeUtil";
 import * as Asm from "stream-json/Assembler";
 import { DocumentConventions } from "../Documents/Conventions/DocumentConventions";
 import { ErrorFirstCallback } from "../Types/Callbacks";
 import { StringBuilder } from "../Utility/StringBuilder";
+import { parser as jsonlParser } from "stream-json/jsonl/Parser";
 
 export interface RavenCommandResponsePipelineOptions<TResult> {
     collectBody?: boolean | ((body: string) => void);
     jsonAsync?: {
         filters: any[]
+    };
+    jsonlAsync?: {
+        transforms: stream.Transform[]
     };
     jsonSync?: boolean;
     streamKeyCaseTransform?: ObjectKeyCaseTransformStreamOptions;
@@ -62,6 +68,25 @@ export class RavenCommandResponsePipeline<TStreamResult> extends EventEmitter {
 
     public parseJsonSync() {
         this._opts.jsonSync = true;
+        return this;
+    }
+
+    public parseJsonlAsync(type: "Item" | "Stats", options: { transforms?: stream.Transform[] } = {}) {
+        const extractItemTransform = new stream.Transform({
+            objectMode: true,
+            transform(chunk, encoding, callback) {
+                const value = chunk["value"][type];
+                if (!value) {
+                    return callback();
+                }
+
+                callback(null, {...chunk, value});
+            }
+        });
+
+        this._opts.jsonlAsync = {
+            transforms: [ extractItemTransform, ...options?.transforms ?? [] ],
+        };
         return this;
     }
 
@@ -170,6 +195,12 @@ export class RavenCommandResponsePipeline<TStreamResult> extends EventEmitter {
 
             if (opts.jsonAsync.filters && opts.jsonAsync.filters.length) {
                 streams.push(...opts.jsonAsync.filters);
+            }
+        } else if (opts.jsonlAsync) {
+            streams.push(jsonlParser());
+
+            if (opts.jsonlAsync.transforms) {
+                streams.push(...opts.jsonlAsync.transforms);
             }
         } else if (opts.jsonSync) {
             const bytesChunks = [];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     "outDir": "dist",
     "declaration": true,
     "removeComments": true,
-    "sourceMap": false,
+    "sourceMap": true,
     "pretty": true,
     "lib": [ "ES2020" ],
     "typeRoots": [


### PR DESCRIPTION
(Work in progress, trying to capture all the details right now, looking for feedback on the points).

# Scope:

Scope:
* [ ] DocumentSession.stream should use JSONL depending on conventions
* [ ] DocumentSession.streamInto should use JSONL depending on conventions

# Parsing JSONL

In stream-json it is possible to use JSON through the default Parser with the `jsonStreaming` flag, or with a dedicated JSONL Parser. In general, like the docs say, the JSONL Parser is more performant. For me, the JSONL parser was at least twice as fast locally. In order to utilize the potential gain from JSONL, i believe the JSONL parser must be used. Testing this locally, and my results might be wrong for an unknown reason, enabling the `jsonStreaming` flag was actually worse than not using `jsonStreaming`. 

JSONL Parser, on the other hand, does not support the same filters and keeps the entire line in memory. I believe this is a good thing, given that the clients will always want to have at least one whole document in memory and that the default Parser is very slow when dealing with a large document set.

However, having the same object in memory means that we need to use the ObjectKeyCaseTransformStream for casing conventions. The library currently uses one of two stream Transforms to apply casing conventions: ObjectKeyCaseTransformStream (readable-stream) and TransformKeysJsonStream (stream-json). TODO - i'm not sure if the parsers are kept in sync, so if we need both, i'd probably figure out a way to only use one.

That being said, i'm not sure where the need for `parseAsyncJson` comes from when not streaming - even for a very large document the clients indicate that they will keep the entire document in memory when not using streaming so even if we assemble the document bit-by-bit while parsing json the end result is the entire object. My question would be would it be possible to:

* use synchronous processing for non-streaming ops
* use jsonl for streaming ops

This negates the need for two keys transformers, because we will always be dealing with an entire document.

At any rate, we need to optimize applying casing conventions for JSONL, because it increases the amount of time needed to process a request by at least 50% according to my tests.

If easier i'm always up for a zoom call, so let me know if that would help with the process.