### PR TITLE
RDBC-1044 Patch 7.2.1

### DIFF
--- a/src/Documents/Operations/AI/Agents/AiAgentToolQuery.ts
+++ b/src/Documents/Operations/AI/Agents/AiAgentToolQuery.ts
@@ -3,6 +3,10 @@ import type { AiAgentToolQueryOptions } from "./AiAgentToolQueryOptions.js";
 export interface AiAgentToolQuery {
     name: string;
     description: string;
+    /**
+     * The actual query string (RQL) that represents this tool.
+     * This query will be executed by the database when the model requests this tool.
+     */
     query: string;
     parametersSampleObject?: string; // JSON example of parameters
     parametersSchema?: string; // JSON schema for parameters

--- a/src/Documents/Operations/AI/AiConversation.ts
+++ b/src/Documents/Operations/AI/AiConversation.ts
@@ -24,7 +24,7 @@ export class AiConversation {
     private _conversationId: string;
     private readonly _options?: AiConversationCreationOptions;
     private _actionRequests: AiAgentActionRequest[] | null = null;
-    private readonly _actionResponses: AiAgentActionResponse[] = [];
+    private readonly _actionResponses: Map<string, AiAgentActionResponse> = new Map();
     private readonly _artificialActions: AiAgentArtificialActionResponse[] = [];
     private readonly _promptParts: ContentPart[] = [];
     private readonly _invocations: Map<string, ActionInvocation> = new Map();
@@ -68,11 +68,16 @@ export class AiConversation {
         if (!toolId) throwError("InvalidArgumentException", "toolId cannot be empty");
         if (actionResponse == null) throwError("InvalidArgumentException", `Action response for '${toolId}' cannot be null.`);
 
-        if (typeof actionResponse === "string") {
-            this._actionResponses.push({toolId, content: actionResponse});
-            return;
+        if (this._actionResponses.has(toolId)) {
+            throwError("InvalidOperationException",
+                `An action response for tool-id '${toolId}' was already added. Each tool call must have exactly one response. ` +
+                `If you're using handle(), return the value from the handler (don't call addActionResponse() manually).`);
         }
-        this._actionResponses.push({toolId, content: JSON.stringify(actionResponse)});
+
+        const content = typeof actionResponse === "string"
+            ? actionResponse
+            : JSON.stringify(actionResponse);
+        this._actionResponses.set(toolId, { toolId, content });
     }
 
     /**
@@ -147,9 +152,9 @@ export class AiConversation {
         }
     }
 
-    public handle<TArgs = any>(
+    public handle<TArgs = any, TResult extends object = object>(
         actionName: string,
-        action: (args: TArgs) => Promise<object>,
+        action: (args: TArgs) => Promise<TResult>,
         aiHandleError?: AiHandleErrorStrategy
     ): void;
 
@@ -159,9 +164,9 @@ export class AiConversation {
         aiHandleError?: AiHandleErrorStrategy
     ): void;
 
-    public handle<TArgs = any>(
+    public handle<TArgs = any, TResult extends object = object>(
         actionName: string,
-        action: (request: AiAgentActionRequest, args: TArgs) => Promise<object>,
+        action: (request: AiAgentActionRequest, args: TArgs) => Promise<TResult>,
         aiHandleError?: AiHandleErrorStrategy
     ): void;
 
@@ -171,10 +176,10 @@ export class AiConversation {
         aiHandleError?: AiHandleErrorStrategy
     ): void
 
-    public handle<TArgs = any>(
+    public handle<TArgs = any, TResult extends object = object>(
         actionName: string,
-        action: ((args: TArgs) => Promise<object> | object) |
-            ((request: AiAgentActionRequest, args: TArgs) => Promise<object> | object),
+        action: ((args: TArgs) => Promise<TResult> | object) |
+            ((request: AiAgentActionRequest, args: TArgs) => Promise<TResult> | object),
         aiHandleError: AiHandleErrorStrategy = AiHandleErrorStrategy.SendErrorsToModel
     ) {
         const wrappedAction = action.length === 1
@@ -236,7 +241,7 @@ export class AiConversation {
                 }
             }
 
-            if (this._actionResponses.length === 0) {
+            if (this._actionResponses.size === 0) {
                 return r; // ActionsRequired, nothing to send back yet
             }
         }
@@ -293,14 +298,14 @@ export class AiConversation {
                 }
             }
 
-            if (this._actionResponses.length === 0) {
+            if (this._actionResponses.size === 0) {
                 return r; // ActionsRequired, nothing to send back yet
             }
         }
     }
 
     private async _runInternal<TAnswer>(streamPropertyPath?: string, streamCallback?: AiStreamCallback): Promise<AiAnswer<TAnswer>> {
-        if (this._actionRequests != null && this._promptParts.length === 0 && this._actionResponses.length === 0 && this._artificialActions.length === 0) {
+        if (this._actionRequests != null && this._promptParts.length === 0 && this._actionResponses.size === 0 && this._artificialActions.length === 0) {
             return {status: "Done" as const} as AiAnswer<TAnswer>;
         }
 
@@ -308,7 +313,7 @@ export class AiConversation {
             this._agentId,
             this._conversationId,
             this._promptParts as ContentPart[],
-            this._actionResponses,
+            [...this._actionResponses.values()],
             this._artificialActions,
             this._options,
             this._changeVector,
@@ -332,7 +337,7 @@ export class AiConversation {
         } finally {
             // clear prompt, responses and artificial actions after running the conversation
             this._promptParts.length = 0;
-            this._actionResponses.length = 0;
+            this._actionResponses.clear();
             this._artificialActions.length = 0;
         }
     }

--- a/src/Documents/Operations/AI/EmbeddingsGenerationConfiguration.ts
+++ b/src/Documents/Operations/AI/EmbeddingsGenerationConfiguration.ts
@@ -118,14 +118,20 @@ export class EmbeddingsGenerationConfiguration extends AbstractAiIntegrationConf
         validateName?: boolean;
         validateConnection?: boolean;
         validateIdentifier?: boolean;
+        existingConfiguration?: EmbeddingsGenerationConfiguration;
     }): string[] {
         const {
             validateName = true,
             validateConnection = true,
-            validateIdentifier = true
+            validateIdentifier = true,
+            existingConfiguration
         } = options ?? {};
 
         const errors: string[] = [];
+
+        if (existingConfiguration?.name && existingConfiguration.name !== this.name) {
+            errors.push("Changing Name of ETL is not supported.");
+        }
 
         if (validateIdentifier) {
             const idErrors = AiTaskIdentifierHelper.validateIdentifier(this.identifier);

--- a/src/Documents/Operations/AI/GenAiConfiguration.ts
+++ b/src/Documents/Operations/AI/GenAiConfiguration.ts
@@ -14,6 +14,8 @@ const TRANSFORMATION_NAME = "GenAi-transform-script";
  * and updates documents based on AI responses.
  */
 export class GenAiConfiguration extends AbstractAiIntegrationConfiguration {
+    public version?: number;
+
     /**
      * Unique normalized identifier for this GenAI task.
      * Must be lowercase, alphanumeric with hyphens only.
@@ -115,14 +117,20 @@ export class GenAiConfiguration extends AbstractAiIntegrationConfiguration {
         validateName?: boolean;
         validateConnection?: boolean;
         validateIdentifier?: boolean;
+        existingConfiguration?: GenAiConfiguration;
     }): string[] {
         const {
             validateName = true,
             validateConnection = true,
-            validateIdentifier = true
+            validateIdentifier = true,
+            existingConfiguration
         } = options ?? {};
 
         const errors: string[] = [];
+
+        if (existingConfiguration?.name && existingConfiguration.name !== this.name) {
+            errors.push("Changing Name of ETL is not supported.");
+        }
 
         if (validateIdentifier) {
             const idErrors = AiTaskIdentifierHelper.validateIdentifier(this.identifier);
@@ -205,6 +213,9 @@ export class GenAiConfiguration extends AbstractAiIntegrationConfiguration {
         result.Queries = this.queries ? this.queries.map(q => this._serializeQuery(q)) : null;
         result.EnableTracing = this.enableTracing;
         result.ExpirationInSec = this.expirationInSec;
+        if (this.version != null) {
+            result.Version = this.version;
+        }
 
         return result;
     }

--- a/src/ServerWide/Tcp/TcpConnectionHeaderMessage.ts
+++ b/src/ServerWide/Tcp/TcpConnectionHeaderMessage.ts
@@ -40,6 +40,9 @@ export const SUBSCRIPTION_COUNTER_INCLUDES = 50_000;
 export const SUBSCRIPTION_TIME_SERIES_INCLUDES = 51_000;
 export const TCP_CONNECTIONS_WITH_COMPRESSION = 53_000;
 export const TEST_CONNECTION_BASE_LINE = 50;
+export const REPLICATION_WITH_REMOTE_ATTACHMENTS = 72_000;
+export const REPLICATION_WITH_TIME_SERIES_DOCUMENT_CHANGE_VECTOR = 72_001;
+export const REPLICATION_TCP_VERSION = REPLICATION_WITH_TIME_SERIES_DOCUMENT_CHANGE_VECTOR;
 
 export const HEARTBEATS_TCP_VERSION = HEARTBEATS_WITH_TCP_COMPRESSION;
 export const SUBSCRIPTION_TCP_VERSION = TCP_CONNECTIONS_WITH_COMPRESSION;
@@ -74,6 +77,21 @@ export class TestConnectionFeatures {
     public baseLine = true;
 }
 
+export class ReplicationFeatures {
+    public baseLine = true;
+    public missingAttachments = false;
+    public countersBatch = false;
+    public pullReplication = false;
+    public timeSeries = false;
+    public caseInsensitiveCounters = false;
+    public clusterTransaction = false;
+    public incrementalTimeSeries = false;
+    public deduplicatedAttachments = false;
+    public revisionTombstonesWithId = false;
+    public remoteAttachments = false;
+    public timeSeriesWithDocumentChangeVector = false;
+}
+
 export class SupportedFeatures {
     public readonly protocolVersion: number;
 
@@ -92,6 +110,7 @@ export class SupportedFeatures {
         this.subscription = source.subscription;
         this.heartbeats = source.heartbeats;
         this.testConnection = source.testConnection;
+        this.replication = source.replication;
         this.dataCompression = source.dataCompression;
     }
 
@@ -102,6 +121,7 @@ export class SupportedFeatures {
     public subscription: SubscriptionFeatures;
     public heartbeats: HeartbeatsFeatures;
     public testConnection: TestConnectionFeatures;
+    public replication: ReplicationFeatures;
 
     public dataCompression: boolean;
 }
@@ -124,6 +144,10 @@ const supportedFeaturesByProtocol = new Map<OperationTypes, Map<number, Supporte
         HEARTBEATS_BASE_LINE
     ]);
     operationsToSupportedProtocolVersions.set("TestConnection", [TEST_CONNECTION_BASE_LINE]);
+    operationsToSupportedProtocolVersions.set("Replication", [
+        REPLICATION_WITH_TIME_SERIES_DOCUMENT_CHANGE_VECTOR,
+        REPLICATION_WITH_REMOTE_ATTACHMENTS
+    ]);
 
     const pingFeaturesMap = new Map<number, SupportedFeatures>();
     supportedFeaturesByProtocol.set("Ping", pingFeaturesMap);
@@ -204,6 +228,40 @@ const supportedFeaturesByProtocol = new Map<OperationTypes, Map<number, Supporte
     const testConnectionFeatures = new SupportedFeatures(TEST_CONNECTION_BASE_LINE);
     testConnectionFeatures.testConnection = new TestConnectionFeatures();
     testConnectionFeaturesMap.set(TEST_CONNECTION_BASE_LINE, testConnectionFeatures);
+
+    const replicationFeaturesMap = new Map<number, SupportedFeatures>();
+    supportedFeaturesByProtocol.set("Replication", replicationFeaturesMap);
+
+    const replication72000Features = new SupportedFeatures(REPLICATION_WITH_REMOTE_ATTACHMENTS);
+    replication72000Features.dataCompression = true;
+    replication72000Features.replication = new ReplicationFeatures();
+    replication72000Features.replication.missingAttachments = true;
+    replication72000Features.replication.countersBatch = true;
+    replication72000Features.replication.pullReplication = true;
+    replication72000Features.replication.timeSeries = true;
+    replication72000Features.replication.caseInsensitiveCounters = true;
+    replication72000Features.replication.clusterTransaction = true;
+    replication72000Features.replication.incrementalTimeSeries = true;
+    replication72000Features.replication.deduplicatedAttachments = true;
+    replication72000Features.replication.revisionTombstonesWithId = true;
+    replication72000Features.replication.remoteAttachments = true;
+    replicationFeaturesMap.set(REPLICATION_WITH_REMOTE_ATTACHMENTS, replication72000Features);
+
+    const replication72001Features = new SupportedFeatures(REPLICATION_WITH_TIME_SERIES_DOCUMENT_CHANGE_VECTOR);
+    replication72001Features.dataCompression = true;
+    replication72001Features.replication = new ReplicationFeatures();
+    replication72001Features.replication.missingAttachments = true;
+    replication72001Features.replication.countersBatch = true;
+    replication72001Features.replication.pullReplication = true;
+    replication72001Features.replication.timeSeries = true;
+    replication72001Features.replication.caseInsensitiveCounters = true;
+    replication72001Features.replication.clusterTransaction = true;
+    replication72001Features.replication.incrementalTimeSeries = true;
+    replication72001Features.replication.deduplicatedAttachments = true;
+    replication72001Features.replication.revisionTombstonesWithId = true;
+    replication72001Features.replication.remoteAttachments = true;
+    replication72001Features.replication.timeSeriesWithDocumentChangeVector = true;
+    replicationFeaturesMap.set(REPLICATION_WITH_TIME_SERIES_DOCUMENT_CHANGE_VECTOR, replication72001Features);
 }
 
 export type SupportedStatus = "OutOfRange" | "NotSupported" | "Supported";

--- a/test/Ported/Documents/Operations/AiConversationTest.ts
+++ b/test/Ported/Documents/Operations/AiConversationTest.ts
@@ -57,6 +57,17 @@ import {AiUsage} from "../../../../src/Documents/Operations/AI/Agents/AiUsage.js
         conv.addActionResponse("tool2", {ok: true, count: 1});
     });
 
+    it("addActionResponse should throw on duplicate toolId", async () => {
+        const conv = store.ai.conversation("agents/1-A", "conversations/3a|") as any;
+
+        conv.addActionResponse("tool1", "first response");
+
+        await assertThrows(() => Promise.resolve(conv.addActionResponse("tool1", "second response")), err => {
+            assertThat(err.message).contains("already added");
+            assertThat(err.message).contains("tool1");
+        });
+    });
+
     it("receive should reject duplicate action names", async () => {
         const conv = store.ai.conversation("agents/1-A", "conversations/4|") as any;
 
@@ -187,7 +198,7 @@ import {AiUsage} from "../../../../src/Documents/Operations/AI/Agents/AiUsage.js
         assertThat(capturedArgs.value).isSameAs("test-data");
 
         // Verify response was added
-        assertThat(conv._actionResponses.length).isGreaterThan(0);
+        assertThat(conv._actionResponses.size).isGreaterThan(0);
     });
 
     it("handle method works without request parameter (backward compat, sync)", async () => {
@@ -211,7 +222,7 @@ import {AiUsage} from "../../../../src/Documents/Operations/AI/Agents/AiUsage.js
         });
 
         assertThat(handlerCalled).isTrue();
-        assertThat(conv._actionResponses.length).isGreaterThan(0);
+        assertThat(conv._actionResponses.size).isGreaterThan(0);
     });
 
     it("handle method works with request parameter (with metadata, async)", async () => {


### PR DESCRIPTION
This pull request introduces several improvements and new features across the AI operations and server-wide TCP protocol handling, with a focus on stricter validation, improved type safety, and enhanced replication protocol support.

AI Operations Enhancements:

* The `handle` method in `AiConversation` is now strongly typed with a generic `TResult` for the action result, improving type safety for handler return values. [[1]](diffhunk://#diff-30faef4e68ca97d40894241b719870b02aae99d3e0d9566a6ec6477d7b8e17d9L150-R158) [[2]](diffhunk://#diff-30faef4e68ca97d40894241b719870b02aae99d3e0d9566a6ec6477d7b8e17d9L162-R170) [[3]](diffhunk://#diff-30faef4e68ca97d40894241b719870b02aae99d3e0d9566a6ec6477d7b8e17d9L174-R183)
* The `AiAgentToolQuery` interface now documents the purpose of its `query` property, clarifying that it represents the RQL executed by the database.

Validation and Configuration Improvements:

* Both `GenAiConfiguration` and `EmbeddingsGenerationConfiguration` classes now prevent changing the configuration name after creation, returning a validation error if attempted. [[1]](diffhunk://#diff-9023ec8623356d5b6680355950306324279269f75cd32ff16db111a5bd3f8738R120-R134) [[2]](diffhunk://#diff-2aacb342477cd1793cacae9a2123bdb7e96fe001281bfd3a79fe51089f746976R121-R135)
* The `GenAiConfiguration` class introduces an optional `version` property, which is serialized if present. [[1]](diffhunk://#diff-9023ec8623356d5b6680355950306324279269f75cd32ff16db111a5bd3f8738R17-R18) [[2]](diffhunk://#diff-9023ec8623356d5b6680355950306324279269f75cd32ff16db111a5bd3f8738R216-R218)

Replication Protocol and TCP Feature Expansion:

* New replication protocol versions and features are added, including support for remote attachments and time series document change vectors. This includes new constants, a `ReplicationFeatures` class, and updates to the `SupportedFeatures` infrastructure to support these features and their negotiation. [[1]](diffhunk://#diff-8072f99c2dca8610c1596097ce4ca1cfd6c542753e9cd99ffe340961d79c65aaR43-R45) [[2]](diffhunk://#diff-8072f99c2dca8610c1596097ce4ca1cfd6c542753e9cd99ffe340961d79c65aaR80-R94) [[3]](diffhunk://#diff-8072f99c2dca8610c1596097ce4ca1cfd6c542753e9cd99ffe340961d79c65aaR113) [[4]](diffhunk://#diff-8072f99c2dca8610c1596097ce4ca1cfd6c542753e9cd99ffe340961d79c65aaR124) [[5]](diffhunk://#diff-8072f99c2dca8610c1596097ce4ca1cfd6c542753e9cd99ffe340961d79c65aaR147-R150) [[6]](diffhunk://#diff-8072f99c2dca8610c1596097ce4ca1cfd6c542753e9cd99ffe340961d79c65aaR231-R264)