### PR TITLE
RDBC-916 - add Bun runtime support with TLS configuration

### DIFF
--- a/.github/workflows/BunClient.yml
+++ b/.github/workflows/BunClient.yml
@@ -1,0 +1,78 @@
+name: tests/bun
+
+on:
+  push:
+    branches: [ v7.1 ]
+  pull_request:
+    branches: [ v7.1 ]
+  schedule:
+    - cron: '0 10 * * *'
+  workflow_dispatch:
+    inputs:
+      ravendb_version:
+        description: 'RavenDB Version'
+        required: true
+        type: string
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    env:
+      RAVENDB_TEST_SERVER_PATH: ./RavenDB/Server/Raven.Server
+      RAVENDB_TEST_SERVER_CERTIFICATE_PATH: ./certs/server.pfx
+      RAVENDB_TEST_CLIENT_CERT_PASSPHRASE: client11
+      RAVENDB_TEST_CLIENT_CERT_PATH: ./certs/nodejs.pem
+      RAVENDB_TEST_CA_PATH: /usr/local/share/ca-certificates/ca.crt
+      RAVENDB_TEST_HTTPS_SERVER_URL: https://localhost:8989
+      RAVENDB_BUILD_TYPE: nightly
+      RAVEN_License: ${{ secrets.RAVEN_LICENSE }}
+      RAVENDB_SERVER_VERSION: ${{ matrix.serverVersion }}
+
+    strategy:
+      matrix:
+        bun-version: [latest]
+        serverVersion: ["6.2", "7.1", "7.2"]
+      fail-fast: false
+
+    steps:
+    - uses: actions/checkout@v4.1.4
+
+    - name: Setup Bun
+      uses: oven-sh/setup-bun@v2
+      with:
+        bun-version: ${{ matrix.bun-version }}
+
+    - name: Download RavenDB Server
+      run: |
+        if [[ -n "${{ inputs.ravendb_version }}" ]]; then
+          wget -O RavenDB.tar.bz2 "https://daily-builds.s3.amazonaws.com/RavenDB-${{ inputs.ravendb_version }}-linux-x64.tar.bz2"
+        else
+          wget -O RavenDB.tar.bz2 "https://hibernatingrhinos.com/downloads/RavenDB%20for%20Linux%20x64/latest?buildType=${{ env.RAVENDB_BUILD_TYPE }}&version=${{ matrix.serverVersion }}"
+        fi
+
+    - run: mkdir certs
+    - run: openssl genrsa -out certs/ca.key 2048
+    - run: openssl req -new -x509 -key certs/ca.key -out certs/ca.crt -subj "/C=US/ST=Arizona/L=Nevada/O=RavenDB Test CA/OU=RavenDB test CA/CN=localhost/emailAddress=ravendbca@example.com"
+    - run: openssl genrsa -traditional -out certs/localhost.key 2048
+    - run: openssl req -new  -key certs/localhost.key -out certs/localhost.csr -subj "/C=US/ST=Arizona/L=Nevada/O=RavenDB Test/OU=RavenDB test/CN=localhost/emailAddress=ravendb@example.com" -addext "subjectAltName = DNS:localhost"
+    - run: openssl x509 -req -extensions ext -extfile test/Assets/test_cert.conf -in certs/localhost.csr -CA certs/ca.crt -CAkey certs/ca.key -CAcreateserial -out certs/localhost.crt
+    - run: cat certs/localhost.key certs/localhost.crt > certs/nodejs.pem
+    - run: openssl pkcs12 -passout pass:"" -export -out certs/server.pfx -inkey certs/localhost.key -in certs/localhost.crt
+    - run: sudo cp certs/ca.crt /usr/local/share/ca-certificates/ca.crt
+    - run: sudo update-ca-certificates
+
+    - name: Extract RavenDB Server
+      run: tar xjf RavenDB.tar.bz2
+
+    - name: Install dependencies
+      run: bun install
+
+    - name: Run Linter
+      run: bun run lint
+
+    - name: Check exports
+      run: bun run check-exports
+
+    - name: Run Tests
+      run: bun run test

--- a/src/Auth/Certificate.ts
+++ b/src/Auth/Certificate.ts
@@ -4,6 +4,7 @@ import { throwError } from "../Exceptions/index.js";
 import { ClientOptions } from "ws";
 import { Agent } from "undici-types";
 import { ConnectionOptions } from "node:tls";
+import { BunTlsOptions } from "../Types/BunTypes.js";
 
 export type CertificateType = "pem" | "pfx";
 
@@ -11,6 +12,7 @@ export interface ICertificate {
     toAgentOptions(): Agent.Options;
     toSocketOptions(): ConnectionOptions;
     toWebSocketOptions(): ClientOptions;
+    toBunTlsOptions(): BunTlsOptions;
 }
 
 export abstract class Certificate implements ICertificate {
@@ -91,6 +93,14 @@ export abstract class Certificate implements ICertificate {
 
         return {};
     }
+
+    public toBunTlsOptions(): BunTlsOptions {
+        if (this._passphrase) {
+            return { passphrase: this._passphrase };
+        }
+
+        return {};
+    }
 }
 
 export class PemCertificate extends Certificate {
@@ -143,6 +153,16 @@ export class PemCertificate extends Certificate {
             key: this._key,
             ca: this._ca
         });
+    }
+
+    public toBunTlsOptions(): BunTlsOptions {
+        const options = super.toBunTlsOptions();
+        return {
+            ...options,
+            cert: this._certificate,
+            key: this._key,
+            ca: this._ca
+        };
     }
 
     protected _fetchPart(token: string): string {
@@ -202,5 +222,20 @@ export class PfxCertificate extends Certificate {
             pfx: this._certificate as Buffer,
             ca: this._ca
         });
+    }
+
+    public toBunTlsOptions(): BunTlsOptions {
+        const options = super.toBunTlsOptions();
+
+        console.warn(
+            "WARNING: PFX certificates are not currently supported in Bun runtime. " +
+            "The connection may fail. Please use PEM certificates instead. "
+        );
+
+        return {
+            ...options,
+            pfx: this._certificate as Buffer,
+            ca: this._ca
+        };
     }
 }

--- a/src/Documents/Conventions/DocumentConventions.ts
+++ b/src/Documents/Conventions/DocumentConventions.ts
@@ -20,6 +20,7 @@ import { InMemoryDocumentSessionOperations } from "../Session/InMemoryDocumentSe
 import { ShardingConventions } from "./ShardingConventions.js";
 import { plural } from "../../ext/pluralize/pluralize.js";
 import { HttpCompressionAlgorithm } from "../../Http/HttpCompressionAlgorithm.js";
+import {RuntimeUtil} from "../../Utility/RuntimeUtil.js";
 
 export type IdConvention = (databaseName: string, entity: object) => Promise<string>;
 export type IValueForQueryConverter<T> =
@@ -458,6 +459,10 @@ export class DocumentConventions {
      * Can accept compressed HTTP response content and will use decompression methods
      */
     public get useHttpDecompression() {
+        if (RuntimeUtil.isBun() && this._useHttpDecompression === null) {
+            return false;
+        }
+
         if (this._useHttpDecompression === null) {
             return true;
         }

--- a/src/Http/RavenCommand.ts
+++ b/src/Http/RavenCommand.ts
@@ -14,9 +14,10 @@ import { DocumentConventions } from "../Documents/Conventions/DocumentConvention
 import { ObjectTypeDescriptor } from "../Types/index.js";
 import { ObjectUtil } from "../Utility/ObjectUtil.js";
 import { Dispatcher } from "undici-types";
-import { RequestInit } from "undici";
 import { HEADERS } from "../Constants.js";
 import { DefaultCommandResponseBehavior } from "./Behaviors/DefaultCommandResponseBehavior.js";
+import { RuntimeUtil } from "../Utility/RuntimeUtil.js";
+import { BunFetchRequestInit } from "../Types/BunTypes.js";
 
 const log = getLogger({ module: "RavenCommand" });
 
@@ -154,13 +155,18 @@ export abstract class RavenCommand<TResult> {
 
         log.info(`Send command ${this.constructor.name} to ${uri}${body ? " with body " + body : ""}.`);
 
-        if (requestOptions.dispatcher) { // support for fiddler
-            agent = requestOptions.dispatcher;
-        }
-
         const bodyToUse = fetcher ? RavenCommand.maybeWrapBody(body) : body;
 
-        const optionsToUse = { body: bodyToUse, ...restOptions, dispatcher: agent } as RequestInit;
+        let optionsToUse: RequestInit | BunFetchRequestInit;
+
+        if (RuntimeUtil.isBun()) {
+            optionsToUse = { body: bodyToUse, ...restOptions } as BunFetchRequestInit;
+        } else {
+            if (requestOptions.dispatcher) { // support for fiddler
+                agent = requestOptions.dispatcher;
+            }
+            optionsToUse = { body: bodyToUse, ...restOptions, dispatcher: agent } as RequestInit;
+        }
 
         const passthrough = new PassThrough();
         passthrough.pause();

--- a/src/Http/RequestExecutor.ts
+++ b/src/Http/RequestExecutor.ts
@@ -49,6 +49,7 @@ import { Semaphore } from "../Utility/Semaphore.js";
 import { Dispatcher, Agent } from "undici-types";
 import { EOL } from "../Utility/OsUtil.js";
 import { importFix } from "../Utility/ImportUtil.js";
+import { RuntimeUtil } from "../Utility/RuntimeUtil.js";
 
 const DEFAULT_REQUEST_OPTIONS = {};
 
@@ -336,6 +337,10 @@ export class RequestExecutor implements IDisposable {
 
     public async getHttpAgent(): Promise<Dispatcher> {
         if (this.conventions.customFetch) {
+            return null;
+        }
+
+        if (RuntimeUtil.isBun()) {
             return null;
         }
 
@@ -1949,6 +1954,10 @@ export class RequestExecutor implements IDisposable {
         this._defaultRequestOptions = Object.assign(
             DEFAULT_REQUEST_OPTIONS,
             this._customHttpRequestOptions);
+
+        if (RuntimeUtil.isBun() && this._certificate) {
+            this._defaultRequestOptions.tls = this._certificate.toBunTlsOptions();
+        }
     }
 
     public dispose(): void {

--- a/src/Primitives/Http.ts
+++ b/src/Primitives/Http.ts
@@ -1,10 +1,13 @@
+import { BunTlsOptions } from "../Types/BunTypes.js";
 
 export type HttpRequestParameters = RequestInit & {
   uri: string;
   fetcher?: any;
+  tls?: BunTlsOptions;
 };
 export type HttpRequestParametersWithoutUri = RequestInit & {
   fetcher?: any;
+  tls?: BunTlsOptions;
 };
 export type HttpResponse = Response;
 export type HttpRequest = Request;

--- a/src/Types/BunTypes.ts
+++ b/src/Types/BunTypes.ts
@@ -1,0 +1,125 @@
+/**
+ * Minimal Bun type definitions for TLS support
+ * Based on: https://bun.com/docs/guides/http/tls
+ * https://bun.sh/docs/api/tcp
+ */
+
+import {BufferSource} from "node:stream/web";
+
+/**
+ * TLS options for Bun's fetch API
+ */
+export interface BunTlsOptions {
+    /**
+     * Passphrase for the TLS key
+     */
+    passphrase?: string;
+
+    /**
+     * File path to a .pem file custom Diffie Helman parameters
+     */
+    dhParamsFile?: string;
+
+    /**
+     * Explicitly set a server name
+     */
+    serverName?: string;
+
+    /**
+     * This sets `OPENSSL_RELEASE_BUFFERS` to 1.
+     * It reduces overall performance but saves some memory.
+     * @default false
+     */
+    lowMemoryMode?: boolean;
+
+    /**
+     * If set to `false`, any certificate is accepted.
+     * Default is `$NODE_TLS_REJECT_UNAUTHORIZED` environment variable, or `true` if it is not set.
+     */
+    rejectUnauthorized?: boolean;
+
+    /**
+     * If set to `true`, the server will request a client certificate.
+     *
+     * Default is `false`.
+     */
+    requestCert?: boolean;
+
+    /**
+     * Optionally override the trusted CA certificates. Default is to trust
+     * the well-known CAs curated by Mozilla. Mozilla's CAs are completely
+     * replaced when CAs are explicitly specified using this option.
+     */
+    ca?: string | BufferSource | Array<string | BufferSource> | undefined;
+
+    /**
+     * Cert chains in PEM format. One cert chain should be provided per
+     * private key. Each cert chain should consist of the PEM formatted
+     * certificate for a provided private key, followed by the PEM
+     * formatted intermediate certificates (if any), in order, and not
+     * including the root CA (the root CA must be pre-known to the peer,
+     * see ca). When providing multiple cert chains, they do not have to
+     * be in the same order as their private keys in key. If the
+     * intermediate certificates are not provided, the peer will not be
+     * able to validate the certificate, and the handshake will fail.
+     */
+    cert?: string | BufferSource | Array<string | BufferSource> | undefined;
+
+    /**
+     * Private keys in PEM format. PEM allows the option of private keys
+     * being encrypted. Encrypted keys will be decrypted with
+     * options.passphrase. Multiple keys using different algorithms can be
+     * provided either as an array of unencrypted key strings or buffers,
+     * or an array of objects in the form {pem: <string|buffer>[,
+     * passphrase: <string>]}. The object form can only occur in an array.
+     * object.passphrase is optional. Encrypted keys will be decrypted with
+     * object.passphrase if provided, or options.passphrase if it is not.
+     */
+    key?: string | BufferSource | Array<string | BufferSource> | undefined;
+
+    /**
+     * Optionally affect the OpenSSL protocol behavior, which is not
+     * usually necessary. This should be used carefully if at all! Value is
+     * a numeric bitmask of the SSL_OP_* options from OpenSSL Options
+     */
+    secureOptions?: number | undefined;
+
+    /**
+     * ALPN protocols
+     */
+    ALPNProtocols?: string | BufferSource;
+
+    /**
+     * Cipher suite specification
+     */
+    ciphers?: string;
+
+    /**
+     * Client renegotiation limit
+     */
+    clientRenegotiationLimit?: number;
+
+    /**
+     * Client renegotiation window
+     */
+    clientRenegotiationWindow?: number;
+
+    /**
+     * PFX or PKCS12 encoded certificate and private key
+     *
+     * @warning This property is included for Node.js compatibility, but PFX certificates
+     * are NOT currently supported in Bun runtime. Use PEM certificates (cert/key/ca) instead.
+     */
+    pfx?: Buffer;
+}
+
+/**
+ * Bun-specific fetch request initialization options
+ * Extend standard RequestInit with Bun-specific TLS options
+ */
+export interface BunFetchRequestInit extends RequestInit {
+    /**
+     * TLS configuration for HTTPS requests
+     */
+    tls?: BunTlsOptions;
+}

--- a/src/Utility/RuntimeUtil.ts
+++ b/src/Utility/RuntimeUtil.ts
@@ -1,0 +1,16 @@
+/**
+ * Utility class for detecting runtime environment
+ */
+export class RuntimeUtil {
+    private static _isBun: boolean = null;
+
+    /**
+     * Detects if the code is running in Bun runtime
+     */
+    public static isBun(): boolean {
+        if (this._isBun === null) {
+            this._isBun = !!process.versions.bun;
+        }
+        return this._isBun;
+    }
+}


### PR DESCRIPTION
This pull request adds support for the Bun runtime by introducing Bun-specific TLS options and runtime detection throughout the codebase. The changes ensure that HTTP requests, certificate handling, and decompression settings work correctly when running under Bun, with graceful fallbacks and warnings where Bun does not support certain features (such as PFX certificates).

**Bun runtime support and TLS handling:**

* Introduced a new `BunTlsOptions` interface and `BunFetchRequestInit` type in `BunTypes.ts` to define Bun-specific TLS and fetch options.
* Added a `RuntimeUtil` utility class to detect if the code is running under Bun.
* Updated `Certificate`, `PemCertificate`, and `PfxCertificate` classes to implement a `toBunTlsOptions()` method for generating Bun-compatible TLS options, with a warning for unsupported PFX certificates. [[1]](diffhunk://#diff-368993f7cd4ee0706b6bd643f23d3a80508110ec3804a37daa89343f46378cadR7-R15) [[2]](diffhunk://#diff-368993f7cd4ee0706b6bd643f23d3a80508110ec3804a37daa89343f46378cadR96-R103) [[3]](diffhunk://#diff-368993f7cd4ee0706b6bd643f23d3a80508110ec3804a37daa89343f46378cadR158-R167) [[4]](diffhunk://#diff-368993f7cd4ee0706b6bd643f23d3a80508110ec3804a37daa89343f46378cadR226-R240)

**HTTP request and agent configuration for Bun:**

* Modified `RavenCommand` and `RequestExecutor` to use Bun-specific request options and to skip agent configuration in Bun, ensuring HTTP requests are compatible with Bun's fetch API and TLS handling. [[1]](diffhunk://#diff-66e3ebf4e5a0ac50a772593ee8636a712258a7868e0d4729dcb5d59310a7a148L17-R20) [[2]](diffhunk://#diff-66e3ebf4e5a0ac50a772593ee8636a712258a7868e0d4729dcb5d59310a7a148R158-R169) [[3]](diffhunk://#diff-39dc164b877d5dd0a28b6790c76ae2e4e57066a628b18e575dbf63a6e01dbf12R52) [[4]](diffhunk://#diff-39dc164b877d5dd0a28b6790c76ae2e4e57066a628b18e575dbf63a6e01dbf12R343-R346) [[5]](diffhunk://#diff-39dc164b877d5dd0a28b6790c76ae2e4e57066a628b18e575dbf63a6e01dbf12R1957-R1960) [[6]](diffhunk://#diff-15c2445d67a9f8bf3da7402ac564f5f7f70bf03b52f9c86e1e69112fb0382982R1-R10)

**Runtime-aware decompression behavior:**

* Updated `DocumentConventions` to disable HTTP decompression by default when running under Bun, avoiding unsupported features. [[1]](diffhunk://#diff-9fe55d6daa71cd2ad253b88aae2742f92de819875b408aa428d1ac748979f360R23) [[2]](diffhunk://#diff-9fe55d6daa71cd2ad253b88aae2742f92de819875b408aa428d1ac748979f360R462-R465)