### PR TITLE
RDBC-882 Expose SingleNodeBatchCommand in index.ts (v6.0)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -163,6 +163,7 @@ export { DeleteByQueryOperation } from "./Documents/Operations/DeleteByQueryOper
 export { GetCollectionStatisticsOperation } from "./Documents/Operations/GetCollectionStatisticsOperation.js";
 export type { CollectionStatistics } from "./Documents/Operations/CollectionStatistics.js";
 export type { GetServerWideExternalReplicationsResponse } from "./Documents/Operations/GetServerWideExternalReplicationsResponse.js";
+export { SingleNodeBatchCommand } from "./Documents/Commands/Batches/SingleNodeBatchCommand.js";
 export { CreateSubscriptionCommand } from "./Documents/Commands/CreateSubscriptionCommand.js";
 export { GetNextOperationIdCommand } from "./Documents/Commands/GetNextOperationIdCommand.js";
 export { KillOperationCommand } from "./Documents/Commands/KillOperationCommand.js";


### PR DESCRIPTION
Related issue:
https://issues.hibernatingrhinos.com/issue/RDBC-882/Expose-SingleNodeBatchCommand-in-index.ts