### PR TITLE
RDBC-1082 Fix CustomEntityName test for RavenDB-25738 control-char guard

### DIFF
--- a/test/Ported/CustomEntityName.ts
+++ b/test/Ported/CustomEntityName.ts
@@ -4,18 +4,12 @@ import { assertThat } from "../Utils/AssertExtensions.js";
 
 describe("CustomEntityName", function () {
 
-    const getChars = () => {
-        const basicChars = [...new Array(31).keys()].map(x => {
-            return String.fromCodePoint(x + 1);
-        });
-
-        const extraChars = [ "a", "-", "'", "\"", "\\", "\b", "\f", "\n", "\r", "\t" ];
-
-        return [...basicChars, ...extraChars];
-    };
-
     const getCharactersToTestWithSpecial = () => {
-        const basicChars = getChars();
+        // RavenDB-25738: the server rejects control characters in a collection name
+        // unconditionally (the SupportedFeatures opt-out only relaxes document IDs).
+        // These chars are therefore everything the server allows in a collection name
+        // and match the C# CustomEntityName test's GetChars().
+        const basicChars = [ "a", "-", "'", "\"", "\\", "\b", "\f", "\n", "\r", "\t" ];
         const specialChars = [ "Ā", "Ȁ", "Ѐ", "Ԁ", "؀", "܀", "ऀ", "ਅ", "ଈ", "అ", "ഊ", "ข", "ဉ", "ᄍ", "ሎ", "ጇ", "ᐌ", "ᔎ", "ᘀ", "ᜩ", "ᢹ", "ᥤ", "ᨇ" ];
         return [...basicChars, ...specialChars];
     }
@@ -29,11 +23,6 @@ describe("CustomEntityName", function () {
 
         const store = await testContext.getDocumentStore();
         try {
-
-            if (c.charCodeAt(0) >= 14 && c.charCodeAt(0) <= 31) {
-                return;
-            }
-
             {
                 const session = store.openSession();
                 const car = new Car();


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RDBC-1082

### Additional description

[RavenDB-25738](https://issues.hibernatingrhinos.com/issue/RavenDB-25738) The server now rejects control characters in collection names unconditionally. Align basicChars with the C# CustomEntityName test (no control chars) and drop the obsolete 14-31 skip.


### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low
- [ ] Moderate
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`)
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
