### PR TITLE
RDBC-673 Add tests: Set lock mode + Set priority for multiple indexes

### DIFF
--- a/src/Documents/Operations/Indexes/SetIndexesPriorityOperation.ts
+++ b/src/Documents/Operations/Indexes/SetIndexesPriorityOperation.ts
@@ -13,7 +13,7 @@ export class SetIndexesPriorityOperation implements IMaintenanceOperation<void> 
 
     private readonly _parameters: SetIndexesPriorityOperationParameters;
 
-    public constructor(indexName: string, mode: IndexPriority);
+    public constructor(indexName: string, priority: IndexPriority);
     public constructor(parameters: SetIndexesPriorityOperationParameters);
     public constructor(paramsOrIndexName: string | SetIndexesPriorityOperationParameters, priority?: IndexPriority) {
         if (TypeUtil.isString(paramsOrIndexName)) {


### PR DESCRIPTION
**Related issue:**
https://issues.hibernatingrhinos.com/issue/RDBC-673/Add-tests-Set-lock-mode-Set-priority-for-multiple-indexes