### PR TITLE
RDBC-1014 - Missing getRaftUniqueRequestId method in DeleteAiAgent

### DIFF
--- a/src/Documents/Operations/AI/Agents/DeleteAiAgentOperation.ts
+++ b/src/Documents/Operations/AI/Agents/DeleteAiAgentOperation.ts
@@ -7,6 +7,7 @@ import { ServerNode } from "../../../../Http/ServerNode.js";
 import { HttpRequestParameters } from "../../../../Primitives/Http.js";
 import { StringUtil } from "../../../../Utility/StringUtil.js";
 import { throwError } from "../../../../Exceptions/index.js";
+import { RaftIdGenerator } from "../../../../Utility/RaftIdGenerator.js";
 
 export class DeleteAiAgentOperation implements IMaintenanceOperation<AiAgentConfigurationResult> {
     private readonly _identifier: string;
@@ -56,5 +57,9 @@ class DeleteAiAgentCommand extends RavenCommand<AiAgentConfigurationResult> {
         }
 
         return this._parseResponseDefaultAsync(bodyStream)
+    }
+
+    public getRaftUniqueRequestId(): string {
+        return RaftIdGenerator.newId();
     }
 }

--- a/test/Ported/Documents/Operations/AiAgentTest.ts
+++ b/test/Ported/Documents/Operations/AiAgentTest.ts
@@ -1,32 +1,36 @@
 import {
     AddOrUpdateAiAgentOperation,
+    AiConnectionString,
     IDocumentStore,
-    PutConnectionStringOperation,
-    RavenConnectionString
+    OpenAiSettings,
+    PutConnectionStringOperation
 } from "../../../../src/index.js";
 import {disposeTestDocumentStore, RavenTestContext, testContext} from "../../../Utils/TestUtil.js";
 import {assertThat, assertThrows} from "../../../Utils/AssertExtensions.js";
 import {AiAgentConfiguration} from "../../../../src/Documents/Operations/AI/Agents/config/AiAgentConfiguration.js";
 
 ((RavenTestContext.isRavenDbServerVersion("7.1") && !RavenTestContext.isPullRequest) ? describe : describe.skip)("AiAgentTest", function () {
-
     let store: IDocumentStore;
 
-    beforeEach(async function () {
-        store = await testContext.getDocumentStore();
-    });
+    beforeEach(async () => store = await testContext.getDocumentStore());
 
     afterEach(async () =>
         await disposeTestDocumentStore(store));
 
+    async function putAiConnectionString() {
+        const csName = `ai-agents-${Date.now()}`;
+        const aiConnectionString = new AiConnectionString();
+        aiConnectionString.name = csName;
+        aiConnectionString.identifier = "openai-test";
+        aiConnectionString.modelType = "Chat";
+        aiConnectionString.openAiSettings = new OpenAiSettings("test-api-key", "https://api.openai.example", "gpt-test");
+
+        await store.maintenance.send(new PutConnectionStringOperation(aiConnectionString));
+        return csName;
+    }
+
     it("canCreateAiAgent", async () => {
-        const csName = `r1-${Date.now()}`;
-        const ravenConnectionString = Object.assign(new RavenConnectionString(), {
-            database: store.database,
-            topologyDiscoveryUrls: ["http://localhost:8080"],
-            name: csName
-        });
-        await store.maintenance.send(new PutConnectionStringOperation(ravenConnectionString));
+        const csName = await putAiConnectionString();
 
         const agentConfiguration: AiAgentConfiguration = {
             name: `TestAgent-${Date.now()}`,
@@ -66,13 +70,7 @@ import {AiAgentConfiguration} from "../../../../src/Documents/Operations/AI/Agen
     });
 
     it("canUpdateAiAgent", async () => {
-        const csName = `r1-${Date.now()}`;
-        const ravenConnectionString = Object.assign(new RavenConnectionString(), {
-            database: store.database,
-            topologyDiscoveryUrls: ["http://localhost:8080"],
-            name: csName
-        });
-        await store.maintenance.send(new PutConnectionStringOperation(ravenConnectionString));
+        const csName = await putAiConnectionString();
 
         const name = `Agent-${Date.now()}`;
         const initialConfig: AiAgentConfiguration = {
@@ -101,13 +99,7 @@ import {AiAgentConfiguration} from "../../../../src/Documents/Operations/AI/Agen
     });
 
     it("canListAndDeleteAiAgent", async () => {
-        const csName = `r1-${Date.now()}`;
-        const ravenConnectionString = Object.assign(new RavenConnectionString(), {
-            database: store.database,
-            topologyDiscoveryUrls: ["http://localhost:8080"],
-            name: csName
-        });
-        await store.maintenance.send(new PutConnectionStringOperation(ravenConnectionString));
+        const csName = await putAiConnectionString();
 
         const name = `agent-${Date.now()}`;
         const config: AiAgentConfiguration = {


### PR DESCRIPTION
AI Agent operation improvements:

* Added a `getRaftUniqueRequestId` method to `DeleteAiAgentCommand` to generate unique Raft request IDs using `RaftIdGenerator`. [[1]](diffhunk://#diff-cf8e41de08845e64568e12eb2b79883f5185695baf825334501e2826d1fcacabR10) [[2]](diffhunk://#diff-cf8e41de08845e64568e12eb2b79883f5185695baf825334501e2826d1fcacabR61-R64)

Test refactoring and maintainability:

* Refactored AI Agent tests to use a new helper function `putAiConnectionString`, which creates and stores an `AiConnectionString` with `OpenAiSettings`, replacing the previous use of `RavenConnectionString`. [[1]](diffhunk://#diff-e29c11d6861e7615fbf0cd80b5f4b9a2cc9df8d7389c5a183c1d476848e8f317R3-R34) [[2]](diffhunk://#diff-e29c11d6861e7615fbf0cd80b5f4b9a2cc9df8d7389c5a183c1d476848e8f317L69-R74) [[3]](diffhunk://#diff-e29c11d6861e7615fbf0cd80b5f4b9a2cc9df8d7389c5a183c1d476848e8f317L104-R103)