### PR TITLE
RavenDB-1061 - 7.2.1 -> 7.2.2 Patch

### DIFF
--- a/.github/workflows/BunClient.yml
+++ b/.github/workflows/BunClient.yml
@@ -2,9 +2,9 @@ name: tests/bun
 
 on:
   push:
-    branches: [ v7.1 ]
+    branches: [ v7.2 ]
   pull_request:
-    branches: [ v7.1 ]
+    branches: [ v7.2 ]
   schedule:
     - cron: '0 10 * * *'
   workflow_dispatch:

--- a/.github/workflows/RavenClient.yml
+++ b/.github/workflows/RavenClient.yml
@@ -2,9 +2,9 @@ name: tests/node
 
 on:
   push:
-    branches: [ v7.1 ]
+    branches: [ v7.2 ]
   pull_request:
-    branches: [ v7.1 ]
+    branches: [ v7.2 ]
   schedule:
     - cron: '0 10 * * *'
   workflow_dispatch:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ravendb",
-  "version": "7.2.1",
+  "version": "7.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ravendb",
-      "version": "7.2.1",
+      "version": "7.2.2",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^20.14.14",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ravendb",
-  "version": "7.2.1",
+  "version": "7.2.2",
   "description": "RavenDB client for Node.js",
   "files": [
     "dist"

--- a/src/Documents/Commands/AbstractQueryCommand.ts
+++ b/src/Documents/Commands/AbstractQueryCommand.ts
@@ -9,6 +9,7 @@ export abstract class AbstractQueryCommand<TResult, TParameters> extends RavenCo
     private readonly _metadataOnly: boolean;
     private readonly _indexEntriesOnly: boolean;
     private readonly _ignoreLimit: boolean;
+    private readonly _tag: string | undefined;
 
     protected constructor(indexQuery: IndexQuery, canCache: boolean, metadataOnly: boolean, indexEntriesOnly: boolean, ignoreLimit: boolean) {
         super();
@@ -16,6 +17,7 @@ export abstract class AbstractQueryCommand<TResult, TParameters> extends RavenCo
         this._metadataOnly = metadataOnly;
         this._indexEntriesOnly = indexEntriesOnly;
         this._ignoreLimit = ignoreLimit;
+        this._tag = indexQuery.tag;
 
         this._canCache = canCache;
 
@@ -50,6 +52,10 @@ export abstract class AbstractQueryCommand<TResult, TParameters> extends RavenCo
 
         if (this._ignoreLimit) {
             path.append("&ignoreLimit=true");
+        }
+
+        if (this._tag) {
+            path.append("&tag=").append(encodeURIComponent(this._tag));
         }
 
         path.append("&addTimeSeriesNames=true");

--- a/src/Documents/Commands/CommandData.ts
+++ b/src/Documents/Commands/CommandData.ts
@@ -28,6 +28,7 @@ export type CommandType =
     | "TimeSeriesCopy"
     | "JsonPatch"
     | "HeartBeat"
+    | "BatchTrackChanges"
     ;
 
 export interface ICommandData {

--- a/src/Documents/Commands/QueryStreamCommand.ts
+++ b/src/Documents/Commands/QueryStreamCommand.ts
@@ -30,9 +30,15 @@ export class QueryStreamCommand extends RavenCommand<StreamResultResponse> {
     }
 
     public createRequest(node: ServerNode): HttpRequestParameters {
+        let uri = `${node.url}/databases/${node.database}/streams/queries?format=jsonl`;
+
+        if (this._indexQuery.tag) {
+            uri += `&tag=${encodeURIComponent(this._indexQuery.tag)}`;
+        }
+
         return {
             method: "POST",
-            uri: `${node.url}/databases/${node.database}/streams/queries?format=jsonl`,
+            uri,
             body: writeIndexQuery(this._conventions, this._indexQuery),
             headers: this._headers().typeAppJson().build()
         };

--- a/src/Documents/Conventions/DocumentConventions.ts
+++ b/src/Documents/Conventions/DocumentConventions.ts
@@ -17,6 +17,7 @@ import { ObjectUtil, FieldNameConversion } from "../../Utility/ObjectUtil.js";
 import { LoadBalanceBehavior } from "../../Http/LoadBalanceBehavior.js";
 import { BulkInsertConventions } from "./BulkInsertConventions.js";
 import { InMemoryDocumentSessionOperations } from "../Session/InMemoryDocumentSessionOperations.js";
+import { OptimisticConcurrencyMode } from "../Session/SessionOptions.js";
 import { ShardingConventions } from "./ShardingConventions.js";
 import { plural } from "../../ext/pluralize/pluralize.js";
 import { HttpCompressionAlgorithm } from "../../Http/HttpCompressionAlgorithm.js";
@@ -77,6 +78,9 @@ export class DocumentConventions {
     private _findJsType: (id: string, doc: object) => ObjectTypeDescriptor;
 
     private _useOptimisticConcurrency: boolean;
+    private _optimisticConcurrencyMode: OptimisticConcurrencyMode = "None";
+    private _useOptimisticConcurrencyWasSet: boolean = false;
+    private _optimisticConcurrencyModeWasSet: boolean = false;
     private _maxNumberOfRequestsPerSession: number;
 
     private _requestTimeout: number | undefined;
@@ -395,11 +399,33 @@ export class DocumentConventions {
 
     public set useOptimisticConcurrency(val: boolean) {
         this._assertNotFrozen();
+        if (this._optimisticConcurrencyModeWasSet) {
+            throwError("InvalidOperationException",
+                "useOptimisticConcurrency cannot be set when optimisticConcurrencyMode was already set. " +
+                "Use optimisticConcurrencyMode instead.");
+        }
+        this._useOptimisticConcurrencyWasSet = true;
+        this._optimisticConcurrencyMode = val ? "Writes" : "None";
         this._useOptimisticConcurrency = val;
     }
 
     public get useOptimisticConcurrency() {
-        return this._useOptimisticConcurrency;
+        return this._optimisticConcurrencyMode !== "None";
+    }
+
+    public get optimisticConcurrencyMode(): OptimisticConcurrencyMode {
+        return this._optimisticConcurrencyMode;
+    }
+
+    public set optimisticConcurrencyMode(value: OptimisticConcurrencyMode) {
+        this._assertNotFrozen();
+        if (this._useOptimisticConcurrencyWasSet) {
+            throwError("InvalidOperationException",
+                "optimisticConcurrencyMode cannot be set when useOptimisticConcurrency was already set. " +
+                "Use optimisticConcurrencyMode instead.");
+        }
+        this._optimisticConcurrencyModeWasSet = true;
+        this._optimisticConcurrencyMode = value;
     }
 
     public deserializeEntityFromJson(documentType: ObjectTypeDescriptor, document: object): object {
@@ -505,7 +531,7 @@ export class DocumentConventions {
      * Whether UseOptimisticConcurrency is set to true by default for all opened sessions
      */
     public isUseOptimisticConcurrency(): boolean {
-        return this._useOptimisticConcurrency;
+        return this._optimisticConcurrencyMode !== "None";
     }
 
     /**
@@ -513,7 +539,14 @@ export class DocumentConventions {
      */
     public setUseOptimisticConcurrency(useOptimisticConcurrency: boolean): void {
         this._assertNotFrozen();
+        if (this._optimisticConcurrencyModeWasSet) {
+            throwError("InvalidOperationException",
+                "useOptimisticConcurrency cannot be set when optimisticConcurrencyMode was already set. " +
+                "Use optimisticConcurrencyMode instead.");
+        }
+        this._useOptimisticConcurrencyWasSet = true;
         this._useOptimisticConcurrency = useOptimisticConcurrency;
+        this._optimisticConcurrencyMode = useOptimisticConcurrency ? "Writes" : "None";
     }
 
     public get identityProperty() {

--- a/src/Documents/Conventions/DocumentConventions.ts
+++ b/src/Documents/Conventions/DocumentConventions.ts
@@ -79,8 +79,8 @@ export class DocumentConventions {
 
     private _useOptimisticConcurrency: boolean;
     private _optimisticConcurrencyMode: OptimisticConcurrencyMode = "None";
-    private _useOptimisticConcurrencyWasSet: boolean = false;
-    private _optimisticConcurrencyModeWasSet: boolean = false;
+    private _useOptimisticConcurrencyWasSet: boolean;
+    private _optimisticConcurrencyModeWasSet: boolean;
     private _maxNumberOfRequestsPerSession: number;
 
     private _requestTimeout: number | undefined;

--- a/src/Documents/Operations/AI/Agents/AiAgentParameter.ts
+++ b/src/Documents/Operations/AI/Agents/AiAgentParameter.ts
@@ -1,4 +1,23 @@
 /**
+ * Controls how a parameter behaves, especially across parent and sub-agent boundaries.
+ */
+export type AiAgentParameterPolicy = "Default" | "ForbidModelGeneration";
+
+/**
+ * Defines the expected JSON value type of an agent parameter.
+ * "Default" disables type validation (backward compatibility).
+ */
+export type AiAgentParameterValueType =
+    | "Default"
+    | "String"
+    | "Number"
+    | "Boolean"
+    | "ArrayOfString"
+    | "ArrayOfNumber"
+    | "ArrayOfBoolean"
+    | "Null";
+
+/**
  * Represents a parameter that can be passed to an AI agent.
  * Parameters can be marked as hidden from the model for security/privacy purposes.
  */
@@ -15,4 +34,20 @@ export interface AiAgentParameter {
      * - `undefined` (default): Treated as exposed to the model.
      */
     sendToModel?: boolean;
+
+    /**
+     * Defines policy flags that control how a parameter behaves when used across
+     * parent and sub-agent boundaries.
+     * When set to "ForbidModelGeneration" and this agent is used as a sub-agent,
+     * the parent agent cannot generate a value for this parameter; the value may
+     * only be inherited from the parent agent's parameters.
+     */
+    policy?: AiAgentParameterPolicy;
+
+    /**
+     * Specifies the expected JSON value type for this parameter.
+     * When set to a specific value, the agent validates the provided value against it.
+     * "Default" disables type validation (backward compatible).
+     */
+    type?: AiAgentParameterValueType;
 }

--- a/src/Documents/Operations/AI/Agents/AiAgentToolSubAgent.ts
+++ b/src/Documents/Operations/AI/Agents/AiAgentToolSubAgent.ts
@@ -1,0 +1,15 @@
+/**
+ * Represents a server-side sub-agent that the model can call as a tool.
+ * Sub-agents are managed by the server and inherit parameters from the root agent.
+ */
+export interface AiAgentToolSubAgent {
+    /**
+     * The identifier of the sub-agent to call (e.g., "attendance-agent").
+     */
+    identifier: string;
+
+    /**
+     * A description the model uses to decide when to invoke this sub-agent.
+     */
+    description: string;
+}

--- a/src/Documents/Operations/AI/Agents/AiConversationCreationOptions.ts
+++ b/src/Documents/Operations/AI/Agents/AiConversationCreationOptions.ts
@@ -1,4 +1,79 @@
-export interface AiConversationCreationOptions {
-    parameters?: Record<string, unknown>;
+/**
+ * Optional configuration for a conversation parameter.
+ */
+export interface AiConversationParameterOptions {
+    /**
+     * When false, the parameter is available for internal use (queries, actions, sub-agents)
+     * but is not sent to the LLM. Default is true.
+     */
+    sendToModel?: boolean;
+}
+
+/**
+ * A typed conversation parameter with a value and visibility control.
+ */
+export interface AiConversationParameter {
+    value: unknown;
+    /**
+     * Whether this parameter is sent to the model. Default is true.
+     */
+    sendToModel: boolean;
+}
+
+/**
+ * Options used when creating or continuing an AI conversation.
+ */
+export class AiConversationCreationOptions {
+    /**
+     * Conversation-level parameters passed to the agent.
+     * Each parameter defines a value and whether it should be sent to the model.
+     */
+    parameters?: Record<string, AiConversationParameter>;
+
+    /**
+     * Optional conversation expiration in seconds.
+     */
     expirationInSec?: number;
+
+    /**
+     * Limits the number of model iterations (tool call round-trips) per run() call.
+     */
+    maxModelIterationsPerCall?: number;
+
+    public constructor();
+    public constructor(parameters: Record<string, AiConversationParameter>);
+    /**
+     * Legacy constructor: accepts a plain Record<string, unknown> and wraps each value
+     * as an AiConversationParameter with sendToModel = true.
+     *
+     * **Note:** If a plain-object value happens to have both a `value` property and a
+     * `sendToModel` property, it will be treated as an already-structured
+     * `AiConversationParameter` rather than a raw value. Prefer the typed overload or
+     * `addParameter()` when parameter values may have this shape.
+     */
+    public constructor(parameters: Record<string, unknown>);
+    public constructor(parameters?: Record<string, AiConversationParameter | unknown>) {
+        if (parameters) {
+            this.parameters = {};
+            for (const [key, val] of Object.entries(parameters)) {
+                if (val != null && typeof val === "object" && "value" in val && "sendToModel" in val) {
+                    this.parameters[key] = val as AiConversationParameter;
+                } else {
+                    this.parameters[key] = { value: val, sendToModel: true };
+                }
+            }
+        }
+    }
+
+    /**
+     * Adds a parameter to the conversation. Fluent builder pattern.
+     */
+    public addParameter(name: string, value: unknown, options?: AiConversationParameterOptions): this {
+        this.parameters ??= {};
+        this.parameters[name] = {
+            value,
+            sendToModel: options?.sendToModel ?? true
+        };
+        return this;
+    }
 }

--- a/src/Documents/Operations/AI/Agents/RunConversationOperation.ts
+++ b/src/Documents/Operations/AI/Agents/RunConversationOperation.ts
@@ -5,17 +5,20 @@ import type { AiAgentActionResponse, AiAgentArtificialActionResponse } from "./A
 import type { AiConversationCreationOptions } from "./AiConversationCreationOptions.js";
 import type { ConversationResult } from "./ConversationResult.js";
 import type { AiStreamCallback } from "../AiStreamCallback.js";
+import type { AiAttachmentCommand } from "../AiConversation.js";
 import { ContentPart, TextPart } from "../ContentPart.js";
 import { RavenCommand } from "../../../../Http/RavenCommand.js";
 import { DocumentConventions } from "../../../Conventions/DocumentConventions.js";
 import { IRaftCommand } from "../../../../Http/IRaftCommand.js";
 import { RaftIdGenerator } from "../../../../Utility/RaftIdGenerator.js";
 import { ServerNode } from "../../../../Http/ServerNode.js";
-import { HttpRequestParameters } from "../../../../Primitives/Http.js";
+import { HttpRequestParameters, HttpResponse } from "../../../../Primitives/Http.js";
 import { throwError } from "../../../../Exceptions/index.js";
 import { JsonSerializer } from "../../../../Mapping/Json/Serializer.js";
 import { ObjectUtil } from "../../../../Utility/ObjectUtil.js";
 import { StringUtil } from "../../../../Utility/StringUtil.js";
+import { readToBuffer } from "../../../../Utility/StreamUtil.js";
+import { Dispatcher } from "undici-types";
 
 export class RunConversationOperation<TAnswer> implements IMaintenanceOperation<ConversationResult<TAnswer>> {
     private readonly _agentId: string;
@@ -25,6 +28,7 @@ export class RunConversationOperation<TAnswer> implements IMaintenanceOperation<
     private readonly _artificialActions?: AiAgentArtificialActionResponse[];
     private readonly _options?: AiConversationCreationOptions;
     private readonly _changeVector?: string;
+    private readonly _attachmentCommands?: AiAttachmentCommand[];
     private readonly _streamPropertyPath?: string;
     private readonly _streamCallback?: AiStreamCallback;
 
@@ -36,6 +40,7 @@ export class RunConversationOperation<TAnswer> implements IMaintenanceOperation<
         artificialActions?: AiAgentArtificialActionResponse[],
         options?: AiConversationCreationOptions,
         changeVector?: string,
+        attachmentCommands?: AiAttachmentCommand[],
         streamPropertyPath?: string,
         streamCallback?: AiStreamCallback
     ) {
@@ -65,6 +70,7 @@ export class RunConversationOperation<TAnswer> implements IMaintenanceOperation<
         this._artificialActions = artificialActions;
         this._options = options;
         this._changeVector = changeVector;
+        this._attachmentCommands = attachmentCommands;
         this._streamPropertyPath = streamPropertyPath;
         this._streamCallback = streamCallback;
     }
@@ -82,6 +88,7 @@ export class RunConversationOperation<TAnswer> implements IMaintenanceOperation<
             this._artificialActions,
             this._options,
             this._changeVector,
+            this._attachmentCommands,
             conventions,
             this._streamPropertyPath,
             this._streamCallback
@@ -99,6 +106,7 @@ class RunConversationCommand<TAnswer>
     private readonly _artificialActions?: AiAgentArtificialActionResponse[];
     private readonly _options?: AiConversationCreationOptions;
     private readonly _changeVector?: string;
+    private readonly _attachmentCommands?: AiAttachmentCommand[];
     private readonly _streamPropertyPath?: string;
     private readonly _streamCallback?: AiStreamCallback;
     private _raftId: string;
@@ -111,6 +119,7 @@ class RunConversationCommand<TAnswer>
         artificialActions: AiAgentArtificialActionResponse[] | undefined,
         options: AiConversationCreationOptions | undefined,
         changeVector: string | undefined,
+        attachmentCommands: AiAttachmentCommand[] | undefined,
         conventions: DocumentConventions,
         streamPropertyPath?: string,
         streamCallback?: AiStreamCallback
@@ -123,6 +132,7 @@ class RunConversationCommand<TAnswer>
         this._artificialActions = artificialActions;
         this._options = options;
         this._changeVector = changeVector;
+        this._attachmentCommands = attachmentCommands;
         this._streamPropertyPath = streamPropertyPath;
         this._streamCallback = streamCallback;
 
@@ -161,31 +171,98 @@ class RunConversationCommand<TAnswer>
 
         const uri = `${node.url}/databases/${node.database}/ai/agent?${uriParams}`;
 
+        const creationOptions = this._options ?? {};
         const bodyObj = {
             ActionResponses: this._actionResponses,
             ArtificialActions: this._artificialActions,
             UserPrompt: this._promptParts.length > 0 ? this._promptParts : null,
-            CreationOptions: this._options ?? {}
+            CreationOptions: creationOptions
         };
 
         const headers = this._headers().typeAppJson().build();
 
-        // Serialize properties to PascalCase, except "parameters" in CreationOptions, which must keep user-provided, case-sensitive keys unchanged.
+        // Serialize properties to PascalCase, except user-provided parameter keys in
+        // CreationOptions.Parameters which must stay case-sensitive (e.g. "userId", "locale").
+        // Sub-properties of each parameter (Value, SendToModel) are still PascalCased.
         const serialized = ObjectUtil.transformObjectKeys(bodyObj, {
             defaultTransform: ObjectUtil.pascalCase,
             ignorePaths: [
-                new RegExp("^CreationOptions\\.Parameters\\..*$"),
+                new RegExp("^CreationOptions\\.Parameters\\.[^.]+$"),
                 new RegExp("^UserPrompt\\..*$")
             ]
         });
 
+        const attachments = this._attachmentCommands;
+        if (!attachments || attachments.length === 0) {
+            return {
+                method: "POST",
+                uri,
+                headers,
+                body: JsonSerializer.getDefault().serialize(serialized)
+            };
+        }
+
+        // Server parses multipart positionally (AbstractAiAgentProcessor.ParseMultipartAsync):
+        // part 0 = JSON body, part 1 = { "Commands": [...] }, parts 2+ = raw attachment streams.
+        // Field names in multipart/form-data are ignored; order is what matters.
+        const commands = attachments.map(cmd => {
+            if (cmd.kind === "put") {
+                return {
+                    Type: "AttachmentPUT",
+                    Id: "__this__",
+                    Name: cmd.name,
+                    ContentType: cmd.contentType,
+                    ChangeVector: null
+                };
+            } else {
+                return {
+                    Type: "AttachmentCOPY",
+                    Id: cmd.sourceDocumentId,
+                    Name: cmd.fileName,
+                    DestinationId: "__this__",
+                    DestinationName: cmd.fileName,
+                    ChangeVector: null
+                };
+            }
+        });
+
+        const form = new FormData();
+        form.append("main", new Blob([JsonSerializer.getDefault().serialize(serialized)], { type: "application/json" }));
+        form.append("attachmentCommands", new Blob([JSON.stringify({ Commands: commands })], { type: "application/json" }));
+
+        // NOTE: Buffer data is appended here; Readable streams are appended in send()
+        for (const cmd of attachments) {
+            if (cmd.kind === "put" && Buffer.isBuffer(cmd.stream)) {
+                form.append("attachment", new Blob([cmd.stream], { type: cmd.contentType }));
+            }
+        }
 
         return {
             method: "POST",
             uri,
-            headers,
-            body: JsonSerializer.getDefault().serialize(serialized)
+            // strip content-type header so the browser/fetch can set correct multipart boundary
+            body: form
         };
+    }
+
+    async send(agent: Dispatcher, requestOptions: HttpRequestParameters): Promise<{
+        response: HttpResponse;
+        bodyStream: Readable
+    }> {
+        const { body } = requestOptions;
+        if (body instanceof FormData && this._attachmentCommands) {
+            // NOTE: Readable streams are single-consumption. If the request is retried on
+            // node failover, an already-drained Readable will produce an empty Blob.
+            // Only Buffer inputs are safe for retries. This limitation is consistent with
+            // how SingleNodeBatchCommand handles the same scenario.
+            for (const cmd of this._attachmentCommands) {
+                if (cmd.kind === "put" && !Buffer.isBuffer(cmd.stream)) {
+                    const buf = await readToBuffer(cmd.stream as Readable);
+                    body.append("attachment", new Blob([buf], { type: cmd.contentType }));
+                }
+            }
+        }
+        return super.send(agent, requestOptions);
     }
 
     async setResponseAsync(bodyStream: Stream, fromCache: boolean): Promise<string> {

--- a/src/Documents/Operations/AI/Agents/config/AiAgentConfiguration.ts
+++ b/src/Documents/Operations/AI/Agents/config/AiAgentConfiguration.ts
@@ -1,5 +1,6 @@
 import type { AiAgentToolQuery } from "../AiAgentToolQuery.js";
 import type { AiAgentToolAction } from "../AiAgentToolAction.js";
+import type { AiAgentToolSubAgent } from "../AiAgentToolSubAgent.js";
 import type { AiAgentParameter } from "../AiAgentParameter.js";
 import type { AiAgentChatTrimmingConfiguration } from "./AiAgentChatTrimmingConfiguration.js";
 
@@ -13,6 +14,14 @@ export interface AiAgentConfiguration {
     outputSchema?: string; // JSON schema for output
     queries?: AiAgentToolQuery[];
     actions?: AiAgentToolAction[];
+    /**
+     * Server-side sub-agents the model can call as tools.
+     * Sub-agents are managed entirely by the server and inherit parameters from the root agent.
+     *
+     * Client-side action handlers can be registered for sub-agent actions using the path syntax:
+     * `handle("sub-agent-id/ActionName", ...)` or `handle("parent/child/ActionName", ...)`
+     */
+    subAgents?: AiAgentToolSubAgent[];
     parameters?: AiAgentParameter[];
     chatTrimming?: AiAgentChatTrimmingConfiguration;
     maxModelIterationsPerCall?: number;

--- a/src/Documents/Operations/AI/Agents/index.ts
+++ b/src/Documents/Operations/AI/Agents/index.ts
@@ -3,3 +3,6 @@ export * from "./AddOrUpdateAiAgentOperation.js";
 export * from "./DeleteAiAgentOperation.js";
 export * from "./RunConversationOperation.js";
 export * from "./AiAgentToolQueryOptions.js";
+export * from "./AiAgentToolSubAgent.js";
+export * from "./AiAgentParameter.js";
+export * from "./AiConversationCreationOptions.js";

--- a/src/Documents/Operations/AI/AiConversation.ts
+++ b/src/Documents/Operations/AI/AiConversation.ts
@@ -9,6 +9,22 @@ import type { UnhandledActionEventArgs } from "./UnhandledActionEventArgs.js";
 import { ContentPart, TextPart } from "./ContentPart.js";
 import { throwError } from "../../../Exceptions/index.js";
 import { StringUtil } from "../../../Utility/StringUtil.js";
+import type { Readable } from "node:stream";
+
+type PutAttachmentCommand = {
+    kind: "put";
+    name: string;
+    stream: Readable | Buffer;
+    contentType: string;
+};
+
+type CopyAttachmentCommand = {
+    kind: "copy";
+    sourceDocumentId: string;
+    fileName: string;
+};
+
+export type AiAttachmentCommand = PutAttachmentCommand | CopyAttachmentCommand;
 
 export enum AiHandleErrorStrategy {
     SendErrorsToModel = "SendErrorsToModel",
@@ -27,6 +43,7 @@ export class AiConversation {
     private readonly _actionResponses: Map<string, AiAgentActionResponse> = new Map();
     private readonly _artificialActions: AiAgentArtificialActionResponse[] = [];
     private readonly _promptParts: ContentPart[] = [];
+    private readonly _attachmentCommands: AiAttachmentCommand[] = [];
     private readonly _invocations: Map<string, ActionInvocation> = new Map();
     public onUnhandledAction?: (args: UnhandledActionEventArgs) => Promise<void> | void;
 
@@ -150,6 +167,35 @@ export class AiConversation {
             if (!prompt) throwError("InvalidArgumentException", "prompt cannot be empty");
             this._promptParts.push(new TextPart(prompt));
         }
+    }
+
+    /**
+     * Adds a file attachment as a stream to the next conversation turn.
+     * Use a descriptive name — the LLM uses the filename for context.
+     *
+     * @param name Descriptive filename (e.g. "monthly_budget.pdf")
+     * @param stream The file data as a Node.js Readable stream or Buffer
+     * @param contentType MIME type (e.g. "image/png", "application/pdf")
+     */
+    public addAttachment(name: string, stream: Readable | Buffer, contentType: string): void {
+        if (!stream) throwError("InvalidArgumentException", "stream cannot be null");
+        if (!name) throwError("InvalidArgumentException", "name cannot be empty");
+        if (!contentType) throwError("InvalidArgumentException", "contentType cannot be empty");
+        this._attachmentCommands.push({ kind: "put", name, stream, contentType });
+    }
+
+    /**
+     * Copies an existing attachment from a RavenDB document into the conversation context.
+     *
+     * @param sourceDocumentId The ID of the document containing the attachment
+     * @param fileName The name of the attachment to copy
+     */
+    public copyAttachmentFrom(sourceDocumentId: string, fileName: string): void {
+        if (StringUtil.isNullOrEmpty(sourceDocumentId))
+            throwError("InvalidArgumentException", "sourceDocumentId cannot be empty");
+        if (StringUtil.isNullOrEmpty(fileName))
+            throwError("InvalidArgumentException", "fileName cannot be empty");
+        this._attachmentCommands.push({ kind: "copy", sourceDocumentId, fileName });
     }
 
     public handle<TArgs = any, TResult extends object = object>(
@@ -305,7 +351,7 @@ export class AiConversation {
     }
 
     private async _runInternal<TAnswer>(streamPropertyPath?: string, streamCallback?: AiStreamCallback): Promise<AiAnswer<TAnswer>> {
-        if (this._actionRequests != null && this._promptParts.length === 0 && this._actionResponses.size === 0 && this._artificialActions.length === 0) {
+        if (this._actionRequests != null && this._promptParts.length === 0 && this._actionResponses.size === 0 && this._artificialActions.length === 0 && this._attachmentCommands.length === 0) {
             return {status: "Done" as const} as AiAnswer<TAnswer>;
         }
 
@@ -317,6 +363,7 @@ export class AiConversation {
             this._artificialActions,
             this._options,
             this._changeVector,
+            this._attachmentCommands.length > 0 ? [...this._attachmentCommands] : undefined,
             streamPropertyPath,
             streamCallback
         );
@@ -335,10 +382,11 @@ export class AiConversation {
                 elapsed: res.elapsed
             };
         } finally {
-            // clear prompt, responses and artificial actions after running the conversation
+            // clear prompt, responses, artificial actions and attachment commands after running the conversation
             this._promptParts.length = 0;
             this._actionResponses.clear();
             this._artificialActions.length = 0;
+            this._attachmentCommands.length = 0;
         }
     }
 

--- a/src/Documents/Operations/AI/ConnectionStrings/Settings/AzureOpenAiSettings.ts
+++ b/src/Documents/Operations/AI/ConnectionStrings/Settings/AzureOpenAiSettings.ts
@@ -14,9 +14,10 @@ export class AzureOpenAiSettings extends OpenAiBaseSettings {
         model: string,
         public deploymentName: string,
         dimensions?: number,
-        temperature?: number
+        temperature?: number,
+        enablePromptCache?: boolean
     ) {
-        super(apiKey, endpoint, model, dimensions, temperature);
+        super(apiKey, endpoint, model, dimensions, temperature, enablePromptCache);
     }
 
     public validate(errors: string[]): void {

--- a/src/Documents/Operations/AI/ConnectionStrings/Settings/OpenAiBaseSettings.ts
+++ b/src/Documents/Operations/AI/ConnectionStrings/Settings/OpenAiBaseSettings.ts
@@ -35,12 +35,20 @@ export abstract class OpenAiBaseSettings extends AbstractAiSettings implements I
      */
     public temperature?: number;
 
+    /**
+     * When true, enables server-side prompt caching for eligible requests.
+     * Reduces cost and latency by reusing the KV cache from previous requests
+     * with shared prefixes.
+     */
+    public enablePromptCache?: boolean;
+
     protected constructor(
         apiKey: string,
         endpoint: string,
         model: string,
         dimensions?: number,
-        temperature?: number
+        temperature?: number,
+        enablePromptCache?: boolean
     ) {
         super();
         this.apiKey = apiKey;
@@ -48,6 +56,7 @@ export abstract class OpenAiBaseSettings extends AbstractAiSettings implements I
         this.model = model;
         this.dimensions = dimensions;
         this.temperature = temperature;
+        this.enablePromptCache = enablePromptCache;
     }
 
     public getBaseEndpointUri(): string {
@@ -109,6 +118,10 @@ export abstract class OpenAiBaseSettings extends AbstractAiSettings implements I
         if (hasTemperature !== otherHasTemperature ||
             (hasTemperature && otherHasTemperature &&
              Math.abs(this.temperature - other.temperature) > 0.0001)) {
+            differences |= AiSettingsCompareDifferences.EndpointConfiguration;
+        }
+
+        if (this.enablePromptCache !== other.enablePromptCache) {
             differences |= AiSettingsCompareDifferences.EndpointConfiguration;
         }
 

--- a/src/Documents/Operations/AI/ConnectionStrings/Settings/OpenAiSettings.ts
+++ b/src/Documents/Operations/AI/ConnectionStrings/Settings/OpenAiSettings.ts
@@ -3,6 +3,12 @@ import { AbstractAiSettings } from "./AbstractAiSettings.js";
 import { AiSettingsCompareDifferences } from "../AiSettingsCompareDifferences.js";
 
 /**
+ * Controls the amount of internal reasoning the model performs.
+ * Lower values reduce latency; higher values improve response quality for complex tasks.
+ */
+export type OpenAiReasoningEffort = "Minimal" | "Low" | "Medium" | "High";
+
+/**
  * The configuration for the OpenAI API client.
  */
 export class OpenAiSettings extends OpenAiBaseSettings {
@@ -23,6 +29,18 @@ export class OpenAiSettings extends OpenAiBaseSettings {
      */
     public projectId?: string;
 
+    /**
+     * Controls the reasoning depth used by supported models (e.g. GPT-5 family).
+     * Lower values reduce internal reasoning, improving latency.
+     */
+    public reasoningEffort?: OpenAiReasoningEffort;
+
+    /**
+     * Optional seed for more reproducible sampling across requests.
+     * Does not guarantee fully deterministic results.
+     */
+    public seed?: number;
+
     private static readonly OPENAI_BASE_URI = "https://api.openai.com/";
 
     public constructor(
@@ -32,11 +50,16 @@ export class OpenAiSettings extends OpenAiBaseSettings {
         organizationId?: string,
         projectId?: string,
         dimensions?: number,
-        temperature?: number
+        temperature?: number,
+        enablePromptCache?: boolean,
+        reasoningEffort?: OpenAiReasoningEffort,
+        seed?: number
     ) {
-        super(apiKey, endpoint, model, dimensions, temperature);
+        super(apiKey, endpoint, model, dimensions, temperature, enablePromptCache);
         this.organizationId = organizationId;
         this.projectId = projectId;
+        this.reasoningEffort = reasoningEffort;
+        this.seed = seed;
     }
 
     public getBaseEndpointUri(): string {
@@ -59,6 +82,11 @@ export class OpenAiSettings extends OpenAiBaseSettings {
         if (this.organizationId !== other.organizationId ||
             this.projectId !== other.projectId) {
             differences |= AiSettingsCompareDifferences.AuthenticationSettings;
+        }
+
+        if (this.reasoningEffort !== other.reasoningEffort ||
+            this.seed !== other.seed) {
+            differences |= AiSettingsCompareDifferences.EndpointConfiguration;
         }
 
         return differences;

--- a/src/Documents/Queries/IndexQueryBase.ts
+++ b/src/Documents/Queries/IndexQueryBase.ts
@@ -9,4 +9,10 @@ export class IndexQueryBase<T> implements IIndexQuery {
     public waitForNonStaleResults: boolean;
     public waitForNonStaleResultsTimeout: number;
 
+    /**
+     * User-defined query tag. Sent to the server as the `tag` query-string parameter.
+     * Useful for identifying query sources in server logs and monitoring.
+     */
+    public tag?: string;
+
 }

--- a/src/Documents/Queries/RavenQuery.ts
+++ b/src/Documents/Queries/RavenQuery.ts
@@ -1,0 +1,29 @@
+import { RavenDateMethodCall } from "../Session/RavenDateMethodCall.js";
+
+export class RavenQuery {
+    /**
+     * Returns a MethodCall representing the server-side `now()` RQL function.
+     * The server evaluates the current UTC timestamp at query execution time,
+     * avoiding clock skew between client and server.
+     *
+     * @param offset Optional duration string (e.g. "+1y6mo", "-2hours") — see RavenDB docs.
+     *
+     * @example
+     * session.query(Order).whereGreaterThan("createdAt", RavenQuery.now())
+     * session.query(Order).whereLessThan("expiresAt", RavenQuery.now("+30d"))
+     */
+    public static now(offset?: string): RavenDateMethodCall {
+        return RavenDateMethodCall.now(offset);
+    }
+
+    /**
+     * Returns a MethodCall representing the server-side `today()` RQL function.
+     * Returns midnight of the current UTC day on the server.
+     *
+     * @example
+     * session.query(Order).whereGreaterThanOrEqual("date", RavenQuery.today())
+     */
+    public static today(): RavenDateMethodCall {
+        return RavenDateMethodCall.today();
+    }
+}

--- a/src/Documents/Session/AbstractDocumentQuery.ts
+++ b/src/Documents/Session/AbstractDocumentQuery.ts
@@ -53,6 +53,7 @@ import { DynamicSpatialField } from "../Queries/Spatial/DynamicSpatialField.js";
 import { SpatialCriteria } from "../Queries/Spatial/SpatialCriteria.js";
 import { SessionBeforeQueryEventArgs } from "./SessionEvents.js";
 import { CmpXchg } from "./CmpXchg.js";
+import { RavenDateMethodCall } from "./RavenDateMethodCall.js";
 import { ValueCallback } from "../../Types/Callbacks.js";
 import { DocumentQueryCustomization } from "./DocumentQueryCustomization.js";
 import { FacetBase } from "../Queries/Facets/FacetBase.js";
@@ -195,6 +196,8 @@ export abstract class AbstractDocumentQuery<T extends object, TSelf extends Abst
     protected _disableEntitiesTracking: boolean;
 
     protected _disableCaching: boolean;
+
+    protected _queryTag: string | undefined;
 
     protected projectionBehavior: ProjectionBehavior;
 
@@ -961,8 +964,7 @@ export abstract class AbstractDocumentQuery<T extends object, TSelf extends Abst
             }
 
             let token: WhereToken;
-            const type = mc.constructor.name;
-            if (CmpXchg.name === type) {
+            if (mc instanceof CmpXchg) {
                 token = WhereToken.create(
                     op,
                     whereParams.fieldName,
@@ -973,8 +975,19 @@ export abstract class AbstractDocumentQuery<T extends object, TSelf extends Abst
                         property: mc.accessPath,
                         exact: whereParams.exact
                     }));
+            } else if (mc instanceof RavenDateMethodCall) {
+                token = WhereToken.create(
+                    op,
+                    whereParams.fieldName,
+                    null,
+                    new WhereOptions({
+                        methodType: mc.dateMethodType,
+                        parameters: args,
+                        property: mc.accessPath,
+                        exact: whereParams.exact
+                    }));
             } else {
-                throwError("InvalidArgumentException", `Unknown method ${type}.`);
+                throwError("InvalidArgumentException", `Unknown method ${mc.constructor.name}.`);
             }
 
             tokens.push(token);
@@ -1173,6 +1186,10 @@ export abstract class AbstractDocumentQuery<T extends object, TSelf extends Abst
         whereParams.value = value;
         whereParams.fieldName = fieldName;
 
+        if (this._ifValueIsMethod("GreaterThan", whereParams, tokens)) {
+            return;
+        }
+
         const parameter = this._addQueryParameter(
             value == null ? "*" : this._transformValue(whereParams, true));
 
@@ -1202,6 +1219,10 @@ export abstract class AbstractDocumentQuery<T extends object, TSelf extends Abst
         whereParams.value = value;
         whereParams.fieldName = fieldName;
 
+        if (this._ifValueIsMethod("GreaterThanOrEqual", whereParams, tokens)) {
+            return;
+        }
+
         const parameter = this._addQueryParameter(
             value == null ? "*" : this._transformValue(whereParams, true));
         const whereToken = WhereToken.create(
@@ -1222,6 +1243,10 @@ export abstract class AbstractDocumentQuery<T extends object, TSelf extends Abst
         whereParams.value = value;
         whereParams.fieldName = fieldName;
 
+        if (this._ifValueIsMethod("LessThan", whereParams, tokens)) {
+            return;
+        }
+
         const parameter = this._addQueryParameter(
             value == null ? "NULL" : this._transformValue(whereParams, true));
         const whereToken = WhereToken.create(
@@ -1240,6 +1265,10 @@ export abstract class AbstractDocumentQuery<T extends object, TSelf extends Abst
         const whereParams = new WhereParams();
         whereParams.value = value;
         whereParams.fieldName = fieldName;
+
+        if (this._ifValueIsMethod("LessThanOrEqual", whereParams, tokens)) {
+            return;
+        }
 
         const parameter = this._addQueryParameter(
             value == null ? "NULL" : this._transformValue(whereParams, true));
@@ -1521,6 +1550,7 @@ export abstract class AbstractDocumentQuery<T extends object, TSelf extends Abst
         indexQuery.disableCaching = this._disableCaching;
         indexQuery.projectionBehavior = this.projectionBehavior;
         indexQuery.skipStatistics = !this._queryStats.requestedByUser;
+        indexQuery.tag = this._queryTag;
         return indexQuery;
     }
 
@@ -1939,6 +1969,14 @@ export abstract class AbstractDocumentQuery<T extends object, TSelf extends Abst
 
     public _noCaching(): void {
         this._disableCaching = true;
+    }
+
+    public withTag(tag: string): this {
+        if (!tag || !tag.trim()) {
+            throwError("InvalidArgumentException", "Query tag cannot be null or whitespace.");
+        }
+        this._queryTag = tag;
+        return this;
     }
 
     public _includeTimings(timingsCallback: (timings: QueryTimings) => void): void {

--- a/src/Documents/Session/IAdvancedSessionOperations.ts
+++ b/src/Documents/Session/IAdvancedSessionOperations.ts
@@ -8,6 +8,7 @@ import { EntityToJson } from "./EntityToJson.js";
 import { IMetadataDictionary } from "./IMetadataDictionary.js";
 import { SessionEventsEmitter } from "./SessionEvents.js";
 import { TransactionMode } from "./TransactionMode.js";
+import { OptimisticConcurrencyMode } from "./SessionOptions.js";
 import { IEagerSessionOperations } from "./Operations/Lazy/IEagerSessionOperations.js";
 import { ILazySessionOperations } from "./Operations/Lazy/ILazySessionOperations.js";
 import { IAttachmentsSessionOperations } from "./IAttachmentsSessionOperations.js";
@@ -243,6 +244,13 @@ export interface IAdvancedDocumentSessionOperations extends SessionEventsEmitter
      * and raise ConcurrencyException
      */
     useOptimisticConcurrency: boolean;
+
+    /**
+     * The optimistic concurrency mode for this session.
+     * "None": no concurrency checks; "Writes": checks only modified documents;
+     * "WritesAndReads": checks all tracked documents.
+     */
+    optimisticConcurrencyMode: OptimisticConcurrencyMode;
 
     /**
      * Clears this instance.

--- a/src/Documents/Session/IQueryBase.ts
+++ b/src/Documents/Session/IQueryBase.ts
@@ -63,4 +63,11 @@ export interface IQueryBase<T, TSelf extends IQueryBase<T, TSelf>> extends Query
      * Add a named parameter to the query
      */
     addParameter(name: string, value: any): TSelf;
+
+    /**
+     * Attaches a user-defined tag that is forwarded to the server as the `tag`
+     * query-string parameter. Useful for identifying query sources in server logs
+     * and monitoring dashboards. The tag does not affect query results or caching.
+     */
+    withTag(tag: string): TSelf;
 }

--- a/src/Documents/Session/InMemoryDocumentSessionOperations.ts
+++ b/src/Documents/Session/InMemoryDocumentSessionOperations.ts
@@ -1538,7 +1538,7 @@ export abstract class InMemoryDocumentSessionOperations
                         Type: "BatchTrackChanges",
                         TrackedEntities: trackedEntities
                     })
-                } as ICommandData);
+                } satisfies ICommandData);
             }
         }
 

--- a/src/Documents/Session/InMemoryDocumentSessionOperations.ts
+++ b/src/Documents/Session/InMemoryDocumentSessionOperations.ts
@@ -52,7 +52,7 @@ import { CounterTracking } from "./CounterInternalTypes.js";
 import { CaseInsensitiveKeysMap } from "../../Primitives/CaseInsensitiveKeysMap.js";
 import { CaseInsensitiveStringSet } from "../../Primitives/CaseInsensitiveStringSet.js";
 import { DocumentStore } from "../DocumentStore.js";
-import { SessionOptions } from "./SessionOptions.js";
+import { SessionOptions, OptimisticConcurrencyMode } from "./SessionOptions.js";
 import { ClusterTransactionOperationsBase } from "./ClusterTransactionOperationsBase.js";
 import { BatchCommandResult } from "./Operations/BatchCommandResult.js";
 import { SessionOperationExecutor } from "../Operations/SessionOperationExecutor.js";
@@ -206,6 +206,8 @@ export abstract class InMemoryDocumentSessionOperations
 
     public useOptimisticConcurrency: boolean;
 
+    private _optimisticConcurrencyMode: OptimisticConcurrencyMode;
+
     protected _deferredCommands: ICommandData[] = [];
 
     // keys are produced with IdTypeAndName.keyFor() method
@@ -252,7 +254,9 @@ export abstract class InMemoryDocumentSessionOperations
 
         this.noTracking = options.noTracking;
 
-        this.useOptimisticConcurrency = this._requestExecutor.conventions.isUseOptimisticConcurrency();
+        this._optimisticConcurrencyMode = options.optimisticConcurrencyMode
+            ?? this._requestExecutor.conventions.optimisticConcurrencyMode;
+        this.useOptimisticConcurrency = this._optimisticConcurrencyMode !== "None";
         this.maxNumberOfRequestsPerSession = this._requestExecutor.conventions.maxNumberOfRequestsPerSession;
         this._generateEntityIdOnTheClient =
             new GenerateEntityIdOnTheClient(this._requestExecutor.conventions,
@@ -273,6 +277,15 @@ export abstract class InMemoryDocumentSessionOperations
                 indexOptions: null
             }
         }
+    }
+
+    public get optimisticConcurrencyMode(): OptimisticConcurrencyMode {
+        return this._optimisticConcurrencyMode;
+    }
+
+    public set optimisticConcurrencyMode(value: OptimisticConcurrencyMode) {
+        this._optimisticConcurrencyMode = value;
+        this.useOptimisticConcurrency = value !== "None";
     }
 
     protected abstract _generateId(entity: object): Promise<string>;
@@ -1503,6 +1516,29 @@ export abstract class InMemoryDocumentSessionOperations
         for (const deferredCommand of result.deferredCommands) {
             if (deferredCommand.onBeforeSaveChanges) {
                 deferredCommand.onBeforeSaveChanges(this);
+            }
+        }
+
+        // WritesAndReads: send change vectors for all tracked docs not already in batch
+        if (this._optimisticConcurrencyMode === "WritesAndReads") {
+            const trackedEntities: Record<string, string> = {};
+            const idsInBatch = new Set(result.sessionCommands.map(c => c.id?.toLowerCase()));
+            for (const [id, docInfo] of this.documentsById.entries()) {
+                if (!idsInBatch.has(id.toLowerCase()) && docInfo.changeVector) {
+                    trackedEntities[id] = docInfo.changeVector;
+                }
+            }
+            if (Object.keys(trackedEntities).length > 0) {
+                result.sessionCommands.push({
+                    id: null,
+                    name: null,
+                    changeVector: null,
+                    type: "BatchTrackChanges",
+                    serialize: (_conventions) => ({
+                        Type: "BatchTrackChanges",
+                        TrackedEntities: trackedEntities
+                    })
+                } as ICommandData);
             }
         }
 

--- a/src/Documents/Session/Operations/BatchOperation.ts
+++ b/src/Documents/Session/Operations/BatchOperation.ts
@@ -111,6 +111,9 @@ export class BatchOperation {
                     this._handleCompareExchangeDelete(batchResult);
                     break;
                 }
+                case "BatchTrackChanges": {
+                    break;
+                }
                 default: {
                     throwError("InvalidOperationException", `Command '${type}' is not supported.`);
                 }
@@ -170,7 +173,8 @@ export class BatchOperation {
                 case "TimeSeriesCopy": {
                     break;
                 }
-                case "BatchPATCH": {
+                case "BatchPATCH":
+                case "BatchTrackChanges": {
                     break;
                 }
                 default: {

--- a/src/Documents/Session/RavenDateMethodCall.ts
+++ b/src/Documents/Session/RavenDateMethodCall.ts
@@ -1,0 +1,27 @@
+import { MethodCall } from "./MethodCall.js";
+
+export type DateMethodType = "Now" | "Today";
+
+/**
+ * A MethodCall that represents a server-side date/time function (now() or today()).
+ * Pass instances returned by RavenQuery.now() / RavenQuery.today() to DocumentQuery
+ * where* methods to generate server-side RQL date expressions.
+ */
+export class RavenDateMethodCall extends MethodCall {
+    public readonly dateMethodType: DateMethodType;
+
+    private constructor(type: DateMethodType, args: string[]) {
+        super();
+        this.dateMethodType = type;
+        this.args = args;
+        this.accessPath = null;
+    }
+
+    public static now(offset?: string): RavenDateMethodCall {
+        return new RavenDateMethodCall("Now", offset ? [offset] : []);
+    }
+
+    public static today(): RavenDateMethodCall {
+        return new RavenDateMethodCall("Today", []);
+    }
+}

--- a/src/Documents/Session/SessionOptions.ts
+++ b/src/Documents/Session/SessionOptions.ts
@@ -2,6 +2,16 @@ import { RequestExecutor } from "../../Http/RequestExecutor.js";
 import { TransactionMode } from "./TransactionMode.js";
 import { ShardedBatchBehavior } from "./ShardedBatchBehavior.js";
 
+/**
+ * Controls how the session checks for concurrent document modifications.
+ *
+ * - "None": No checks. PUT/DELETE are sent without a change vector.
+ * - "Writes": Change vectors are sent only for modified/deleted documents.
+ * - "WritesAndReads": Change vectors are sent for ALL tracked documents
+ *   (including unmodified ones).
+ */
+export type OptimisticConcurrencyMode = "None" | "Writes" | "WritesAndReads";
+
 export interface SessionOptions {
     database?: string;
     requestExecutor?: RequestExecutor;
@@ -10,4 +20,9 @@ export interface SessionOptions {
     transactionMode?: TransactionMode;
     disableAtomicDocumentWritesInClusterWideTransaction?: boolean;
     shardedBatchBehavior?: ShardedBatchBehavior;
+    /**
+     * Override the optimistic concurrency mode for this session.
+     * When omitted, inherits from DocumentConventions.optimisticConcurrencyMode.
+     */
+    optimisticConcurrencyMode?: OptimisticConcurrencyMode;
 }

--- a/src/Documents/Session/Tokens/WhereToken.ts
+++ b/src/Documents/Session/Tokens/WhereToken.ts
@@ -7,7 +7,7 @@ import { WhereOperator } from "./WhereOperator.js";
 import { CONSTANTS } from "../../../Constants.js";
 import { IVectorOptions } from "../../Queries/VectorSearch/VectorSearchOptions.js";
 
-export type MethodsType = "CmpXchg";
+export type MethodsType = "CmpXchg" | "Now" | "Today";
 
 export class WhereMethodCall {
     public methodType: MethodsType;
@@ -142,6 +142,26 @@ export class WhereToken extends QueryToken {
     private _writeMethod(writer): boolean {
         if (this.options.method) {
             switch (this.options.method.methodType) {
+                case "Now": {
+                    if (this.options.method.parameters && this.options.method.parameters.length > 0) {
+                        writer.append("now($");
+                        writer.append(this.options.method.parameters[0]);
+                        writer.append(")");
+                    } else {
+                        writer.append("now()");
+                    }
+                    if (this.options.method.property) {
+                        writer.append(".").append(this.options.method.property);
+                    }
+                    return true;
+                }
+                case "Today": {
+                    writer.append("today()");
+                    if (this.options.method.property) {
+                        writer.append(".").append(this.options.method.property);
+                    }
+                    return true;
+                }
                 case "CmpXchg": {
                     writer.append("cmpxchg(");
                     break;

--- a/src/Http/RequestExecutor.ts
+++ b/src/Http/RequestExecutor.ts
@@ -148,7 +148,7 @@ export class RequestExecutor implements IDisposable {
 
     private _log: ILogger;
 
-    public static readonly CLIENT_VERSION = "7.2.1";
+    public static readonly CLIENT_VERSION = "7.2.2";
 
     private _updateDatabaseTopologySemaphore = new Semaphore();
     private _updateClientConfigurationSemaphore = new Semaphore();

--- a/src/index.ts
+++ b/src/index.ts
@@ -461,6 +461,7 @@ export * from "./Documents/Subscriptions/SubscriptionUpdateOptions.js";
 // SESSION
 export * from "./Documents/Session/AbstractDocumentQuery.js";
 export * from "./Documents/Session/CmpXchg.js";
+export * from "./Documents/Session/RavenDateMethodCall.js";
 export * from "./Documents/Session/DocumentInfo.js";
 export * from "./Documents/Session/DocumentQuery.js";
 export * from "./Documents/Session/DocumentQueryHelper.js";
@@ -626,6 +627,7 @@ export * from "./Types/Contracts.js";
 export * from "./Types/index.js";
 
 // QUERIES
+export * from "./Documents/Queries/RavenQuery.js";
 export * from "./Documents/Queries/IndexQuery.js";
 export * from "./Documents/Queries/GroupBy.js";
 export * from "./Documents/Queries/QueryOperator.js";

--- a/test/Documents/Queries/RavenQueryDateMethodsTest.ts
+++ b/test/Documents/Queries/RavenQueryDateMethodsTest.ts
@@ -1,0 +1,77 @@
+import assert from "node:assert";
+import { testContext, disposeTestDocumentStore } from "../../Utils/TestUtil.js";
+import { IDocumentStore, RavenQuery } from "../../../src/index.js";
+
+describe("RavenQuery.now() and RavenQuery.today()", function () {
+
+    let store: IDocumentStore;
+
+    beforeEach(async function () {
+        store = await testContext.getDocumentStore();
+    });
+
+    afterEach(async () =>
+        await disposeTestDocumentStore(store));
+
+    it("whereGreaterThan with now() generates server-side now() in RQL", function () {
+        const session = store.openSession();
+        const query = session.query({ collection: "orders" })
+            .whereGreaterThan("createdAt", RavenQuery.now());
+
+        const indexQuery = query.getIndexQuery();
+        assert.ok(indexQuery.query.includes("createdAt > now()"),
+            `Expected RQL to contain "createdAt > now()", got: ${indexQuery.query}`);
+    });
+
+    it("whereLessThan with now(offset) generates now($p0) with parameter", function () {
+        const session = store.openSession();
+        const query = session.query({ collection: "orders" })
+            .whereLessThan("expiresAt", RavenQuery.now("+30d"));
+
+        const indexQuery = query.getIndexQuery();
+        assert.ok(indexQuery.query.includes("expiresAt < now($p0)"),
+            `Expected RQL to contain "expiresAt < now($p0)", got: ${indexQuery.query}`);
+        assert.strictEqual(indexQuery.queryParameters["p0"], "+30d",
+            "Expected query parameter p0 to equal '+30d'");
+    });
+
+    it("whereGreaterThanOrEqual with today() generates server-side today() in RQL", function () {
+        const session = store.openSession();
+        const query = session.query({ collection: "orders" })
+            .whereGreaterThanOrEqual("date", RavenQuery.today());
+
+        const indexQuery = query.getIndexQuery();
+        assert.ok(indexQuery.query.includes("date >= today()"),
+            `Expected RQL to contain "date >= today()", got: ${indexQuery.query}`);
+    });
+
+    it("whereEquals with now() generates now() in RQL", function () {
+        const session = store.openSession();
+        const query = session.query({ collection: "orders" })
+            .whereEquals("snapshotAt", RavenQuery.now());
+
+        const indexQuery = query.getIndexQuery();
+        assert.ok(indexQuery.query.includes("snapshotAt = now()"),
+            `Expected RQL to contain "snapshotAt = now()", got: ${indexQuery.query}`);
+    });
+
+    it("now() without offset passes no query parameter", function () {
+        const session = store.openSession();
+        const query = session.query({ collection: "orders" })
+            .whereGreaterThan("createdAt", RavenQuery.now());
+
+        const indexQuery = query.getIndexQuery();
+        assert.strictEqual(Object.keys(indexQuery.queryParameters).length, 0,
+            "now() without offset should produce no query parameters");
+    });
+
+    it("today() passes no query parameter", function () {
+        const session = store.openSession();
+        const query = session.query({ collection: "orders" })
+            .whereGreaterThanOrEqual("date", RavenQuery.today());
+
+        const indexQuery = query.getIndexQuery();
+        assert.strictEqual(Object.keys(indexQuery.queryParameters).length, 0,
+            "today() should produce no query parameters");
+    });
+});

--- a/test/Documents/Queries/WithTagTest.ts
+++ b/test/Documents/Queries/WithTagTest.ts
@@ -1,0 +1,53 @@
+import { IDocumentStore } from "../../../src/index.js";
+import { disposeTestDocumentStore, testContext } from "../../Utils/TestUtil.js";
+import { assertThat, assertThrows } from "../../Utils/AssertExtensions.js";
+
+describe("WithTagTest", function () {
+
+    let store: IDocumentStore;
+
+    beforeEach(async function () {
+        store = await testContext.getDocumentStore();
+    });
+
+    afterEach(async () => await disposeTestDocumentStore(store));
+
+    it("withTag_setsTagOnIndexQuery", async () => {
+        const session = store.openSession();
+        const indexQuery = session.query({ collection: "orders" })
+            .withTag("my-tag")
+            .getIndexQuery();
+
+        assertThat(indexQuery.tag).isEqualTo("my-tag");
+    });
+
+    it("withTag_withNoTag_tagIsUndefined", async () => {
+        const session = store.openSession();
+        const indexQuery = session.query({ collection: "orders" })
+            .getIndexQuery();
+
+        assertThat(indexQuery.tag).isUndefined();
+    });
+
+    it("withTag_isChainable", async () => {
+        const session = store.openSession();
+        const query = session.query({ collection: "orders" });
+        const returned = query.withTag("x");
+
+        // withTag returns the same query instance
+        assertThat(returned).isSameAs(query);
+        assertThat(returned.getIndexQuery().tag).isEqualTo("x");
+    });
+
+    it("withTag_emptyOrWhitespace_throws", async () => {
+        const session = store.openSession();
+        const query = session.query({ collection: "orders" });
+
+        await assertThrows(() => query.withTag(""), err => {
+            assertThat(err.message).contains("Query tag cannot be null or whitespace");
+        });
+        await assertThrows(() => query.withTag("   "), err => {
+            assertThat(err.message).contains("Query tag cannot be null or whitespace");
+        });
+    });
+});

--- a/test/Documents/Session/OptimisticConcurrencyModeTest.ts
+++ b/test/Documents/Session/OptimisticConcurrencyModeTest.ts
@@ -1,0 +1,100 @@
+import { DocumentConventions, IDocumentStore, SessionOptions } from "../../../src/index.js";
+import { disposeTestDocumentStore, testContext } from "../../Utils/TestUtil.js";
+import { assertThat, assertThrows } from "../../Utils/AssertExtensions.js";
+
+describe("OptimisticConcurrencyModeTest", function () {
+
+    let store: IDocumentStore;
+
+    beforeEach(async function () {
+        store = await testContext.getDocumentStore();
+    });
+
+    afterEach(async () => await disposeTestDocumentStore(store));
+
+    it("modeSetter_updatesUseOptimisticConcurrencyField_whenCalledAfterSessionOptions", async () => {
+        const session = store.openSession({ optimisticConcurrencyMode: "WritesAndReads" } as SessionOptions);
+        // mode setter also updates the boolean field
+        session.advanced.optimisticConcurrencyMode = "None";
+        assertThat(session.advanced.useOptimisticConcurrency).isFalse();
+        assertThat(session.advanced.optimisticConcurrencyMode).isEqualTo("None");
+    });
+
+    it("modeSetter_updatesUseOptimisticConcurrencyField", async () => {
+        const session = store.openSession();
+        assertThat(session.advanced.useOptimisticConcurrency).isFalse();
+
+        // mode setter keeps both fields in sync
+        session.advanced.optimisticConcurrencyMode = "WritesAndReads";
+        assertThat(session.advanced.optimisticConcurrencyMode).isEqualTo("WritesAndReads");
+        assertThat(session.advanced.useOptimisticConcurrency).isTrue();
+
+        session.advanced.optimisticConcurrencyMode = "None";
+        assertThat(session.advanced.optimisticConcurrencyMode).isEqualTo("None");
+        assertThat(session.advanced.useOptimisticConcurrency).isFalse();
+    });
+
+    it("plainFieldWrite_doesNotUpdateMode", async () => {
+        const session = store.openSession({ optimisticConcurrencyMode: "Writes" } as SessionOptions);
+        assertThat(session.advanced.optimisticConcurrencyMode).isEqualTo("Writes");
+        assertThat(session.advanced.useOptimisticConcurrency).isTrue();
+
+        // direct field write only updates the boolean — mode is unchanged
+        session.advanced.useOptimisticConcurrency = false;
+        assertThat(session.advanced.useOptimisticConcurrency).isFalse();
+        assertThat(session.advanced.optimisticConcurrencyMode).isEqualTo("Writes");
+    });
+
+    it("canConfigureOptimisticConcurrencyModeForSessions", async () => {
+        {
+            const session = store.openSession({ optimisticConcurrencyMode: "WritesAndReads" } as SessionOptions);
+            assertThat(session.advanced.optimisticConcurrencyMode).isEqualTo("WritesAndReads");
+        }
+        {
+            const session = store.openSession({ optimisticConcurrencyMode: "Writes" } as SessionOptions);
+            assertThat(session.advanced.optimisticConcurrencyMode).isEqualTo("Writes");
+        }
+        {
+            const session = store.openSession({ optimisticConcurrencyMode: "None" } as SessionOptions);
+            assertThat(session.advanced.optimisticConcurrencyMode).isEqualTo("None");
+        }
+    });
+
+    it("conventions_mutualExclusion_modeFirst_thenUseOptimistic_shouldThrow", async () => {
+        const conventions = new DocumentConventions();
+        conventions.optimisticConcurrencyMode = "WritesAndReads";
+
+        await assertThrows(() => {
+            conventions.useOptimisticConcurrency = true;
+        }, err => {
+            assertThat(err.message).contains("useOptimisticConcurrency");
+        });
+    });
+
+    it("conventions_mutualExclusion_useOptimisticFirst_thenMode_shouldThrow", async () => {
+        const conventions = new DocumentConventions();
+        conventions.useOptimisticConcurrency = true;
+
+        await assertThrows(() => {
+            conventions.optimisticConcurrencyMode = "Writes";
+        }, err => {
+            assertThat(err.message).contains("optimisticConcurrencyMode");
+        });
+    });
+
+    it("conventions_setWritesAndReads_roundTrips", async () => {
+        const conventions = new DocumentConventions();
+        conventions.optimisticConcurrencyMode = "WritesAndReads";
+        assertThat(conventions.optimisticConcurrencyMode).isEqualTo("WritesAndReads");
+    });
+
+    it("sessionOptionsMode_doesNotPreventUseOptimisticConcurrencyChange", async () => {
+        const session = store.openSession({ optimisticConcurrencyMode: "WritesAndReads" } as SessionOptions);
+        assertThat(session.advanced.optimisticConcurrencyMode).isEqualTo("WritesAndReads");
+
+        session.advanced.useOptimisticConcurrency = false;
+        // plain field write — no guard on session; mode field is not updated
+        assertThat(session.advanced.useOptimisticConcurrency).isFalse();
+        assertThat(session.advanced.optimisticConcurrencyMode).isEqualTo("WritesAndReads");
+    });
+});

--- a/test/Ported/Attachments/BulkInsertRemoteAttachmentsTests.ts
+++ b/test/Ported/Attachments/BulkInsertRemoteAttachmentsTests.ts
@@ -17,7 +17,7 @@ interface Order {
     shipVia?: string;
 }
 
-(RavenTestContext.isRavenDbServerVersion("7.2") ? describe : describe.skip)("BulkInsertRemoteAttachmentsTests", () => {
+(RavenTestContext.isPullRequest ? describe.skip : describe)("BulkInsertRemoteAttachmentsTests", () => {
     let store: IDocumentStore;
 
     beforeEach(async () => {

--- a/test/Ported/Attachments/DocumentSessionRemoteAttachmentsTests.ts
+++ b/test/Ported/Attachments/DocumentSessionRemoteAttachmentsTests.ts
@@ -20,7 +20,7 @@ interface User {
     email?: string;
 }
 
-(RavenTestContext.isRavenDbServerVersion("7.2") ? describe : describe.skip)("DocumentSessionRemoteAttachmentsTests", function () {
+(RavenTestContext.isPullRequest ? describe.skip : describe)("DocumentSessionRemoteAttachmentsTests", function () {
     let store: IDocumentStore;
 
     beforeEach(async function () {

--- a/test/Ported/Attachments/RemoteAttachmentsBasicTests.ts
+++ b/test/Ported/Attachments/RemoteAttachmentsBasicTests.ts
@@ -10,7 +10,7 @@ import {
 } from "../../../src/index.js";
 import { assertThat } from "../../Utils/AssertExtensions.js";
 
-(RavenTestContext.isRavenDbServerVersion("7.2") ? describe : describe.skip)("RemoteAttachmentsBasicTests", function () {
+(RavenTestContext.isPullRequest ? describe.skip : describe)("RemoteAttachmentsBasicTests", function () {
     let store: IDocumentStore;
 
     beforeEach(async function () {

--- a/test/Ported/Documents/Operations/AiConversationTest.ts
+++ b/test/Ported/Documents/Operations/AiConversationTest.ts
@@ -4,7 +4,9 @@ import {assertThat, assertThrows} from "../../../Utils/AssertExtensions.js";
 
 import {AiHandleErrorStrategy} from "../../../../src/Documents/Operations/AI/AiConversation.js";
 import {AiUsage} from "../../../../src/Documents/Operations/AI/Agents/AiUsage.js";
-import { AiConversationCreationOptions } from "../../../../src/Documents/Operations/AI/Agents/AiConversationCreationOptions.js";
+import {
+    AiConversationCreationOptions
+} from "../../../../src/Documents/Operations/AI/Agents/AiConversationCreationOptions.js";
 
 (RavenTestContext.isRavenDbServerVersion("7.1") ? describe : describe.skip)("AiConversationTest", function () {
     let store: IDocumentStore;
@@ -247,7 +249,7 @@ import { AiConversationCreationOptions } from "../../../../src/Documents/Operati
         const testRequest = {
             name: "action-with-request",
             toolId: "tool-102",
-            arguments: JSON.stringify({"data":"metadata-test"})
+            arguments: JSON.stringify({"data": "metadata-test"})
         };
 
         await invocation(testRequest);
@@ -577,7 +579,7 @@ import { AiConversationCreationOptions } from "../../../../src/Documents/Operati
     });
 
     it("addAttachment_validatesName", async () => {
-        const conv = store.ai.conversation("agents/1-A", "conversations/att1|") as any;
+        const conv = store.ai.conversation("agents/1-A", "conversations/att1|");
         const buf = Buffer.from("data");
 
         await assertThrows(() => Promise.resolve(conv.addAttachment("", buf, "image/png")), err => {
@@ -586,7 +588,7 @@ import { AiConversationCreationOptions } from "../../../../src/Documents/Operati
     });
 
     it("addAttachment_validatesStream", async () => {
-        const conv = store.ai.conversation("agents/1-A", "conversations/att2|") as any;
+        const conv = store.ai.conversation("agents/1-A", "conversations/att2|");
 
         await assertThrows(() => Promise.resolve(conv.addAttachment("file.png", null, "image/png")), err => {
             assertThat(err.message).contains("stream cannot be null");
@@ -594,7 +596,7 @@ import { AiConversationCreationOptions } from "../../../../src/Documents/Operati
     });
 
     it("addAttachment_validatesContentType", async () => {
-        const conv = store.ai.conversation("agents/1-A", "conversations/att3|") as any;
+        const conv = store.ai.conversation("agents/1-A", "conversations/att3|");
         const buf = Buffer.from("data");
 
         await assertThrows(() => Promise.resolve(conv.addAttachment("file.png", buf, "")), err => {
@@ -603,7 +605,7 @@ import { AiConversationCreationOptions } from "../../../../src/Documents/Operati
     });
 
     it("copyAttachmentFrom_validatesSourceDocumentId", async () => {
-        const conv = store.ai.conversation("agents/1-A", "conversations/att4|") as any;
+        const conv = store.ai.conversation("agents/1-A", "conversations/att4|");
 
         await assertThrows(() => Promise.resolve(conv.copyAttachmentFrom("", "file.png")), err => {
             assertThat(err.message).contains("sourceDocumentId cannot be empty");
@@ -611,7 +613,7 @@ import { AiConversationCreationOptions } from "../../../../src/Documents/Operati
     });
 
     it("copyAttachmentFrom_validatesFileName", async () => {
-        const conv = store.ai.conversation("agents/1-A", "conversations/att5|") as any;
+        const conv = store.ai.conversation("agents/1-A", "conversations/att5|");
 
         await assertThrows(() => Promise.resolve(conv.copyAttachmentFrom("docs/1", "")), err => {
             assertThat(err.message).contains("fileName cannot be empty");
@@ -627,7 +629,7 @@ import { AiConversationCreationOptions } from "../../../../src/Documents/Operati
 
     it("addParameter_withSendToModel_false_storesFlag", () => {
         const options = new AiConversationCreationOptions();
-        options.addParameter("key", "value", { sendToModel: false });
+        options.addParameter("key", "value", {sendToModel: false});
 
         assertThat(options.parameters["key"].sendToModel).isFalse();
         assertThat(options.parameters["key"].value).isEqualTo("value");
@@ -642,7 +644,7 @@ import { AiConversationCreationOptions } from "../../../../src/Documents/Operati
     });
 
     it("legacyConstructor_withPlainRecord_wrapsValues", () => {
-        const options = new AiConversationCreationOptions({ userId: "users/1" } as any);
+        const options = new AiConversationCreationOptions({userId: "users/1"});
 
         assertThat(options.parameters["userId"].value).isEqualTo("users/1");
         assertThat(options.parameters["userId"].sendToModel).isTrue();
@@ -650,8 +652,8 @@ import { AiConversationCreationOptions } from "../../../../src/Documents/Operati
 
     it("legacyConstructor_withStructuredRecord_passesThrough", () => {
         const options = new AiConversationCreationOptions({
-            userId: { value: "users/1", sendToModel: false }
-        } as any);
+            userId: {value: "users/1", sendToModel: false}
+        });
 
         assertThat(options.parameters["userId"].value).isEqualTo("users/1");
         assertThat(options.parameters["userId"].sendToModel).isFalse();

--- a/test/Ported/Documents/Operations/AiConversationTest.ts
+++ b/test/Ported/Documents/Operations/AiConversationTest.ts
@@ -4,6 +4,7 @@ import {assertThat, assertThrows} from "../../../Utils/AssertExtensions.js";
 
 import {AiHandleErrorStrategy} from "../../../../src/Documents/Operations/AI/AiConversation.js";
 import {AiUsage} from "../../../../src/Documents/Operations/AI/Agents/AiUsage.js";
+import { AiConversationCreationOptions } from "../../../../src/Documents/Operations/AI/Agents/AiConversationCreationOptions.js";
 
 (RavenTestContext.isRavenDbServerVersion("7.1") ? describe : describe.skip)("AiConversationTest", function () {
     let store: IDocumentStore;
@@ -573,5 +574,86 @@ import {AiUsage} from "../../../../src/Documents/Operations/AI/Agents/AiUsage.js
 
         assertThat(diff.reasoningTokens).isSameAs(40);
         assertThat(diff.completionTokens).isSameAs(100);
+    });
+
+    it("addAttachment_validatesName", async () => {
+        const conv = store.ai.conversation("agents/1-A", "conversations/att1|") as any;
+        const buf = Buffer.from("data");
+
+        await assertThrows(() => Promise.resolve(conv.addAttachment("", buf, "image/png")), err => {
+            assertThat(err.message).contains("name cannot be empty");
+        });
+    });
+
+    it("addAttachment_validatesStream", async () => {
+        const conv = store.ai.conversation("agents/1-A", "conversations/att2|") as any;
+
+        await assertThrows(() => Promise.resolve(conv.addAttachment("file.png", null, "image/png")), err => {
+            assertThat(err.message).contains("stream cannot be null");
+        });
+    });
+
+    it("addAttachment_validatesContentType", async () => {
+        const conv = store.ai.conversation("agents/1-A", "conversations/att3|") as any;
+        const buf = Buffer.from("data");
+
+        await assertThrows(() => Promise.resolve(conv.addAttachment("file.png", buf, "")), err => {
+            assertThat(err.message).contains("contentType cannot be empty");
+        });
+    });
+
+    it("copyAttachmentFrom_validatesSourceDocumentId", async () => {
+        const conv = store.ai.conversation("agents/1-A", "conversations/att4|") as any;
+
+        await assertThrows(() => Promise.resolve(conv.copyAttachmentFrom("", "file.png")), err => {
+            assertThat(err.message).contains("sourceDocumentId cannot be empty");
+        });
+    });
+
+    it("copyAttachmentFrom_validatesFileName", async () => {
+        const conv = store.ai.conversation("agents/1-A", "conversations/att5|") as any;
+
+        await assertThrows(() => Promise.resolve(conv.copyAttachmentFrom("docs/1", "")), err => {
+            assertThat(err.message).contains("fileName cannot be empty");
+        });
+    });
+
+    it("addParameter_fluent_returnsOptions", () => {
+        const options = new AiConversationCreationOptions();
+        const returned = options.addParameter("key", "value");
+
+        assertThat(returned).isSameAs(options);
+    });
+
+    it("addParameter_withSendToModel_false_storesFlag", () => {
+        const options = new AiConversationCreationOptions();
+        options.addParameter("key", "value", { sendToModel: false });
+
+        assertThat(options.parameters["key"].sendToModel).isFalse();
+        assertThat(options.parameters["key"].value).isEqualTo("value");
+    });
+
+    it("addParameter_withSendToModel_default_isTrue", () => {
+        const options = new AiConversationCreationOptions();
+        options.addParameter("key", "value");
+
+        assertThat(options.parameters["key"].sendToModel).isTrue();
+        assertThat(options.parameters["key"].value).isEqualTo("value");
+    });
+
+    it("legacyConstructor_withPlainRecord_wrapsValues", () => {
+        const options = new AiConversationCreationOptions({ userId: "users/1" } as any);
+
+        assertThat(options.parameters["userId"].value).isEqualTo("users/1");
+        assertThat(options.parameters["userId"].sendToModel).isTrue();
+    });
+
+    it("legacyConstructor_withStructuredRecord_passesThrough", () => {
+        const options = new AiConversationCreationOptions({
+            userId: { value: "users/1", sendToModel: false }
+        } as any);
+
+        assertThat(options.parameters["userId"].value).isEqualTo("users/1");
+        assertThat(options.parameters["userId"].sendToModel).isFalse();
     });
 });

--- a/test/Ported/Documents/Operations/AiStreamingTest.ts
+++ b/test/Ported/Documents/Operations/AiStreamingTest.ts
@@ -25,6 +25,7 @@ import {RavenTestContext} from "../../../Utils/TestUtil.js";
             [],
             undefined,
             undefined,
+            undefined,
             "message",
             streamCallback
         );
@@ -87,6 +88,7 @@ import {RavenTestContext} from "../../../Utils/TestUtil.js";
             "Test",
             [],
             [],
+            undefined,
             undefined,
             undefined,
             "text",

--- a/test/Ported/SchemaValidationBasicTests.ts
+++ b/test/Ported/SchemaValidationBasicTests.ts
@@ -8,7 +8,7 @@ import {
 import {assertThat} from "../Utils/AssertExtensions.js";
 
 
-(RavenTestContext.isRavenDbServerVersion("7.2") ? describe : describe.skip)("SchemaValidationBasicTests", () => {
+(RavenTestContext.isPullRequest ? describe.skip : describe)("SchemaValidationBasicTests", () => {
     let store: IDocumentStore;
 
     beforeEach(async () => {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RDBC-1061

### Additional description

- **AiAgentParameter** gains policy and type fields
- **AiAgentConfiguration** supports subAgents
- **AiConversationCreationOptions** is now a class with fluent addParameter() and
  maxModelIterationsPerCall 
- **OpenAiSettings** adds reasoningEffort, seed, enablePromptCache; AzureOpenAiSettings adds
  enablePromptCache
 - **query.withTag()** for server-side routing/diagnostics
 - **RavenQuery.now() / RavenQuery.today()** for server-side date evaluation in queries
 - **OptimisticConcurrencyMode** - new "WritesAndReads" mode tracks read documents for concurrency
  checks
 - **AiConversation.addAttachment() / copyAttachmentFrom()** - file attachment support in
  conversation turns

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [ ] Low
- [x] Moderate
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [x] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`)
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
