### PR TITLE
RDBC-1053: Implemented several fixes.

### DIFF
--- a/src/Documents/Commands/Batches/BatchPatchCommandData.ts
+++ b/src/Documents/Commands/Batches/BatchPatchCommandData.ts
@@ -57,10 +57,12 @@ export class BatchPatchCommandData implements ICommandData {
             throwError("InvalidArgumentException", "Value cannot be null or whitespace.");
         }
 
-        if (!this._seenIds.add(id)) {
+        if (this._seenIds.has(id)) {
             throwError("InvalidOperationException",
                 "Could not add ID '" + id + "' because item with the same ID was already added");
         }
+
+        this._seenIds.add(id);
 
         this._ids.push({ id, changeVector });
     }

--- a/src/Documents/Conventions/DocumentConventions.ts
+++ b/src/Documents/Conventions/DocumentConventions.ts
@@ -568,7 +568,7 @@ export class DocumentConventions {
     public set identityPartsSeparator(value: string) {
         this._assertNotFrozen();
 
-        if (this.identityPartsSeparator === "|") {
+        if (value === "|") {
             throwError("InvalidArgumentException", "Cannot set identity parts separator to '|'");
         }
 

--- a/src/Documents/Session/AbstractDocumentQuery.ts
+++ b/src/Documents/Session/AbstractDocumentQuery.ts
@@ -213,7 +213,7 @@ export abstract class AbstractDocumentQuery<T extends object, TSelf extends Abst
     protected _explanationToken: ExplanationToken;
 
     protected isFilterActive(): boolean {
-        return this._filterModeStack.length && this._filterModeStack[0];
+        return this._filterModeStack.length && this._filterModeStack.at(-1);
     }
 
 
@@ -1139,9 +1139,9 @@ export abstract class AbstractDocumentQuery<T extends object, TSelf extends Abst
         endParams.fieldName = fieldName;
 
         const fromParameterName = this._addQueryParameter(
-            !start ? "*" : this._transformValue(startParams, true));
+            start == null ? "*" : this._transformValue(startParams, true));
         const toParameterName = this._addQueryParameter(
-            !end ? "NULL" : this._transformValue(endParams, true));
+            end == null ? "NULL" : this._transformValue(endParams, true));
 
         const whereToken = WhereToken.create(
             "Between", fieldName, null, new WhereOptions({
@@ -1174,7 +1174,7 @@ export abstract class AbstractDocumentQuery<T extends object, TSelf extends Abst
         whereParams.fieldName = fieldName;
 
         const parameter = this._addQueryParameter(
-            !value ? "*" : this._transformValue(whereParams, true));
+            value == null ? "*" : this._transformValue(whereParams, true));
 
         const whereToken = WhereToken.create(
             "GreaterThan", fieldName, parameter, new WhereOptions({ exact }));
@@ -1203,7 +1203,7 @@ export abstract class AbstractDocumentQuery<T extends object, TSelf extends Abst
         whereParams.fieldName = fieldName;
 
         const parameter = this._addQueryParameter(
-            !value ? "*" : this._transformValue(whereParams, true));
+            value == null ? "*" : this._transformValue(whereParams, true));
         const whereToken = WhereToken.create(
             "GreaterThanOrEqual", fieldName, parameter, new WhereOptions({ exact }));
         tokens.push(whereToken);
@@ -1223,7 +1223,7 @@ export abstract class AbstractDocumentQuery<T extends object, TSelf extends Abst
         whereParams.fieldName = fieldName;
 
         const parameter = this._addQueryParameter(
-            !value ? "NULL" : this._transformValue(whereParams, true));
+            value == null ? "NULL" : this._transformValue(whereParams, true));
         const whereToken = WhereToken.create(
             "LessThan", fieldName, parameter, new WhereOptions({ exact }));
         tokens.push(whereToken);
@@ -1242,7 +1242,7 @@ export abstract class AbstractDocumentQuery<T extends object, TSelf extends Abst
         whereParams.fieldName = fieldName;
 
         const parameter = this._addQueryParameter(
-            !value ? "NULL" : this._transformValue(whereParams, true));
+            value == null ? "NULL" : this._transformValue(whereParams, true));
         const whereToken = WhereToken.create(
             "LessThanOrEqual", fieldName, parameter, new WhereOptions({ exact }));
         tokens.push(whereToken);
@@ -1295,7 +1295,7 @@ export abstract class AbstractDocumentQuery<T extends object, TSelf extends Abst
      */
     public _orElse(): void {
         const tokens = this._getCurrentWhereTokens();
-        if (!tokens && !tokens.length) {
+        if (!tokens || !tokens.length) {
             return;
         }
 
@@ -1358,6 +1358,7 @@ export abstract class AbstractDocumentQuery<T extends object, TSelf extends Abst
                 } else if (last instanceof OpenSubclauseToken) {
                     last.boostParameterName = parameter;
                     close.boostParameterName = parameter;
+                    return;
                 }
             }
         } else {
@@ -1376,7 +1377,7 @@ export abstract class AbstractDocumentQuery<T extends object, TSelf extends Abst
         this._assertMethodIsCurrentlySupported("fuzzy");
 
         const tokens = this._getCurrentWhereTokens();
-        if (!tokens && !tokens.length) {
+        if (!tokens || !tokens.length) {
             throwError("InvalidOperationException", "Fuzzy can only be used right after where clause.");
         }
 
@@ -1405,7 +1406,7 @@ export abstract class AbstractDocumentQuery<T extends object, TSelf extends Abst
     public _proximity(proximity: number): void {
         this._assertMethodIsCurrentlySupported("proximity");
         const tokens = this._getCurrentWhereTokens();
-        if (!tokens && !tokens.length) {
+        if (!tokens || !tokens.length) {
             throwError("InvalidOperationException", "Proximity can only be used right after search clause.");
         }
 

--- a/src/Mapping/JsonOperation.ts
+++ b/src/Mapping/JsonOperation.ts
@@ -102,6 +102,7 @@ export class JsonOperation {
                     }
 
                     JsonOperation._newChange(fieldPath, prop, newProp, oldProp, docChanges, "FieldChanged");
+                    continue;
                 }
 
                 changed = JsonOperation._compareJsonArray(

--- a/src/Primitives/TimeValue.ts
+++ b/src/Primitives/TimeValue.ts
@@ -174,7 +174,7 @@ export class TimeValue {
         }
 
         const myBounds = TimeValue._getBoundsInSeconds(this);
-        const otherBounds = TimeValue._getBoundsInSeconds(this);
+        const otherBounds = TimeValue._getBoundsInSeconds(other);
 
         if (otherBounds[1] < myBounds[0]) {
             return 1;
@@ -224,12 +224,12 @@ export class TimeValue {
         }
 
         if (TimeValue._isMin(current)) {
-            resultSetter(TimeValue._isMax(other) ? 0 : -1);
+            resultSetter(TimeValue._isMin(other) ? 0 : -1);
             return true;
         }
 
         if (TimeValue._isMin(other)) {
-            resultSetter(TimeValue._isMax(current) ? 0 : 1);
+            resultSetter(TimeValue._isMin(current) ? 0 : 1);
             return true;
         }
 

--- a/test/Documents/Commands/BatchPatchCommandDataTest.ts
+++ b/test/Documents/Commands/BatchPatchCommandDataTest.ts
@@ -1,0 +1,27 @@
+import assert from "node:assert";
+import { describe, it } from "node:test";
+import { BatchPatchCommandData } from "../../../src/Documents/Commands/Batches/BatchPatchCommandData.js";
+import { PatchRequest } from "../../../src/Documents/Operations/PatchRequest.js";
+
+describe("BatchPatchCommandData", function () {
+
+    it("should reject duplicate document IDs", function () {
+        const patch = PatchRequest.forScript("this.name = 'test';");
+
+        assert.throws(() => {
+            new BatchPatchCommandData(patch, null as any, "companies/1", "companies/1");
+        }, (err: Error) => {
+            return err.message.includes("item with the same ID was already added");
+        });
+    });
+
+    it("should reject duplicate IDs case-insensitively", function () {
+        const patch = PatchRequest.forScript("this.name = 'test';");
+
+        assert.throws(() => {
+            new BatchPatchCommandData(patch, null as any, "companies/1", "Companies/1");
+        }, (err: Error) => {
+            return err.message.includes("item with the same ID was already added");
+        });
+    });
+});

--- a/test/Documents/DocumentConventionsTest.ts
+++ b/test/Documents/DocumentConventionsTest.ts
@@ -1,0 +1,22 @@
+import assert from "node:assert";
+import { describe, it } from "node:test";
+import { DocumentConventions } from "../../src/Documents/Conventions/DocumentConventions.js";
+
+describe("DocumentConventions.identityPartsSeparator", function () {
+
+    it("should reject pipe character as separator", function () {
+        const conventions = new DocumentConventions();
+
+        assert.throws(() => {
+            conventions.identityPartsSeparator = "|";
+        }, (err: Error) => {
+            return err.message.includes("Cannot set identity parts separator to '|'");
+        });
+    });
+
+    it("should allow changing separator to a valid value", function () {
+        const conventions = new DocumentConventions();
+        conventions.identityPartsSeparator = "-";
+        assert.strictEqual(conventions.identityPartsSeparator, "-");
+    });
+});

--- a/test/Documents/Session/AbstractDocumentQueryTest.ts
+++ b/test/Documents/Session/AbstractDocumentQueryTest.ts
@@ -1,0 +1,87 @@
+import assert from "node:assert";
+import { describe, it, beforeEach, afterEach } from "node:test";
+import { testContext, disposeTestDocumentStore } from "../../Utils/TestUtil.js";
+import { IDocumentStore } from "../../../src/index.js";
+
+describe("AbstractDocumentQuery - range queries with falsy values", function () {
+
+    let store: IDocumentStore;
+
+    beforeEach(async function () {
+        store = await testContext.getDocumentStore();
+    });
+
+    afterEach(async () =>
+        await disposeTestDocumentStore(store));
+
+    it("whereBetween preserves 0 as a valid boundary value", function () {
+        const session = store.openSession();
+
+        const query = session.query({ collection: "users" }).whereBetween("age", 0, 100);
+        const indexQuery = query.getIndexQuery();
+
+        assert.strictEqual(indexQuery.queryParameters.p0, 0,
+            "start value 0 should be preserved, not replaced with wildcard '*'");
+        assert.strictEqual(indexQuery.queryParameters.p1, 100);
+    });
+
+    it("whereGreaterThan preserves 0 as a valid value", function () {
+        const session = store.openSession();
+
+        const query = session.query({ collection: "users" }).whereGreaterThan("count", 0);
+        const indexQuery = query.getIndexQuery();
+
+        assert.strictEqual(indexQuery.queryParameters.p0, 0,
+            "value 0 should be preserved, not replaced with wildcard '*'");
+    });
+
+    it("whereLessThan preserves 0 as a valid value", function () {
+        const session = store.openSession();
+
+        const query = session.query({ collection: "users" }).whereLessThan("count", 0);
+        const indexQuery = query.getIndexQuery();
+
+        assert.strictEqual(indexQuery.queryParameters.p0, 0,
+            "value 0 should be preserved, not replaced with 'NULL'");
+    });
+
+    it("whereGreaterThanOrEqual preserves 0 as a valid value", function () {
+        const session = store.openSession();
+
+        const query = session.query({ collection: "users" }).whereGreaterThanOrEqual("count", 0);
+        const indexQuery = query.getIndexQuery();
+
+        assert.strictEqual(indexQuery.queryParameters.p0, 0,
+            "value 0 should be preserved, not replaced with wildcard '*'");
+    });
+
+    it("whereLessThanOrEqual preserves 0 as a valid value", function () {
+        const session = store.openSession();
+
+        const query = session.query({ collection: "users" }).whereLessThanOrEqual("count", 0);
+        const indexQuery = query.getIndexQuery();
+
+        assert.strictEqual(indexQuery.queryParameters.p0, 0,
+            "value 0 should be preserved, not replaced with 'NULL'");
+    });
+
+    it("whereBetween with null start uses wildcard", function () {
+        const session = store.openSession();
+
+        const query = session.query({ collection: "users" }).whereBetween("age", null, 100);
+        const indexQuery = query.getIndexQuery();
+
+        assert.strictEqual(indexQuery.queryParameters.p0, "*",
+            "null start should become wildcard '*'");
+    });
+
+    it("whereBetween with empty string preserves it as a value", function () {
+        const session = store.openSession();
+
+        const query = session.query({ collection: "users" }).whereBetween("name", "", "Z");
+        const indexQuery = query.getIndexQuery();
+
+        assert.strictEqual(indexQuery.queryParameters.p0, "",
+            "empty string should be preserved, not replaced with wildcard '*'");
+    });
+});

--- a/test/Mapping/JsonOperationTest.ts
+++ b/test/Mapping/JsonOperationTest.ts
@@ -1,0 +1,24 @@
+import assert from "node:assert";
+import { describe, it } from "node:test";
+import { JsonOperation } from "../../src/Mapping/JsonOperation.js";
+
+describe("JsonOperation", function () {
+
+    it("scalar to array change should only report FieldChanged", function () {
+        const oldDoc = { name: "test", tags: "single-value" };
+        const newDoc = { name: "test", tags: ["value1", "value2"] };
+
+        const docChanges: any[] = [];
+        (JsonOperation as any)._compareJson("", "test-id", oldDoc, newDoc, {}, docChanges);
+
+        const fieldChanged = docChanges.filter(c => c.change === "FieldChanged");
+        const arrayChanges = docChanges.filter(c =>
+            c.change === "ArrayValueAdded" || c.change === "ArrayValueChanged" || c.change === "ArrayValueRemoved");
+
+        assert.strictEqual(fieldChanged.length, 1,
+            "Should have exactly 1 FieldChanged for 'tags'");
+        assert.strictEqual(fieldChanged[0].fieldName, "tags");
+        assert.strictEqual(arrayChanges.length, 0,
+            "Should not have spurious array change entries from fallthrough");
+    });
+});

--- a/test/Ported/Issues/RavenDB_15693.ts
+++ b/test/Ported/Issues/RavenDB_15693.ts
@@ -13,6 +13,29 @@ describe("RavenDB_15693", function () {
     afterEach(async () =>
         await disposeTestDocumentStore(store));
 
+    it("nestedSubclauseBoostDoesNotCorruptOuterBoost", async () => {
+        const s = store.openSession();
+        const q = s.query(Doc)
+            .openSubclause()
+                .openSubclause()
+                    .search("strVal1", "a")
+                    .orElse()
+                    .search("strVal2", "b")
+                .closeSubclause()
+                .boost(0.5)
+                .orElse()
+                .search("strVal3", "c")
+            .closeSubclause()
+            .boost(0.2);
+
+        const queryBoost = q.toString();
+
+        // The outer boost (0.2) should wrap the entire outer subclause,
+        // and the inner boost (0.5) should only wrap the inner subclause.
+        assertThat(queryBoost)
+            .contains("boost(boost(search(strVal1, $p0) or search(strVal2, $p1), $p2) or search(strVal3, $p3), $p4)");
+    });
+
     it("canQueryOnComplexBoost", async () => {
         const s = store.openSession();
         const q = s.query(Doc)

--- a/test/Primitives/TimeValueTest.ts
+++ b/test/Primitives/TimeValueTest.ts
@@ -1,0 +1,45 @@
+import assert from "node:assert";
+import { describe, it } from "node:test";
+import { TimeValue } from "../../src/Primitives/TimeValue.js";
+
+describe("TimeValue.compareTo", function () {
+
+    it("cross-unit comparison should compare other value, not self", function () {
+        const twoMonths = TimeValue.ofMonths(2);
+        const thirtySeconds = TimeValue.ofSeconds(30);
+
+        const result = twoMonths.compareTo(thirtySeconds);
+        assert.ok(result > 0,
+            "2 months should be greater than 30 seconds, got compareTo=" + result);
+
+        const reverse = thirtySeconds.compareTo(twoMonths);
+        assert.ok(reverse < 0,
+            "30 seconds should be less than 2 months, got compareTo=" + reverse);
+    });
+
+    it("MIN_VALUE compared to MIN_VALUE should be 0", function () {
+        const result = TimeValue.MIN_VALUE.compareTo(TimeValue.MIN_VALUE);
+        assert.strictEqual(result, 0,
+            "MIN_VALUE.compareTo(MIN_VALUE) should be 0, got " + result);
+    });
+
+    it("MAX_VALUE compared to MAX_VALUE should be 0", function () {
+        const result = TimeValue.MAX_VALUE.compareTo(TimeValue.MAX_VALUE);
+        assert.strictEqual(result, 0,
+            "MAX_VALUE.compareTo(MAX_VALUE) should be 0, got " + result);
+    });
+
+    it("MIN_VALUE should be less than any normal value", function () {
+        const normal = TimeValue.ofSeconds(1);
+        const result = TimeValue.MIN_VALUE.compareTo(normal);
+        assert.ok(result < 0,
+            "MIN_VALUE should be less than 1 second, got compareTo=" + result);
+    });
+
+    it("MAX_VALUE should be greater than any normal value", function () {
+        const normal = TimeValue.ofSeconds(1);
+        const result = TimeValue.MAX_VALUE.compareTo(normal);
+        assert.ok(result > 0,
+            "MAX_VALUE should be greater than 1 second, got compareTo=" + result);
+    });
+});


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RDBC-1053

### Additional description

  - **BatchPatchCommandData**: duplicate document IDs silently accepted instead of throwing
  - **AbstractDocumentQuery.closeSubclause**: nested subclause boost iteration doesn't stop after finding the matching open token
  - **JsonOperation**: field type change from scalar to array produces spurious array change records alongside the correct FieldChanged
  - **AbstractDocumentQuery range queries**: `whereBetween`, `whereGreaterThan`, `whereLessThan`, `whereGreaterThanOrEqual`, `whereLessThanOrEqual` all treat `0`, `""`, and `false` as
  null/unbounded
  - **AbstractDocumentQuery.isFilterActive**: checks bottom of filter mode stack instead of top, breaking nested filter scopes
  - **DocumentConventions.identityPartsSeparator**: setter validates the current value instead of the incoming value, allowing `"|"` on first set and blocking all subsequent changes
  - **TimeValue.compareTo**: cross-unit comparison (months vs seconds) compares the same value's bounds against itself instead of the other value's bounds
  - **TimeValue._isSpecialCompare**: `MIN_VALUE.compareTo(MIN_VALUE)` returns `-1` instead of `0` due to swapped min/max checks
  - **AbstractDocumentQuery._fuzzy/_proximity**: null token list causes `TypeError` instead of the intended error message

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low
- [ ] Moderate
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`)
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
