### PR TITLE
RDBC-832 Fix DeleteCompareExchangeValueOperation behavior when key doesn't exist

### DIFF
--- a/src/Documents/Operations/CompareExchange/CompareExchangeResult.ts
+++ b/src/Documents/Operations/CompareExchange/CompareExchangeResult.ts
@@ -27,7 +27,7 @@ export class CompareExchangeResult<T> {
             throwError("InvalidOperationException", "Response is invalid. Index is missing");
         }
 
-        const val = response.Value.Object || null;
+        const val = response.Value?.Object || null;
         return CompareExchangeResult._create(val, response.Index, response.Successful, conventions, clazz);
     }
 

--- a/test/Ported/UniqueValuesTest.ts
+++ b/test/Ported/UniqueValuesTest.ts
@@ -124,6 +124,35 @@ describe("UniqueValuesTest", function () {
         assert.strictEqual(readValue.value, "Karmel");
     });
 
+    it("tryingToDeleteNonExistingKeyShouldNotThrow", async () => {
+        const res1= await store.operations.send(
+            new PutCompareExchangeValueOperation<string>("key/1", "Name", 0));
+
+        assert.strictEqual(res1.value, "Name");
+        assert.ok(res1.successful);
+
+        const res2 = await store.operations.send(
+            new DeleteCompareExchangeValueOperation<string>("key/2", res1.index));
+
+        assert.ok(res2.successful);
+        assert.equal(res2.value, null);
+        assert.equal(res2.index, res1.index + 1);
+
+        const res3 = await store.operations.send(
+            new DeleteCompareExchangeValueOperation<string>("key/2", 0));
+
+        assert.ok(res3.successful);
+        assert.equal(res3.value, null);
+        assert.equal(res3.index, res2.index + 1);
+
+        const res4 = await store.operations.send(
+            new DeleteCompareExchangeValueOperation<string>("key/2", 999));
+
+        assert.ok(res4.successful);
+        assert.equal(res4.value, null);
+        assert.equal(res4.index, res3.index + 1);
+    });
+
     it("returnCurrentValueWhenPuttingConcurrently", async () => {
         const user = new User();
         user.name = "Karmel";


### PR DESCRIPTION
**Related issue:**
https://issues.hibernatingrhinos.com/issue/RDBC-832/Fix-DeleteCompareExchangeValueOperation-behavior-when-key-doesnt-exist

