### PR TITLE
Fix payload mapping for mentorNode in ETL configuration

### DIFF
--- a/src/Documents/Operations/Etl/EtlConfiguration.ts
+++ b/src/Documents/Operations/Etl/EtlConfiguration.ts
@@ -15,7 +15,7 @@ export class EtlConfiguration<T extends ConnectionString> {
         return {
             TaskId: this.taskId,
             Name: this.name,
-            MentorName: this.mentorNode,
+            MentorNode: this.mentorNode,
             ConnectionStringName: this.connectionStringName,
             Transforms: this.transforms.map(x => serializeTransformation(x)),
             Disabled: this.disabled,

--- a/src/Documents/Subscriptions/SubscriptionState.ts
+++ b/src/Documents/Subscriptions/SubscriptionState.ts
@@ -4,7 +4,7 @@ export interface SubscriptionState {
     changeVectorForNextBatchStartingPoint: string;
     subscriptionId: number;
     subscriptionName: string;
-    mentorName: string;
+    mentorNode: string;
     nodeTag: string;
     lastBatchAckTime: string;
     lastClientConnectionTime: string;


### PR DESCRIPTION
I believe this mapping is wrong, the studio uses `MentorNode` not `MentorName` and when I create / update an ETL task via the node client the responsible node for the task is not set correctly.

Also not sure whether SubscriptionState should have a `mentorNode` instead of `mentorName` field, let me know and I can update the PR

`src/Documents/Subscriptions/SubscriptionState.ts`

```
export interface SubscriptionState {
    query: string;
    changeVectorForNextBatchStartingPoint: string;
    subscriptionId: number;
    subscriptionName: string;
    mentorName: string;
    nodeTag: string;
    lastBatchAckTime: string;
    lastClientConnectionTime: string;
    disabled: boolean;
}

```