### PR TITLE
RDBC-903 - Drop Node.js 18 support

### DIFF
--- a/.github/workflows/RavenClient.yml
+++ b/.github/workflows/RavenClient.yml
@@ -2,9 +2,9 @@ name: tests/node
 
 on:
   push:
-    branches: [ v6.0 ]
+    branches: [ v7.0 ]
   pull_request:
-    branches: [ v6.0 ]
+    branches: [ v7.0 ]
   schedule:
     - cron: '0 10 * * *'
   workflow_dispatch:
@@ -31,7 +31,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [20.x, 22.x]
         serverVersion: ["6.0", "6.2", "7.0"]
       fail-fast: false
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "unzipper": "^0.12.3"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       },
       "optionalDependencies": {
         "@rollup/rollup-linux-x64-gnu": "^4.20.0"

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "Hibernating Rhinos"
   ],
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   },
   "keywords": [
     "ravendb",


### PR DESCRIPTION
Increase minimum Node.js version to 20.0.0 and update GitHub Actions workflow to use v7.0 branch. Remove support for Node.js 18.x in the test matrix to align with updated requirements.