### PR TITLE
RDoc-2699 Fix comment in README about bulkInsert

### DIFF
--- a/README.md
+++ b/README.md
@@ -905,6 +905,7 @@ const bulkInsert = store.bulkInsert();
 for (const name of ["Anna", "Maria", "Miguel", "Emanuel", "Dayanara", "Aleida"]) {
     const user = new User({ name });
     await bulkInsert.store(user);
+    // The data stored in bulkInsert will be streamed to the server in batches 
 }
 
 // Sample documents stored:
@@ -915,7 +916,7 @@ for (const name of ["Anna", "Maria", "Miguel", "Emanuel", "Dayanara", "Aleida"])
 // User { name: 'Dayanara', id: 'users/5-A' }
 // User { name: 'Aleida', id: 'users/6-A' }
 
-// Persist the data - call finish
+// Call finish to send all remaining data to the server
 await bulkInsert.finish();
 ```
 


### PR DESCRIPTION
**Related issue:**
https://issues.hibernatingrhinos.com/issue/RDoc-2699/Node.js-Document-extensions-Attachments-Bulk-insert-Replace-C-samples

I updated the comment in README about bulk insert
Similar to how it was done for the documentation (RDoc-2699)