### PR TITLE
fix: prevent binary attachment corruption (LF to CRLF conversion)

### DIFF
--- a/src/Documents/Commands/Batches/SingleNodeBatchCommand.ts
+++ b/src/Documents/Commands/Batches/SingleNodeBatchCommand.ts
@@ -93,7 +93,7 @@ export class SingleNodeBatchCommand extends RavenCommand<BatchCommandResult> imp
             for (let i = 0; i < attachments.length; i++) {
                 const part = attachments[i].body;
                 const payload = part instanceof Readable ? await readToBuffer(part) : part;
-                body.append("attachment_" + i, payload);
+                body.append("attachment_" + i, new Blob([payload], { type: "application/octet-stream" }));
             }
         }
 

--- a/test/Ported/Attachments/AttachmentsSessionTest.ts
+++ b/test/Ported/Attachments/AttachmentsSessionTest.ts
@@ -319,6 +319,66 @@ describe("Attachments Session", function () {
         }
     });
 
+    it("binary attachment preserves all byte values including LF (0x0A)", async () => {
+        // This test verifies that binary attachments are not corrupted.
+        // Previously, LF bytes (0x0A) were being converted to CRLF (0x0D 0x0A)
+        // when FormData.append() received a Buffer without Blob wrapper.
+
+        // Create binary data with all possible byte values (0x00 to 0xFF)
+        const binaryData = new Uint8Array(256);
+        for (let i = 0; i < 256; i++) {
+            binaryData[i] = i;
+        }
+        const originalBuffer = Buffer.from(binaryData);
+
+        {
+            const session = store.openSession();
+            const user = new User();
+            user.name = "BinaryTest";
+            await session.store(user, "users/binary");
+            session.advanced.attachments.store(
+                user,
+                "allbytes.bin",
+                originalBuffer,
+                "application/octet-stream"
+            );
+            await session.saveChanges();
+        }
+
+        {
+            const session = store.openSession();
+            const result = await session.advanced.attachments.get("users/binary", "allbytes.bin");
+
+            let retrievedBuffer = Buffer.from([]);
+            result.data.pipe(new Writable({
+                write(chunk, enc, cb) {
+                    retrievedBuffer = Buffer.concat([retrievedBuffer, chunk]);
+                    cb();
+                }
+            }));
+
+            await finishedAsync(result.data);
+            result.dispose();
+
+            // Size should be exactly 256 bytes
+            assert.strictEqual(
+                retrievedBuffer.length,
+                originalBuffer.length,
+                `Binary attachment corrupted: expected ${originalBuffer.length} bytes, got ${retrievedBuffer.length} bytes`
+            );
+
+            // Content should be identical
+            assert.ok(
+                Buffer.compare(retrievedBuffer, originalBuffer) === 0,
+                "Binary attachment content was modified during storage/retrieval"
+            );
+
+            // Specifically verify byte 0x0A (LF) was not converted to 0x0D 0x0A (CRLF)
+            assert.strictEqual(retrievedBuffer[10], 0x0A, "Byte at index 10 should be 0x0A (LF)");
+            assert.strictEqual(retrievedBuffer[11], 0x0B, "Byte at index 11 should be 0x0B, not 0x0A from CRLF expansion");
+        }
+    });
+
     it("attachment exists", async () => {
         {
             const session = store.openSession();


### PR DESCRIPTION
When storing binary attachments via session.saveChanges(), Buffer data passed directly to FormData.append() was being treated as text, causing LF (0x0A) bytes to be converted to CRLF (0x0D 0x0A) on Windows.

The fix wraps the payload in a Blob with 'application/octet-stream' content type, consistent with how other binary data is handled elsewhere in the codebase (e.g., DatabaseSmuggler.ts:270).

Fixes binary file corruption affecting ZIP, images, PDFs, and any file containing 0x0A bytes.

Added regression test to verify all 256 byte values (0x00-0xFF) are preserved correctly through attachment storage and retrieval.

Fixes #503