### PR TITLE
RDBC-662 store type of every array member

### DIFF
--- a/src/Mapping/ObjectMapper.ts
+++ b/src/Mapping/ObjectMapper.ts
@@ -425,8 +425,7 @@ export class TypesAwareObjectMapper implements ITypesAwareObjectMapper {
         }
 
         if (Array.isArray(obj)) {
-            const newObjPathPrefix = `${objPathPrefix}[]`;
-            return obj.map(x => this._makeObjectLiteral(x, newObjPathPrefix, typeInfoCallback, knownTypes));
+            return obj.map((x, index) => this._makeObjectLiteral(x, `${objPathPrefix}.${index}`, typeInfoCallback, knownTypes));
         }
 
         if (TypeUtil.isObject(obj)) {


### PR DESCRIPTION
The change introduces a different way to store array field information, but is backwards compatible with the previous version.

The PR relies on the same mechanism as objects for type information.