### PR TITLE
RDBC-1054: C# gap analysis (part 2)

### DIFF
--- a/src/Documents/Identity/Commands/NextHiloCommand.ts
+++ b/src/Documents/Identity/Commands/NextHiloCommand.ts
@@ -64,7 +64,7 @@ export class NextHiloCommand extends RavenCommand<HiLoResult> {
         if (this._identityPartsSeparator) {
             uri += "&identityPartsSeparator=" + this._identityPartsSeparator;
         }
-        if (this._lastRangeMax) {
+        if (this._lastRangeMax != null) {
             uri += "&lastMax=" + this._lastRangeMax;
         }
         return { uri };

--- a/src/Documents/Operations/Backups/BackupStatus.ts
+++ b/src/Documents/Operations/Backups/BackupStatus.ts
@@ -6,7 +6,7 @@ export interface BackupStatus {
     lastFullBackup: Date;
     lastIncrementalBackup: Date;
     fullBackupDurationInMs: number;
-    incrementalBackupDurationIsMs: number;
+    incrementalBackupDurationInMs: number;
     exception: string;
 }
 
@@ -26,7 +26,7 @@ export interface UploadToAzure extends CloudUploadStatus {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface UpdateToGoogleCloud extends CloudUploadStatus {
+export interface UploadToGoogleCloud extends CloudUploadStatus {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface

--- a/src/Documents/Operations/Backups/GetPeriodicBackupStatusOperation.ts
+++ b/src/Documents/Operations/Backups/GetPeriodicBackupStatusOperation.ts
@@ -10,7 +10,7 @@ import { ServerResponse } from "../../../Types/index.js";
 import {
     BackupStatus,
     LocalBackup,
-    UpdateToGoogleCloud,
+    UploadToGoogleCloud,
     UploadToAzure,
     UploadToFtp, UploadToGlacier,
     UploadToS3
@@ -99,7 +99,7 @@ export function revivePeriodicBackupStatus(status: ServerResponse<PeriodicBackup
         } : null,
         uploadToS3: reviveUploadStatus<UploadToS3>(status.uploadToS3),
         uploadToFtp: reviveUploadStatus<UploadToFtp>(status.uploadToFtp),
-        updateToGoogleCloud: reviveUploadStatus<UpdateToGoogleCloud>(status.updateToGoogleCloud),
+        uploadToGoogleCloud: reviveUploadStatus<UploadToGoogleCloud>(status.uploadToGoogleCloud),
         uploadToAzure: reviveUploadStatus<UploadToAzure>(status.uploadToAzure),
         uploadToGlacier: reviveUploadStatus<UploadToGlacier>(status.uploadToGlacier)
     }

--- a/src/Documents/Operations/Backups/PeriodicBackupStatus.ts
+++ b/src/Documents/Operations/Backups/PeriodicBackupStatus.ts
@@ -2,7 +2,7 @@ import { IDatabaseTaskStatus } from "../../../ServerWide/IDatabaseTaskStatus.js"
 import { BackupType } from "./Enums.js";
 import {
     LocalBackup,
-    UpdateToGoogleCloud,
+    UploadToGoogleCloud,
     UploadToAzure,
     UploadToFtp,
     UploadToGlacier,
@@ -25,7 +25,7 @@ export interface PeriodicBackupStatus extends IDatabaseTaskStatus {
     uploadToS3: UploadToS3;
     uploadToGlacier: UploadToGlacier;
     uploadToAzure: UploadToAzure;
-    updateToGoogleCloud: UpdateToGoogleCloud;
+    uploadToGoogleCloud: UploadToGoogleCloud;
     uploadToFtp: UploadToFtp;
     lastEtag: number;
     lastDatabaseChangeVector: string;

--- a/src/Documents/Session/Operations/Lazy/LazyStartsWithOperation.ts
+++ b/src/Documents/Session/Operations/Lazy/LazyStartsWithOperation.ts
@@ -41,7 +41,7 @@ export class LazyStartsWithOperation<T extends object> implements ILazyOperation
         const request = new GetRequest();
         request.url = "/docs";
         request.query =
-            `?startsWith=${enc(this._idPrefix)}&matches=${enc(this._matches) || ""}&exclude=${enc(this._exclude) || ""}&start=${this._start}&pageSize=${this._pageSize}&startAfter=${enc(this._startAfter)}`;
+            `?startsWith=${enc(this._idPrefix)}&matches=${enc(this._matches ?? "")}&exclude=${enc(this._exclude ?? "")}&start=${this._start}&pageSize=${this._pageSize}&startAfter=${enc(this._startAfter ?? "")}`;
         return request;
     }
 

--- a/src/Documents/Session/Tokens/MoreLikeThisToken.ts
+++ b/src/Documents/Session/Tokens/MoreLikeThisToken.ts
@@ -17,10 +17,14 @@ export class MoreLikeThisToken extends WhereToken {
         writer.append("moreLikeThis(");
 
         if (!this.documentParameterName) {
-            for (let i = 0; i < this.whereTokens.length; i++) {
-                DocumentQueryHelper.addSpaceIfNeeded(
-                    i > 0 ? this.whereTokens[i - 1] : null, this.whereTokens[i], writer);
-                this.whereTokens[i].writeTo(writer);
+            if (this.whereTokens.length === 0) {
+                writer.append("true");
+            } else {
+                for (let i = 0; i < this.whereTokens.length; i++) {
+                    DocumentQueryHelper.addSpaceIfNeeded(
+                        i > 0 ? this.whereTokens[i - 1] : null, this.whereTokens[i], writer);
+                    this.whereTokens[i].writeTo(writer);
+                }
             }
         } else {
             writer.append("$").append(this.documentParameterName);

--- a/src/Mapping/JsonOperation.ts
+++ b/src/Mapping/JsonOperation.ts
@@ -43,12 +43,16 @@ export class JsonOperation {
         const newFields = new Set(newJsonProps.filter(x => !oldJsonProps.includes(x)));
         const removedFields = oldJsonProps.filter(x => !newJsonProps.includes(x));
 
+        const ignoredMetadataFields: string[] = [
+            CONSTANTS.Documents.Metadata.LAST_MODIFIED,
+            CONSTANTS.Documents.Metadata.COLLECTION,
+            CONSTANTS.Documents.Metadata.CHANGE_VECTOR,
+            CONSTANTS.Documents.Metadata.ID,
+            CONSTANTS.Documents.Metadata.KEY,
+        ];
+
         for (const field of removedFields) {
-            if (CONSTANTS.Documents.Metadata.LAST_MODIFIED === field ||
-                CONSTANTS.Documents.Metadata.COLLECTION === field ||
-                CONSTANTS.Documents.Metadata.CHANGE_VECTOR === field ||
-                CONSTANTS.Documents.Metadata.ID === field ||
-                CONSTANTS.Documents.Metadata.KEY === field) {
+            if (ignoredMetadataFields.includes(field)) {
                 continue;
             }
 
@@ -61,11 +65,7 @@ export class JsonOperation {
 
         for (const prop of newJsonProps) {
 
-            if (CONSTANTS.Documents.Metadata.LAST_MODIFIED === prop ||
-                CONSTANTS.Documents.Metadata.COLLECTION === prop ||
-                CONSTANTS.Documents.Metadata.CHANGE_VECTOR === prop ||
-                CONSTANTS.Documents.Metadata.ID === prop ||
-                CONSTANTS.Documents.Metadata.KEY === prop) {
+            if (ignoredMetadataFields.includes(prop)) {
                 continue;
             }
 

--- a/src/Mapping/JsonOperation.ts
+++ b/src/Mapping/JsonOperation.ts
@@ -44,6 +44,14 @@ export class JsonOperation {
         const removedFields = oldJsonProps.filter(x => !newJsonProps.includes(x));
 
         for (const field of removedFields) {
+            if (CONSTANTS.Documents.Metadata.LAST_MODIFIED === field ||
+                CONSTANTS.Documents.Metadata.COLLECTION === field ||
+                CONSTANTS.Documents.Metadata.CHANGE_VECTOR === field ||
+                CONSTANTS.Documents.Metadata.ID === field ||
+                CONSTANTS.Documents.Metadata.KEY === field) {
+                continue;
+            }
+
             if (!changes) {
                 return true;
             }

--- a/src/Utility/ObjectUtil.ts
+++ b/src/Utility/ObjectUtil.ts
@@ -17,9 +17,9 @@ export class ObjectUtil {
 
     // WARNING: some methods are assigned below dynamically
 
-    static camelCase = (input: string, locale?: string) => locale ? input[0].toLocaleUpperCase(locale)  + input.slice(1) : input[0].toLowerCase() + input.slice(1);
+    static camelCase = (input: string, locale?: string) => locale ? input[0].toLocaleLowerCase(locale)  + input.slice(1) : input[0].toLowerCase() + input.slice(1);
     static camel = ObjectUtil.camelCase;
-    static pascalCase = (input: string, locale?: string) => locale ? input[0].toLocaleLowerCase(locale) + input.slice(1) : input[0].toUpperCase() + input.slice(1);
+    static pascalCase = (input: string, locale?: string) => locale ? input[0].toLocaleUpperCase(locale) + input.slice(1) : input[0].toUpperCase() + input.slice(1);
     static pascal = ObjectUtil.pascalCase;
 
 

--- a/test/Documents/Identity/Commands/NextHiloCommandTest.ts
+++ b/test/Documents/Identity/Commands/NextHiloCommandTest.ts
@@ -1,0 +1,22 @@
+import assert from "node:assert";
+import { NextHiloCommand } from "../../../../src/Documents/Identity/Commands/NextHiloCommand.js";
+import { DocumentConventions } from "../../../../src/Documents/Conventions/DocumentConventions.js";
+
+describe("NextHiloCommand", function () {
+
+    it("should include lastMax=0 in URL when lastRangeMax is 0", function () {
+        const conventions = DocumentConventions.defaultConventions;
+        const cmd = new NextHiloCommand("users", 0, new Date(), "/", 0, conventions);
+        const request = cmd.createRequest({ url: "http://localhost:8080", database: "testdb" } as any);
+        assert.ok(request.uri.includes("lastMax=0"),
+            `URL should contain 'lastMax=0', got: ${request.uri}`);
+    });
+
+    it("should include lastMax when lastRangeMax is a positive number", function () {
+        const conventions = DocumentConventions.defaultConventions;
+        const cmd = new NextHiloCommand("users", 32, new Date(), "/", 1024, conventions);
+        const request = cmd.createRequest({ url: "http://localhost:8080", database: "testdb" } as any);
+        assert.ok(request.uri.includes("lastMax=1024"),
+            `URL should contain 'lastMax=1024', got: ${request.uri}`);
+    });
+});

--- a/test/Documents/Operations/Backups/BackupStatusTest.ts
+++ b/test/Documents/Operations/Backups/BackupStatusTest.ts
@@ -1,0 +1,33 @@
+import assert from "node:assert";
+import { JsonSerializer } from "../../../../src/Mapping/Json/Serializer.js";
+import type { BackupStatus } from "../../../../src/Documents/Operations/Backups/BackupStatus.js";
+import type { PeriodicBackupStatus } from "../../../../src/Documents/Operations/Backups/PeriodicBackupStatus.js";
+
+describe("BackupStatus field naming", function () {
+
+    const serializer = JsonSerializer.getDefaultForCommandPayload();
+
+    describe("incrementalBackupDurationInMs", function () {
+        it("should have correctly named field that matches server wire format", function () {
+            const serverJson = '{"FullBackupDurationInMs": 500, "IncrementalBackupDurationInMs": 1500}';
+            const result = serializer.deserialize<BackupStatus>(serverJson);
+
+            // Access via the typed interface field — this verifies the interface
+            // field name matches the camelCase form of the server's PascalCase key
+            assert.strictEqual(result.incrementalBackupDurationInMs, 1500,
+                "BackupStatus.incrementalBackupDurationInMs should map from server's IncrementalBackupDurationInMs");
+        });
+    });
+
+    describe("UploadToGoogleCloud", function () {
+        it("should have correctly named field that matches server wire format", function () {
+            const serverJson = '{"UploadToGoogleCloud": {"Skipped": true}, "UploadToS3": null}';
+            const result = serializer.deserialize<PeriodicBackupStatus>(serverJson);
+
+            // Access via the typed interface field — verifies the field name is
+            // uploadToGoogleCloud (not updateToGoogleCloud)
+            assert.ok(result.uploadToGoogleCloud, "Expected uploadToGoogleCloud to exist");
+            assert.strictEqual(result.uploadToGoogleCloud.skipped, true);
+        });
+    });
+});

--- a/test/Documents/Session/Operations/Lazy/LazyStartsWithOperationTest.ts
+++ b/test/Documents/Session/Operations/Lazy/LazyStartsWithOperationTest.ts
@@ -1,0 +1,58 @@
+import assert from "node:assert";
+import { LazyStartsWithOperation } from "../../../../../src/Documents/Session/Operations/Lazy/LazyStartsWithOperation.js";
+import { DocumentConventions } from "../../../../../src/Documents/Conventions/DocumentConventions.js";
+
+describe("LazyStartsWithOperation", function () {
+
+    function createOperation(opts: { matches?: string; exclude?: string; startAfter?: string }) {
+        const conventions = DocumentConventions.defaultConventions;
+        const sessionOps = {
+            conventions,
+        } as any;
+
+        return new LazyStartsWithOperation(
+            "users/",
+            {
+                matches: opts.matches,
+                exclude: opts.exclude,
+                start: 0,
+                pageSize: 25,
+                startAfter: opts.startAfter,
+            } as any,
+            sessionOps
+        );
+    }
+
+    it("should not encode undefined matches as literal 'undefined' string", function () {
+        const op = createOperation({});
+        const request = op.createRequest();
+        assert.ok(!request.query.includes("undefined"),
+            `Query should not contain 'undefined', got: ${request.query}`);
+        assert.ok(request.query.includes("matches=&"),
+            `Query should contain 'matches=&' (empty value), got: ${request.query}`);
+    });
+
+    it("should not encode undefined exclude as literal 'undefined' string", function () {
+        const op = createOperation({});
+        const request = op.createRequest();
+        assert.ok(!request.query.includes("undefined"),
+            `Query should not contain 'undefined', got: ${request.query}`);
+        assert.ok(request.query.includes("exclude=&"),
+            `Query should contain 'exclude=&' (empty value), got: ${request.query}`);
+    });
+
+    it("should not encode undefined startAfter as literal 'undefined' string", function () {
+        const op = createOperation({});
+        const request = op.createRequest();
+        // startAfter is at the end of the query string
+        assert.ok(!request.query.includes("undefined"),
+            `Query should not contain 'undefined', got: ${request.query}`);
+    });
+
+    it("should correctly encode provided matches value", function () {
+        const op = createOperation({ matches: "A*" });
+        const request = op.createRequest();
+        assert.ok(request.query.includes("matches=A"),
+            `Query should contain encoded matches value, got: ${request.query}`);
+    });
+});

--- a/test/Documents/Session/Tokens/MoreLikeThisTokenTest.ts
+++ b/test/Documents/Session/Tokens/MoreLikeThisTokenTest.ts
@@ -1,0 +1,30 @@
+import assert from "node:assert";
+import { MoreLikeThisToken } from "../../../../src/Documents/Session/Tokens/MoreLikeThisToken.js";
+import { StringBuilder } from "../../../../src/Utility/StringBuilder.js";
+
+describe("MoreLikeThisToken", function () {
+
+    it("should write moreLikeThis(true) when whereTokens is empty", function () {
+        const token = new MoreLikeThisToken();
+        // no documentParameterName, no whereTokens
+        const writer = new StringBuilder();
+        token.writeTo(writer);
+        assert.strictEqual(writer.toString(), "moreLikeThis(true)");
+    });
+
+    it("should write moreLikeThis(true, $opts) when whereTokens is empty with options", function () {
+        const token = new MoreLikeThisToken();
+        token.optionsParameterName = "p0";
+        const writer = new StringBuilder();
+        token.writeTo(writer);
+        assert.strictEqual(writer.toString(), "moreLikeThis(true, $p0)");
+    });
+
+    it("should write moreLikeThis($docParam) when documentParameterName is set", function () {
+        const token = new MoreLikeThisToken();
+        token.documentParameterName = "p0";
+        const writer = new StringBuilder();
+        token.writeTo(writer);
+        assert.strictEqual(writer.toString(), "moreLikeThis($p0)");
+    });
+});

--- a/test/Mapping/JsonOperationMetadataTest.ts
+++ b/test/Mapping/JsonOperationMetadataTest.ts
@@ -1,0 +1,66 @@
+import assert from "node:assert";
+import { JsonOperation } from "../../src/Mapping/JsonOperation.js";
+import { DocumentInfo } from "../../src/Documents/Session/DocumentInfo.js";
+
+describe("JsonOperation metadata field handling", function () {
+
+    it("should not report removed metadata fields as changes", function () {
+        // Original document from server has metadata fields
+        const original = {
+            "name": "John",
+            "@last-modified": "2024-01-01T00:00:00.0000000Z",
+            "@change-vector": "A:1-abc",
+            "@id": "users/1",
+            "@collection": "Users"
+        };
+
+        // New document after entity serialization — metadata fields stripped
+        const updated = {
+            "name": "John"
+        };
+
+        const docInfo = new DocumentInfo();
+        docInfo.id = "users/1";
+        docInfo.document = original;
+        docInfo.newDocument = false;
+
+        const changes: Record<string, any[]> = {};
+        const hasChanged = JsonOperation.entityChanged(updated, docInfo, changes);
+
+        assert.strictEqual(hasChanged, false,
+            "Should not detect changes when only metadata fields are removed");
+        assert.deepStrictEqual(changes, {},
+            "Changes map should be empty when only metadata fields differ");
+    });
+
+    it("should still report real field changes alongside metadata removal", function () {
+        const original = {
+            "name": "John",
+            "@last-modified": "2024-01-01T00:00:00.0000000Z",
+            "@change-vector": "A:1-abc"
+        };
+
+        const updated = {
+            "name": "Jane"
+        };
+
+        const docInfo = new DocumentInfo();
+        docInfo.id = "users/1";
+        docInfo.document = original;
+        docInfo.newDocument = false;
+
+        const changes: Record<string, any[]> = {};
+        const hasChanged = JsonOperation.entityChanged(updated, docInfo, changes);
+
+        assert.strictEqual(hasChanged, true,
+            "Should detect changes when real fields differ");
+        // Verify only real field change is reported, not metadata removal
+        const fieldChanges = changes["users/1"];
+        assert.ok(fieldChanges, "Should have changes for users/1");
+        const fieldNames = fieldChanges.map(c => c.fieldName);
+        assert.ok(!fieldNames.includes("@last-modified"),
+            "Should not report @last-modified as a change");
+        assert.ok(!fieldNames.includes("@change-vector"),
+            "Should not report @change-vector as a change");
+    });
+});

--- a/test/Utility/ObjectUtilCasingTest.ts
+++ b/test/Utility/ObjectUtilCasingTest.ts
@@ -1,0 +1,29 @@
+import { ObjectUtil } from "../../src/index.js";
+import assert from "node:assert";
+
+describe("ObjectUtil casing functions", function () {
+
+    describe("camelCase", function () {
+        it("should lowercase first character without locale", function () {
+            assert.strictEqual(ObjectUtil.camelCase("Name"), "name");
+            assert.strictEqual(ObjectUtil.camelCase("FirstName"), "firstName");
+        });
+
+        it("should lowercase first character with locale", function () {
+            assert.strictEqual(ObjectUtil.camelCase("Name", "en"), "name");
+            assert.strictEqual(ObjectUtil.camelCase("FirstName", "en"), "firstName");
+        });
+    });
+
+    describe("pascalCase", function () {
+        it("should uppercase first character without locale", function () {
+            assert.strictEqual(ObjectUtil.pascalCase("name"), "Name");
+            assert.strictEqual(ObjectUtil.pascalCase("firstName"), "FirstName");
+        });
+
+        it("should uppercase first character with locale", function () {
+            assert.strictEqual(ObjectUtil.pascalCase("name", "en"), "Name");
+            assert.strictEqual(ObjectUtil.pascalCase("firstName", "en"), "FirstName");
+        });
+    });
+});


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RDBC-1054

### Additional description

* **`camelCase`/`pascalCase` locale branches are swapped** — The locale-aware code paths use the wrong case conversion methods. `camelCase` with a locale uppercases the first character, and `pascalCase` with a locale lowercases it — the exact opposite of correct behavior. The non-locale paths work correctly.
* **`BackupStatus.incrementalBackupDurationIsMs` field name typo** — The interface field uses "Is" but the server sends "In" (`IncrementalBackupDurationInMs`). The deserialized property name doesn't match the interface, so any typed access returns `undefined` — the incremental backup duration is silently lost.
* **`UpdateToGoogleCloud` interface name typo** — The interface and field use "Update" but the server sends "Upload" (`UploadToGoogleCloud`). Google Cloud backup status is silently lost during deserialization because the property names don't match.
* **Change detection reports false positives for removed metadata fields** — When comparing documents for changes, the removed-fields loop reports `RemovedField` for server-managed metadata properties (`@last-modified`, `@change-vector`, `@id`, `@collection`). The new-fields loop correctly skips these, but the removed-fields loop doesn't. This causes `hasChanged()` and `whatChanged()` to report spurious changes when metadata fields are absent from the serialized entity.
* **`MoreLikeThisToken` writes empty `moreLikeThis()` when no where tokens are present** — When `whereTokens` is empty and no document parameter is set, the token writes `moreLikeThis()` with no argument. The server expects `moreLikeThis(true)` in this case and rejects the query.
* **`NextHiloCommand` omits `lastMax=0` from URL** — The URL construction uses a falsy check on `lastRangeMax`, so when it is `0` (the first document in a HiLo range), the `lastMax `parameter is omitted entirely from the request URL instead of being sent as `lastMax=0`.
* **`LazyStartsWithOperation` encodes `undefined` as the literal string `"undefined"` in URL** — When optional parameters (`matches`, `exclude`, `startAfter`) are not provided, `encodeURIComponent(undefined)` produces the literal string `"undefined"`. The server receives `matches=undefined` instead of an empty value, causing it to match against the literal text and return no results.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low
- [ ] Moderate
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`)
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
