### PR TITLE
V6: Ignore temp directory .tshy-build/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ src/**/*.js.map
 test/**/*.js
 test/**/*.d.ts
 .build/
+.tshy-build/
 test/certs
 tryouts/
 .DS_Store


### PR DESCRIPTION
The `tshy` command creates a bunch of files in the `.tshy-build/` directory, even if temporarily, they should be ignored by git.