### PR TITLE
RDBC-927 Add null check in `revivePeriodicBackupStatus` function to prevent flaky test

### DIFF
--- a/src/Documents/Operations/Backups/GetPeriodicBackupStatusOperation.ts
+++ b/src/Documents/Operations/Backups/GetPeriodicBackupStatusOperation.ts
@@ -80,6 +80,10 @@ class GetPeriodicBackupStatusCommand extends RavenCommand<GetPeriodicBackupStatu
 }
 
 export function revivePeriodicBackupStatus(status: ServerResponse<PeriodicBackupStatus>): PeriodicBackupStatus {
+    if (!status) {
+        return null;
+    }
+
     return {
         ...status,
         lastFullBackup: DateUtil.utc.parse(status.lastFullBackup),


### PR DESCRIPTION
https://issues.hibernatingrhinos.com/issue/RDBC-927/Flaky-test-failure-in-CI

Fixes a potential cause of the flaky test. Previously, this could trigger a `NRE`. Returning null early ensures the value is fetched again