### PR TITLE
fix: Error thrown when running `DocumentStore.initialize()` with an insecure connection when passing `AuthOptions`, even if no certificate was passed.

### DIFF
--- a/src/Http/RequestExecutor.ts
+++ b/src/Http/RequestExecutor.ts
@@ -887,7 +887,7 @@ export class RequestExecutor implements IDisposable {
 
     public static validateUrls(initialUrls: string[], authOptions: IAuthOptions) {
         const cleanUrls = [...Array(initialUrls.length)];
-        let requireHttps = !!authOptions;
+        let requireHttps = !!authOptions?.certificate;
         for (let index = 0; index < initialUrls.length; index++) {
             const url = initialUrls[index];
             validateUri(url);


### PR DESCRIPTION
This PR fixes an error being thrown when `DocumentStore.initialize()` is run after creating a `DocumentStore` passing `AuthOptions` that do not contain a certificate.

In essence, this means that the user is forced to write the following verbose construction if they have a case where their `certificate` is possibly undefined:

```ts
let store: DocumentStore;
if (certificate) {
	store = new DocumentStore(host, database, { certificate, type: "pfx" });
} else {
	store = new DocumentStore(host, database);
}

store.initialize();
```

Instead of:

```ts
// This interface is agnostic to whether `certificate` is present or not, if it's not provided, it will just assume an insecure connection.
const store = new DocumentStore(host, database, { certificate, type: "pfx" });

store.initialize();
```

Given that this piece of code currently throws:

```ts
const store = new DocumentStore(host, database, { certificate: undefined, type: "pfx" });

store.initialize(); // Throws.
```