### PR TITLE
RDBC-653 Don't consider raw objects dirty

### DIFF
--- a/src/Documents/Session/InMemoryDocumentSessionOperations.ts
+++ b/src/Documents/Session/InMemoryDocumentSessionOperations.ts
@@ -1773,9 +1773,18 @@ export abstract class InMemoryDocumentSessionOperations
                 dirty = true;
             }
 
-            for (const prop of Object.keys(documentInfo.metadataInstance)) {
+            const metadataKeysToCheck = Object.keys(documentInfo.metadataInstance);
+
+            const ravenNodeTypeKey = CONSTANTS.Documents.Metadata.RAVEN_JS_TYPE;
+            if (metadataKeysToCheck.includes(ravenNodeTypeKey) && TypeUtil.isNullOrUndefined(documentInfo.metadataInstance[ravenNodeTypeKey]))
+            {
+                metadataKeysToCheck.splice(metadataKeysToCheck.indexOf("Raven-Node-Type"), 1);
+                documentInfo.metadata[ravenNodeTypeKey] = documentInfo.metadataInstance[ravenNodeTypeKey];
+            }
+
+            for (const prop of metadataKeysToCheck) {
                 const propValue = documentInfo.metadataInstance[prop];
-                if (!propValue ||
+                if (TypeUtil.isNullOrUndefined(propValue) ||
                     (typeof propValue["isDirty"] === "function"
                         && (propValue as IMetadataDictionary).isDirty())) {
                     dirty = true;

--- a/test/Issues/RDBC_653.ts
+++ b/test/Issues/RDBC_653.ts
@@ -91,4 +91,8 @@ describe("RDBC-653", function () {
     it("custom metadata wont be updated spuriously on falsy value 3", async () => {
         await checkMetadataUpdates("myMetadata", "");
     })
+
+    it("custom metadata wont be updated spuriously", async () => {
+        await checkMetadataUpdates("myMetadata", 47546921371);
+    })
 })

--- a/test/Issues/RDBC_653.ts
+++ b/test/Issues/RDBC_653.ts
@@ -1,0 +1,94 @@
+import {IDocumentStore} from "../../src";
+import {disposeTestDocumentStore, testContext,} from "../Utils/TestUtil";
+import {assertThat} from "../Utils/AssertExtensions";
+
+describe("RDBC-653", function () {
+
+    let store: IDocumentStore;
+
+    beforeEach(async function () {
+        store = await testContext.getDocumentStore();
+    });
+
+    afterEach(async () =>
+    {
+        await disposeTestDocumentStore(store);
+    });
+
+    async function checkMetadataUpdates(metadataKeyToSet:string, metadataValueToCheck) {
+        let customer = {
+            id: "customer/1",
+            name: "foo",
+            balance: 10
+        };
+
+        let session = await store.openSession();
+        try {
+            await session.store(customer);
+            const metadata = session.advanced.getMetadataFor(customer);
+            metadata[metadataKeyToSet] = metadataValueToCheck;
+            await session.saveChanges();
+        }
+        finally {
+            session.dispose();
+        }
+
+        try
+        {
+            session = await store.openSession();
+            const numberOfRequests = session.advanced.numberOfRequests;
+            customer = await session.load(customer.id);
+            assertThat(session.advanced.numberOfRequests).isEqualTo(numberOfRequests + 1);
+            assertThat(session.advanced.getMetadataFor(customer)[metadataKeyToSet]).isEqualTo(metadataValueToCheck);
+
+            customer.balance = 10;
+            await session.saveChanges();
+            assertThat(session.advanced.numberOfRequests).isEqualTo(numberOfRequests + 1);
+        }
+        finally {
+            session.dispose();
+        }
+    }
+
+    it("raw object metadata wont be updated spuriously", async () => {
+        let customer = {
+            id: "customer/1",
+            name: "foo",
+            balance: 10
+        };
+
+        let session = await store.openSession();
+        try {
+            await session.store(customer);
+            await session.saveChanges();
+        }
+        finally {
+            session.dispose();
+        }
+
+        try {
+            session = await store.openSession();
+            customer = await session.load(customer.id);
+            assertThat(session.advanced.numberOfRequests).isEqualTo(1);
+            customer.balance = 10;
+            await session.saveChanges();
+            assertThat(session.advanced.numberOfRequests).isEqualTo(1);
+        }
+        finally {
+            session.dispose();
+        }
+
+    })
+
+    it("custom metadata wont be updated spuriously on falsy value 1", async () => {
+        await checkMetadataUpdates("myMetadata", 0);
+    })
+
+    it("custom metadata wont be updated spuriously on falsy value 2", async () => {
+        await checkMetadataUpdates("myMetadata", false);
+    })
+
+    it("custom metadata wont be updated spuriously on falsy value 3", async () => {
+        await checkMetadataUpdates("myMetadata", "");
+    })
+})


### PR DESCRIPTION
https://issues.hibernatingrhinos.com/issue/RDBC-653/Raw-object-literal-in-node.js-is-always-considered-dirty

Raw TypeScript objects appear to have a `Raven-Node-Type` metadata field set to `null`. This caused spurious updates every time. I separated this corner case from the usual `updateMetadataModifications` flow and added a test for that.
