### PR TITLE
RDBC-946 Missing Vector Search APIs

### DIFF
--- a/src/Documents/Queries/VectorSearch/Fields/VectorEmbeddingField.ts
+++ b/src/Documents/Queries/VectorSearch/Fields/VectorEmbeddingField.ts
@@ -1,6 +1,7 @@
 import { IVectorEmbeddingField, IVectorEmbeddingFieldFactoryAccessor } from "../../../Session/VectorFieldFactory.js";
 import {VectorEmbeddingType} from "../VectorEmbeddingType.js";
 import { Field } from "../../../../Types/index.js";
+import { throwError } from "../../../../Exceptions/index.js";
 
 export class VectorEmbeddingField<T> implements
     IVectorEmbeddingField, 
@@ -23,7 +24,7 @@ export class VectorEmbeddingField<T> implements
 
     public targetQuantization(targetEmbeddingQuantization: VectorEmbeddingType): IVectorEmbeddingField {
         if (targetEmbeddingQuantization === "Text") {
-            throw new Error("Cannot quantize the embedding to Text. This option is only available for sourceQuantizationType.");
+            throwError("InvalidOperationException", "Cannot quantize the embedding to Text. This option is only available for sourceQuantizationType.");
         }
 
         this.destinationQuantizationType = targetEmbeddingQuantization;
@@ -31,7 +32,7 @@ export class VectorEmbeddingField<T> implements
         if ((this.sourceQuantizationType === "Int8" ||
              this.sourceQuantizationType === "Binary") &&
              this.destinationQuantizationType !== this.sourceQuantizationType) {
-            throw new Error(`Cannot quantize already quantized embeddings. Source VectorEmbeddingType is ${this.sourceQuantizationType}; however the destination is ${this.destinationQuantizationType}.`);
+            throwError("InvalidOperationException", `Cannot quantize already quantized embeddings. Source VectorEmbeddingType is ${this.sourceQuantizationType}; however the destination is ${this.destinationQuantizationType}.`);
         }
 
         return this;

--- a/src/Documents/Queries/VectorSearch/Fields/VectorEmbeddingTextField.ts
+++ b/src/Documents/Queries/VectorSearch/Fields/VectorEmbeddingTextField.ts
@@ -4,6 +4,7 @@ import {
 } from "../../../Session/VectorFieldFactory.js";
 import { VectorEmbeddingType } from "../VectorEmbeddingType.js";
 import { Field } from "../../../../Types/index.js";
+import { throwError } from "../../../../Exceptions/index.js";
 
 export class VectorEmbeddingTextField<T> implements
     IVectorEmbeddingTextField, 
@@ -22,7 +23,7 @@ export class VectorEmbeddingTextField<T> implements
 
     public targetQuantization(targetEmbeddingQuantization: VectorEmbeddingType): IVectorEmbeddingTextField {
         if (targetEmbeddingQuantization === "Text") {
-            throw new Error("Cannot quantize the embedding to Text. This option is only available for sourceQuantizationType.");
+            throwError("InvalidOperationException","Cannot quantize the embedding to Text. This option is only available for sourceQuantizationType.");
         }
 
         this.destinationQuantizationType = targetEmbeddingQuantization;
@@ -31,7 +32,7 @@ export class VectorEmbeddingTextField<T> implements
 
     public usingTask(embeddingsGenerationTaskIdentifier: string): IVectorEmbeddingTextField {
         if (this.sourceQuantizationType !== "Text") {
-            throw new Error("The usingTask method can only be used with text embeddings (withText)");
+            throwError("InvalidOperationException", "The usingTask method can only be used with text embeddings (withText)");
         }
 
         this.embeddingsGenerationTaskIdentifier = embeddingsGenerationTaskIdentifier;

--- a/src/Documents/Session/AbstractDocumentQuery.ts
+++ b/src/Documents/Session/AbstractDocumentQuery.ts
@@ -2579,7 +2579,7 @@ export abstract class AbstractDocumentQuery<T extends object, TSelf extends Abst
         this._assertMethodIsCurrentlySupported("vectorSearch");
 
         const fieldAccessor = this._resolveVectorSearchFieldAccessor(fieldName);
-        const {value, isDocumentId} = this._resolveVectorSearchValueFactory(valueOrFactory);
+        const {value, isDocumentId, embeddingsGenerationTaskIdentifierByValue} = this._resolveVectorSearchValueFactory(valueOrFactory);
 
         const tokens = this._getCurrentWhereTokens();
         this._appendOperatorIfNeeded(tokens);
@@ -2600,7 +2600,8 @@ export abstract class AbstractDocumentQuery<T extends object, TSelf extends Abst
             options?.numberOfCandidates || null,
             options?.isExact || VectorSearchToken.DEFAULT_IS_EXACT,
             isDocumentId,
-            taskIdentifier
+            taskIdentifier,
+            embeddingsGenerationTaskIdentifierByValue
         );
 
         tokens.push(vectorSearchToken);
@@ -2631,9 +2632,13 @@ export abstract class AbstractDocumentQuery<T extends object, TSelf extends Abst
                 throwError("InvalidOperationException", "No value was provided in the valueFactory");
             }
 
-            return {value, isDocumentId: !!fieldValueFactory.byId};
+            return {
+                value,
+                isDocumentId: !!fieldValueFactory.byId,
+                embeddingsGenerationTaskIdentifierByValue: fieldValueFactory.embeddingsGenerationTaskIdentifier
+            };
         } else {
-            return {value: valueOrFactory, isDocumentId: false};
+            return {value: valueOrFactory, isDocumentId: false, embeddingsGenerationTaskIdentifierByValue: null};
         }
     }
 }

--- a/src/Documents/Session/Tokens/VectorSearchToken.ts
+++ b/src/Documents/Session/Tokens/VectorSearchToken.ts
@@ -3,6 +3,7 @@ import { VectorEmbeddingType } from "../../Queries/VectorSearch/VectorEmbeddingT
 import { StringBuilder } from "../../../Utility/StringBuilder.js";
 import { vectorSearchConfigurationToMethodName } from "../../../Utility/VectorSearchUtil.js";
 import { IVectorEmbeddingFieldFactoryAccessor } from "../VectorFieldFactory.js";
+import { throwError } from "../../../Exceptions/index.js";
 
 export class VectorSearchToken extends WhereToken {
     static readonly EMBEDDING_PREFIX = "embedding.";
@@ -25,6 +26,7 @@ export class VectorSearchToken extends WhereToken {
     private readonly _numberOfCandidatesForQuerying: number | null;
     private readonly _isDocumentId: boolean;
     private readonly _embeddingsGenerationTaskIdentifier: string | null;
+    private readonly _embeddingsGenerationTaskIdentifierByValue: string | null;
 
     public constructor(
         fieldName: string,
@@ -35,7 +37,8 @@ export class VectorSearchToken extends WhereToken {
         numberOfCandidatesForQuerying: number | null,
         isExact: boolean,
         isDocumentId: boolean,
-        embeddingsGenerationTaskIdentifier: string | null
+        embeddingsGenerationTaskIdentifier: string | null,
+        embeddingsGenerationTaskIdentifierByValue: string | null
     ) {
         super();
         this.fieldName = fieldName;
@@ -47,6 +50,11 @@ export class VectorSearchToken extends WhereToken {
         this._numberOfCandidatesForQuerying = numberOfCandidatesForQuerying;
         this._isDocumentId = isDocumentId;
         this._embeddingsGenerationTaskIdentifier = embeddingsGenerationTaskIdentifier;
+        this._embeddingsGenerationTaskIdentifierByValue = embeddingsGenerationTaskIdentifierByValue;
+
+        if (embeddingsGenerationTaskIdentifier != null && embeddingsGenerationTaskIdentifierByValue != null) {
+            throwError("InvalidOperationException", "Embeddings generation task identifier set in value factory cannot be used with field factory. It solely purpose to use already generated embeddings.");
+        }
 
         this.options = {
             exact: isExact,
@@ -109,11 +117,7 @@ export class VectorSearchToken extends WhereToken {
 
         writer.append(", ");
 
-        if (this._isDocumentId) {
-            writer.append(`${VectorSearchToken.EMBEDDING_FOR_DOCUMENT}($${this.parameterName})`);
-        } else {
-            writer.append(`$${this.parameterName}`);
-        }
+        writer.append(this.getEmbeddingExpression());
 
         const parametersAreDefault = this._similarityThreshold == null &&
             this._numberOfCandidatesForQuerying == null;
@@ -132,5 +136,15 @@ export class VectorSearchToken extends WhereToken {
         if (this.options.boost != null) {
             writer.append(`, ${this.options.boost.toString()})`);
         }
+    }
+
+    private getEmbeddingExpression() {
+        if (this._isDocumentId) {
+            return `${VectorSearchToken.EMBEDDING_FOR_DOCUMENT}($${this.parameterName})`;
+        }
+        if (this._embeddingsGenerationTaskIdentifierByValue != null) {
+            return `${VectorSearchToken.EMBEDDING_TEXT}($${this.parameterName}, ${VectorSearchToken.AI_TASK_METHOD_NAME}('${this._embeddingsGenerationTaskIdentifierByValue}'))`;
+        }
+        return `$${this.parameterName}`;
     }
 }

--- a/src/Documents/Session/VectorFieldFactory.ts
+++ b/src/Documents/Session/VectorFieldFactory.ts
@@ -81,8 +81,9 @@ export interface IVectorEmbeddingTextFieldValueFactory {
     /**
      * Defines queried text.
      * @param text Queried text
+     * @param embeddingsGenerationTaskIdentifier Task identifier for embeddings generation
      */
-    byText(text: string): void;
+    byText(text: string, embeddingsGenerationTaskIdentifier?: string): void;
 
     /**
      * Query by the embedding(s) indexed from the specified document for the quried field.
@@ -93,8 +94,9 @@ export interface IVectorEmbeddingTextFieldValueFactory {
     /**
      * Defines queried texts.
      * @param texts Queried texts
+     * @param embeddingsGenerationTaskIdentifier Task identifier for embeddings generation
      */
-    byTexts(texts: string[]): void;
+    byTexts(texts: string[], embeddingsGenerationTaskIdentifier?: string): void;
 }
 
 export interface IVectorEmbeddingFieldValueFactory {
@@ -143,6 +145,8 @@ export interface IVectorFieldValueFactoryAccessor {
     texts: string[];
 
     byId: string;
+
+    embeddingsGenerationTaskIdentifier: string;
 }
 
 export class VectorEmbeddingFieldValueFactory implements IVectorEmbeddingFieldValueFactory,
@@ -153,6 +157,7 @@ export class VectorEmbeddingFieldValueFactory implements IVectorEmbeddingFieldVa
     public text: string = null;
     public texts: string[] = null;
     public byId: string = null;
+    public embeddingsGenerationTaskIdentifier: string = null;
 
     public byEmbedding<T extends number>(embedding: T[]): void;
     public byEmbedding<T extends number>(embedding: { "@vector": IRavenVector<T> }): void;
@@ -179,17 +184,21 @@ export class VectorEmbeddingFieldValueFactory implements IVectorEmbeddingFieldVa
     /**
      * Defines queried text.
      * @param text Queried text
+     * @param embeddingsGenerationTaskIdentifier Task identifier for embeddings generation
      */
-    public byText(text: string): void {
+    public byText(text: string, embeddingsGenerationTaskIdentifier?: string): void {
         this.text = text;
+        this.embeddingsGenerationTaskIdentifier = embeddingsGenerationTaskIdentifier;
     }
 
     /**
      * Defines queried texts.
      * @param texts Queried texts
+     * @param embeddingsGenerationTaskIdentifier Task identifier for embeddings generation
      */
-    public byTexts(texts: string[]): void {
+    public byTexts(texts: string[], embeddingsGenerationTaskIdentifier?: string): void {
         this.texts = texts;
+        this.embeddingsGenerationTaskIdentifier = embeddingsGenerationTaskIdentifier;
     }
 
     public forDocument(documentId: string): void {

--- a/test/Issues/RDBC-946.ts
+++ b/test/Issues/RDBC-946.ts
@@ -1,0 +1,124 @@
+import assert from "node:assert";
+import {IDocumentStore, IndexDefinition, PutIndexesOperation} from "../../src/index.js";
+import {disposeTestDocumentStore, RavenTestContext, testContext} from "../Utils/TestUtil.js";
+import {INDEXES} from "../../src/Constants.js";
+
+(RavenTestContext.isRavenDbServerVersion("7.0") ? describe : describe.skip)("[RDBC-946]", () => {
+    let store: IDocumentStore;
+
+    beforeEach(async function () {
+        store = await testContext.getDocumentStore("RDBC-946", false, null, (record) => {
+            record.settings[INDEXES.INDEXING_AUTO_SEARCH_ENGINE_TYPE] = "Corax";
+            record.settings[INDEXES.INDEXING_STATIC_SEARCH_ENGINE_TYPE] = "Corax";
+        });
+    });
+
+    afterEach(async () =>
+        await disposeTestDocumentStore(store));
+
+    it("can use task to query pregenerated embedding - RQL generation with byText", async () => {
+        await setupVectorIndex(store);
+
+        const session = store.openSession();
+
+        const rqlResult = session.query({indexName: "VectorIndex"})
+            .vectorSearch(f => f.withField("Vector"),
+                v => v.byText("car", "localaitask"))
+            .toString();
+
+        assert.strictEqual(rqlResult, "from index 'VectorIndex' where vector.search(Vector, embedding.text($p0, ai.task('localaitask')))");
+    });
+
+    it("can use task to query pregenerated embedding - RQL generation with byTexts", async () => {
+        await setupVectorIndex(store);
+
+        const session = store.openSession();
+
+        const rqlResult = session.query({indexName: "VectorIndex"})
+            .vectorSearch(f => f.withField("Vector"),
+                v => v.byTexts(["car", "planet"], "localaitask"))
+            .toString();
+
+        assert.strictEqual(rqlResult, "from index 'VectorIndex' where vector.search(Vector, embedding.text($p0, ai.task('localaitask')))");
+    });
+
+    it("can use task to query pregenerated embedding - document query with byText", async () => {
+        await setupVectorIndex(store);
+
+        const session = store.openSession();
+
+        const rqlResult = session.advanced.documentQuery({indexName: "VectorIndex"})
+            .vectorSearch(f => f.withField("Vector"),
+                v => v.byText("animal", "localaitask"))
+            .toString();
+
+        assert.strictEqual(rqlResult, "from index 'VectorIndex' where vector.search(Vector, embedding.text($p0, ai.task('localaitask')))");
+    });
+
+    it("can use task to query pregenerated embedding - document query with byTexts", async () => {
+        await setupVectorIndex(store);
+
+        const session = store.openSession();
+
+        const rqlResult = session.advanced.documentQuery({indexName: "VectorIndex"})
+            .vectorSearch(f => f.withField("Vector"),
+                v => v.byTexts(["car", "cosmos"], "localaitask"))
+            .toString();
+
+        assert.strictEqual(rqlResult, "from index 'VectorIndex' where vector.search(Vector, embedding.text($p0, ai.task('localaitask')))");
+    });
+
+    it("should generate RQL for vector search with byText, task identifier and similarity options", async () => {
+        await setupVectorIndex(store);
+
+        const session = store.openSession();
+
+        const query = session.query({indexName: "VectorIndex"})
+            .vectorSearch(field => field.withField("Vector"),
+                factory => factory.byText("query text", "openai-task"), {
+                    similarity: 0.8,
+                    numberOfCandidates: 50
+                })
+            .toString();
+
+        assert.strictEqual(query, "from index 'VectorIndex' where vector.search(Vector, embedding.text($p0, ai.task('openai-task')), 0.8, 50)");
+    });
+
+    it("should generate RQL for vector search with byTexts, task identifier and exact matching", async () => {
+        await setupVectorIndex(store);
+
+        const session = store.openSession();
+
+        const query = session.query({indexName: "VectorIndex"})
+            .vectorSearch(field => field.withField("Vector"),
+                factory => factory.byTexts(["query one", "query two"], "embedding-task"), {
+                    isExact: true
+                })
+            .toString();
+
+        assert.strictEqual(query, "from index 'VectorIndex' where exact(vector.search(Vector, embedding.text($p0, ai.task('embedding-task'))))");
+    });
+
+    it("should throw error when both field factory and value factory task identifiers are set", async () => {
+        const session = store.openSession();
+
+        assert.throws(() => {
+            session.query({collection: "Dtos"})
+                .vectorSearch(field => field.withText("TextualValue").usingTask("field-task"),
+                    factory => factory.byText("query text", "value-task"))
+                .toString();
+        }, /Embeddings generation task identifier set in value factory cannot be used with field factory/);
+    });
+
+    async function setupVectorIndex(store: IDocumentStore) {
+        const indexDefinition = new IndexDefinition();
+        indexDefinition.name = "VectorIndex";
+        indexDefinition.maps = new Set([`
+            from dto in docs.Dtos
+            let attachment = LoadAttachment(dto, "vector")
+            select new { Vector = CreateVector(attachment.GetContentAsStream())}`]);
+
+        const putIndexesOperation = new PutIndexesOperation(indexDefinition);
+        await store.maintenance.send(putIndexesOperation);
+    }
+});


### PR DESCRIPTION
Add support for querying pre-generated embeddings with task identifiers

- Introduced `embeddingsGenerationTaskIdentifier` parameter in vector search methods (`byText`, `byTexts`).
- Enhanced `VectorSearchToken` to validate and generate embedding expressions with task identifiers.
- Updated exception handling for invalid task identifier usage in vector search logic.
- Added tests to verify correct RQL generation and error scenarios for task-based embedding queries.

https://issues.hibernatingrhinos.com/issue/RDBC-946/Missing-Vector-Search-APIs