### PR TITLE
Refactor createEmptyObject as a protected method to allow customization

### DIFF
--- a/src/Mapping/ObjectMapper.ts
+++ b/src/Mapping/ObjectMapper.ts
@@ -1,4 +1,4 @@
-import { ObjectTypeDescriptor, ClassConstructor, ObjectLiteralDescriptor, EntityConstructor } from "../Types";
+import { ObjectTypeDescriptor, ObjectLiteralDescriptor, EntityConstructor } from "../Types";
 import { throwError } from "../Exceptions";
 import { TypeUtil } from "../Utility/TypeUtil";
 import { getLogger } from "../Utility/LogUtil";
@@ -338,8 +338,7 @@ export class TypesAwareObjectMapper implements ITypesAwareObjectMapper {
         if (!ctorOrTypeDescriptor) {
             instance = Object.assign({}, rawValue);
         } else if (TypeUtil.isClass(ctorOrTypeDescriptor)) {
-            instance = this._createEmptyObject(ctorOrTypeDescriptor as ClassConstructor);
-            instance = Object.assign(instance, rawValue);
+            instance = this.createEmptyObject(ctorOrTypeDescriptor, rawValue);
         } else if (TypeUtil.isObjectLiteralTypeDescriptor(ctorOrTypeDescriptor)) {
             instance = (ctorOrTypeDescriptor as ObjectLiteralDescriptor).construct(rawValue);
         } else {
@@ -367,12 +366,12 @@ export class TypesAwareObjectMapper implements ITypesAwareObjectMapper {
         return ctorOrTypeDescriptor;
     }
 
-    private _createEmptyObject<TResult extends object>(ctor: EntityConstructor<TResult>) {
+    protected createEmptyObject<TResult extends object>(ctor: EntityConstructor<TResult>, rawValue: object) {
         if (!ctor) {
             throwError("InvalidArgumentException", "ctor argument must not be null or undefined.");
         }
 
-        return new ctor() as TResult;
+        return Object.assign(new ctor(), rawValue) as TResult;
     }
 
     private _makeObjectLiteral(

--- a/src/Utility/TypeUtil.ts
+++ b/src/Utility/TypeUtil.ts
@@ -63,7 +63,7 @@ export class TypeUtil {
         return value === true || value === false;
     }
 
-    public static isClass(value: any): boolean {
+    public static isClass(value: any): value is ClassConstructor {
         return this.isFunction(value) && ("name" in value) && value.name !== ""
             && ("Object" !== value.name)
             && (!!value.prototype && !!value.prototype.constructor.name);


### PR DESCRIPTION
See: https://issues.hibernatingrhinos.com/issue/RDBC-661/NodeJS-client-should-not-invoke-constructor-when-mapping-entities-from-object-literals

Note: i've made the `createEmptyObject` method protected as we'd like to be able to extend the TypesAwareObjectMapper behavior at certain points. Currently, it only has the interface public methods, and everything else are private methods which prevents us from changing small bits unless we ignore typescript errors. We have a couple of things we'd like to contribute so we'll probably make incremental suggestions.