### PR TITLE
RDBC-1006 small developer experience changes for genAI in Node.js

### DIFF
--- a/src/Documents/Operations/AI/AbstractAiIntegrationConfiguration.ts
+++ b/src/Documents/Operations/AI/AbstractAiIntegrationConfiguration.ts
@@ -2,7 +2,7 @@ import { EtlConfiguration } from "../Etl/EtlConfiguration.js";
 import { AiConnectionString, AiConnectorType } from "./ConnectionStrings/index.js";
 
 export abstract class AbstractAiIntegrationConfiguration extends EtlConfiguration<AiConnectionString> {
-    public get aiConnectorType(): AiConnectorType {
+    public aiConnectorType(): AiConnectorType {
         return this.connection?.getActiveProvider() ?? "None";
     }
 

--- a/test/Documents/Operations/AI/GenAiConfigurationTest.ts
+++ b/test/Documents/Operations/AI/GenAiConfigurationTest.ts
@@ -238,7 +238,7 @@ describe("GenAiConfiguration", () => {
     describe("aiConnectorType", () => {
         it("should return None when no connection", () => {
             const config = new GenAiConfiguration();
-            assert.strictEqual(config.aiConnectorType, "None");
+            assert.strictEqual(config.aiConnectorType(), "None");
         });
 
         it("should return connector type from connection", () => {
@@ -247,7 +247,7 @@ describe("GenAiConfiguration", () => {
             connection.openAiSettings = {apiKey: "test"} as any;
             config.connection = connection;
 
-            assert.strictEqual(config.aiConnectorType, "OpenAi");
+            assert.strictEqual(config.aiConnectorType(), "OpenAi");
         });
     });
 });


### PR DESCRIPTION
This pull request refactors the `aiConnectorType` member from a getter property to a method in the AI integration configuration classes, and updates the related tests accordingly. This change clarifies the interface and usage of `aiConnectorType`.

Refactor to method interface:

* Changed `aiConnectorType` from a getter property to a method in `AbstractAiIntegrationConfiguration`, requiring callers to use `aiConnectorType()` instead of `aiConnectorType`.

Test updates:

* Updated all usages of `aiConnectorType` in `GenAiConfigurationTest.ts` to call the method (`aiConnectorType()`) instead of accessing it as a property. [[1]](diffhunk://#diff-29a1ef605578c6804884837ecaa67dd88b7feef715022b36168a653648ac3f5fL241-R241) [[2]](diffhunk://#diff-29a1ef605578c6804884837ecaa67dd88b7feef715022b36168a653648ac3f5fL250-R250)