### PR TITLE
RDBC-947 Compare-exchange api behavior differs between stable and dev server version

### DIFF
--- a/src/Documents/Commands/Batches/SingleNodeBatchCommand.ts
+++ b/src/Documents/Commands/Batches/SingleNodeBatchCommand.ts
@@ -101,7 +101,7 @@ export class SingleNodeBatchCommand extends RavenCommand<BatchCommandResult> imp
     }
 
     public createRequest(node: ServerNode): HttpRequestParameters {
-        const uri = node.url + "/databases/" + node.database + "/bulk_docs?";
+        const uri = node.url + "/databases/" + node.database + "/bulk_docs";
         const headers = HeadersBuilder.create().typeAppJson().build();
 
         if (TypeUtil.isNullOrUndefined(this._supportsAtomicWrites)) {
@@ -172,7 +172,7 @@ export class SingleNodeBatchCommand extends RavenCommand<BatchCommandResult> imp
 
     protected _appendOptions(): string {
         if (!this._options) {
-            return "";
+            return "?";
         }
 
         return SingleNodeBatchCommand.appendOptions(this._options.indexOptions, this._options.replicationOptions, this._options.shardedOptions);
@@ -180,7 +180,7 @@ export class SingleNodeBatchCommand extends RavenCommand<BatchCommandResult> imp
     }
 
     protected static appendOptions(indexOptions: IndexBatchOptions, replicationOptions: ReplicationBatchOptions, shardedOptions: ShardedBatchOptions): string {
-        let result = "";
+        let result = "?";
 
         if (replicationOptions) {
             result += `&waitForReplicasTimeout=${TimeUtil.millisToTimeSpan(replicationOptions.timeout)}`;


### PR DESCRIPTION

- Remove trailing `?` from URI construction.
- Adjust default options to start with `?` when present.
- Ensure consistency in query string handling logic.