### PR TITLE
RDBC-831 Add test for "GetCompareExchangeValuesOperation"

### DIFF
--- a/test/Ported/UniqueValuesTest.ts
+++ b/test/Ported/UniqueValuesTest.ts
@@ -69,6 +69,38 @@ describe("UniqueValuesTest", function () {
         assert.ok(res2.successful);
     });
 
+    it("canGetMultipleCompareExchangeItemsByKeys", async () => {
+        const user1 = new User();
+        user1.name = "Name1";
+        const user2 = new User();
+        user2.name = "Name2";
+        const user3 = new User();
+        user3.name = "Name3";
+
+        const res1 = await store.operations
+            .send(new PutCompareExchangeValueOperation<User>("users/1", user1, 0));
+        const res2 = await store.operations
+            .send(new PutCompareExchangeValueOperation<User>("users/2", user2, 0));
+        const res3 = await store.operations
+            .send(new PutCompareExchangeValueOperation<User>("users/3", user3, 0));
+
+        assert.ok(res1.successful);
+        assert.ok(res2.successful);
+        assert.ok(res3.successful);
+
+        assert.strictEqual(res1.value.name, "Name1");
+        assert.strictEqual(res2.value.name, "Name2");
+        assert.strictEqual(res3.value.name, "Name3");
+
+        const values = await store.operations.send(new GetCompareExchangeValuesOperation<User>({
+            keys: ["users/1", "users/3"]
+        }));
+        
+        assert.strictEqual(Object.keys(values).length, 2);
+        assert.strictEqual(values["users/1"].value.name, "Name1");
+        assert.strictEqual(values["users/3"].value.name, "Name3");
+    });
+
     it("canListCompareExchange", async () => {
 
         const user1 = new User();


### PR DESCRIPTION
**Related issues:**
https://issues.hibernatingrhinos.com/issue/RDBC-831/Add-test-for-GetCompareExchangeValuesOperation
https://issues.hibernatingrhinos.com/issue/RavenDB-22239/Add-test-for-GetCompareExchangeValuesOperation