### PR TITLE
RDBC-728 Use QueryFieldUtil.escapeIfNecessary

### DIFF
--- a/src/Documents/Session/Tokens/SuggestToken.ts
+++ b/src/Documents/Session/Tokens/SuggestToken.ts
@@ -1,6 +1,7 @@
 import { QueryToken } from "./QueryToken";
 import { throwError } from "../../../Exceptions";
 import { StringUtil } from "../../../Utility/StringUtil";
+import { QueryFieldUtil } from "../../Queries/QueryFieldUtil";
 
 export class SuggestToken extends QueryToken {
 
@@ -21,13 +22,13 @@ export class SuggestToken extends QueryToken {
         }
 
         this._fieldName = fieldName;
-        this._alias = !!alias && alias.includes(" ") ? `"${alias}"` : alias;
+        this._alias = alias;
         this._termParameterName = termParameterName;
         this._optionsParameterName = optionsParameterName;
     }
 
     public static create(fieldName: string, alias: string, termParameterName: string, optionsParameterName: string) {
-        return new SuggestToken(fieldName, alias, termParameterName, optionsParameterName);
+        return new SuggestToken(fieldName, QueryFieldUtil.escapeIfNecessary(alias), termParameterName, optionsParameterName);
     }
 
     public get fieldName() {


### PR DESCRIPTION
This PR fixes the **previous PR** which was: https://github.com/ravendb/ravendb-nodejs-client/pull/375

**The intention was to have the same fix as was done for the C# client**
see the C# PR: https://github.com/ravendb/ravendb/pull/16642

**Related issue:** 
https://issues.hibernatingrhinos.com/issue/RDBC-728/Incorrect-RQL-generated-when-using-WithDisplayName-in-a-suggestion-query-Missing-quotes

