### PR TITLE
RDBC-1083: Cloudflare workers enabled

### DIFF
--- a/.github/workflows/Cloudflare.yml
+++ b/.github/workflows/Cloudflare.yml
@@ -1,0 +1,118 @@
+name: tests/cloudflare
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches: [ v7.2 ]
+  pull_request:
+    branches: [ v7.2 ]
+  schedule:
+    - cron: '0 10 * * *'
+  workflow_dispatch:
+
+jobs:
+  # Boots the client in real workerd across the bundlers used to deploy to
+  # Cloudflare, and asserts it loads (guards the RDBC-1083 load/interop family).
+  # No RavenDB server needed.
+  load:
+    name: load (${{ matrix.dir }}, node ${{ matrix.node-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [20.x, 22.x]
+        dir:
+          - test/cloudflare-worker   # wrangler / esbuild
+          - test/cloudflare-vite     # Vite / Rollup
+          - test/cloudflare-nitro    # Nitro / Rollup + unenv (TanStack Start-style)
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      # `npm ci` runs `prepare` (tshy build + addWorkerCondition.mjs): builds dist/
+      # and injects the workerd/worker export conditions the bundlers resolve.
+      - name: Build the client
+        run: npm ci
+
+      - name: Install example deps (resolves ravendb from repo root)
+        working-directory: ${{ matrix.dir }}
+        run: npm install
+
+      - name: Build the worker (if the bundler needs a build step)
+        working-directory: ${{ matrix.dir }}
+        run: npm run build --if-present
+
+      - name: Load smoke test in workerd
+        working-directory: ${{ matrix.dir }}
+        env:
+          WRANGLER_SEND_METRICS: "false"
+        run: npm run smoke
+
+  # Full data-path end-to-end: a Nitro (TanStack Start-style) worker running in
+  # workerd performs a real store + load against an (insecure) RavenDB server.
+  # Exercises the request + response-stream pipeline that node:stream provides.
+  e2e:
+    name: e2e (nitro -> RavenDB, node ${{ matrix.node-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [22.x]
+        serverVersion: ["7.2"]
+    env:
+      RAVEN_License: ${{ secrets.RAVEN_LICENSE }}
+      RAVENDB_URL: http://127.0.0.1:8080
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Download RavenDB Server
+        run: wget -O RavenDB.tar.bz2 "https://hibernatingrhinos.com/downloads/RavenDB%20for%20Linux%20x64/latest?buildType=nightly&version=${{ matrix.serverVersion }}"
+
+      - name: Extract RavenDB Server
+        run: tar xjf RavenDB.tar.bz2
+
+      - name: Start RavenDB (insecure, in-memory)
+        run: |
+          chmod +x ./RavenDB/Server/Raven.Server
+          ./RavenDB/Server/Raven.Server \
+            --non-interactive \
+            --ServerUrl=http://127.0.0.1:8080 \
+            --Setup.Mode=None \
+            --Security.UnsecuredAccessAllowed=PublicNetwork \
+            --License.Eula.Accepted=true \
+            --RunInMemory=true &
+          for i in $(seq 1 60); do
+            if curl -sf http://127.0.0.1:8080/build/version > /dev/null; then echo "RavenDB up"; exit 0; fi
+            sleep 1
+          done
+          echo "RavenDB did not start in time" && exit 1
+
+      - name: Build the client
+        run: npm ci
+
+      - name: Install example deps
+        working-directory: test/cloudflare-nitro
+        run: npm install
+
+      - name: Build the Nitro worker
+        working-directory: test/cloudflare-nitro
+        run: npm run build
+
+      - name: End-to-end store/load in workerd against RavenDB
+        working-directory: test/cloudflare-nitro
+        env:
+          WRANGLER_SEND_METRICS: "false"
+        run: npm run e2e

--- a/.github/workflows/Cloudflare.yml
+++ b/.github/workflows/Cloudflare.yml
@@ -22,7 +22,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20.x, 22.x]
+        # Node 22+ : the Vite 6 example config loader needs node:module.registerHooks
+        # (absent in Node 20), and GitHub is deprecating Node 20 on runners.
+        node-version: [22.x, 24.x]
         dir:
           - test/cloudflare-worker   # wrangler / esbuild
           - test/cloudflare-vite     # Vite / Rollup

--- a/.mocharc.jsonc
+++ b/.mocharc.jsonc
@@ -2,6 +2,13 @@
   "slow": 1000,
   "timeout": 40000,
 
+  // The test/cloudflare-* dirs are self-contained Cloudflare example projects
+  // (with their own deps); they must not be picked up by the "test/**/*.ts"
+  // runner or it fails to resolve their bundler deps (e.g. nitropack).
+  "ignore": [
+    "test/cloudflare-*/**"
+  ],
+
   "node-option": [
     "import=./register.js"
   ]

--- a/README.md
+++ b/README.md
@@ -2321,6 +2321,91 @@ let store = new DocumentStore('url', 'databaseName', authOptions);
 store.initialize();
 ```
 
+## Cloudflare Workers
+
+The client runs on [Cloudflare Workers](https://developers.cloudflare.com/workers/).
+Three Workers-specific things to know:
+
+**1. Enable the Node.js compatibility flag.** The client uses a few Node built-ins
+(`node:stream`, `node:events`, …). Add `nodejs_compat` to your `wrangler.toml`:
+
+```toml
+compatibility_flags = ["nodejs_compat"]
+compatibility_date = "2024-09-23" # or newer
+```
+
+The package ships `workerd` and `worker` export conditions, so wrangler/esbuild and
+framework bundlers (OpenNext, Vite, …) automatically resolve the Workers-compatible
+ESM build — you do not need any bundler aliases or `serverExternalPackages` tweaks.
+
+**2. On frameworks that use Nitro (TanStack Start, Nuxt, Nitro), make sure Node
+built-ins resolve to the runtime — not to `unenv` stubs.** Nitro polyfills Node with
+[`unenv`](https://github.com/unjs/unenv), whose `node:stream` is incomplete. If Node.js
+compatibility is not enabled, the first request fails and the client raises a descriptive
+error (the underlying `[unenv] PassThrough is not implemented yet!` is kept as its cause):
+
+```
+InvalidOperationException: The RavenDB client requires a working node:stream on Cloudflare
+Workers, but this runtime provided an incomplete polyfill. Enable Node.js compatibility by
+adding compatibility_flags = ["nodejs_compat"] (and a recent compatibility_date) to your
+wrangler configuration. ...
+```
+
+The fix is to enable Cloudflare's real Node.js compatibility so Nitro defers `node:`
+built-ins to `workerd` instead of stubbing them. Provide a `wrangler.toml` (that Nitro
+reads at build time) with the flag, and set a recent `compatibilityDate` in your Nitro
+/ TanStack Start config:
+
+```toml
+# wrangler.toml (read by Nitro at build time)
+compatibility_date = "2024-09-23" # or newer
+compatibility_flags = ["nodejs_compat"]
+```
+
+You can confirm it worked: the built bundle no longer inlines `unenv` `node:*` stubs,
+and requests stream responses successfully.
+
+**3. mTLS is done with a Cloudflare `mtls_certificate` binding, not `authOptions`.**
+Workers has no Node `https` agent, so X.509 client-certificate authentication cannot
+use the usual `authOptions` certificate. Instead, upload the client certificate to
+Cloudflare and hand the client a `fetch` bound to that certificate via
+`conventions.customFetch`:
+
+```bash
+# Upload the RavenDB client certificate (PEM: cert + key) once:
+npx wrangler mtls-certificate upload --cert client.crt --key client.key --name ravendb
+```
+
+```toml
+# wrangler.toml — bind the uploaded certificate
+mtls_certificates = [
+  { binding = "RAVENDB_CERT", certificate_id = "<id printed by the upload command>" }
+]
+```
+
+```javascript
+import { DocumentStore } from "ravendb";
+
+export default {
+  async fetch(request, env) {
+    // `env` (and therefore the binding) is only available inside the handler.
+    const store = new DocumentStore("https://a.free.example.ravendb.cloud", "MyDatabase");
+
+    // Route every request through the mTLS binding's fetch. Because the binding
+    // presents the client certificate at the TLS layer, do NOT also pass authOptions.
+    store.conventions.customFetch = env.RAVENDB_CERT.fetch.bind(env.RAVENDB_CERT);
+    store.initialize();
+
+    const session = store.openSession();
+    const doc = await session.load("users/1");
+    return Response.json(doc ?? null);
+  }
+};
+```
+
+A minimal, runnable load check lives in [`test/cloudflare-worker`](./test/cloudflare-worker)
+and runs in CI.
+
 ## Building
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -13,6 +13,14 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "workerd": {
+        "types": "./dist/esm/index.d.ts",
+        "default": "./dist/esm/index.js"
+      },
+      "worker": {
+        "types": "./dist/esm/index.d.ts",
+        "default": "./dist/esm/index.js"
+      },
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
@@ -25,7 +33,7 @@
   },
   "scripts": {
     "test": "mocha \"test/**/*.ts\"",
-    "prepare": "tshy",
+    "prepare": "tshy && node scripts/addWorkerCondition.mjs",
     "watch": "tsc --watch",
     "lint": "eslint {src,test}/**/*.ts",
     "check-exports": "node ./scripts/reportMissingTopLevelExports.js",

--- a/scripts/addWorkerCondition.mjs
+++ b/scripts/addWorkerCondition.mjs
@@ -1,0 +1,63 @@
+// Post-build step for `prepare` (runs after tshy).
+//
+// tshy regenerates package.json "exports" on every build with only the
+// "import" (ESM) and "require" (CommonJS) conditions. Cloudflare Workers and
+// other edge bundlers (wrangler/esbuild, OpenNext, Vite) resolve the "workerd"
+// and "worker" export conditions. Without them a bundler may fall back to the
+// CommonJS `require()` chain, which is exactly the resolution path that breaks
+// under an ESM bundler (RDBC-1083: "Class extends value [object Module]").
+//
+// We therefore inject "workerd" and "worker" conditions that always point at
+// the ESM build, ordered BEFORE "import"/"require" so they win on Workers.
+// The script is idempotent: it strips any conditions it previously added and
+// re-inserts them, so repeated `prepare` runs converge to the same result.
+import { readFileSync, writeFileSync } from "node:fs";
+
+const PKG_PATH = new URL("../package.json", import.meta.url);
+const WORKER_CONDITIONS = ["workerd", "worker"];
+
+const pkg = JSON.parse(readFileSync(PKG_PATH, "utf8"));
+
+if (!pkg.exports || typeof pkg.exports !== "object") {
+    throw new Error("addWorkerCondition: package.json has no 'exports' map (did tshy run first?)");
+}
+
+let patched = 0;
+
+for (const [subpath, entry] of Object.entries(pkg.exports)) {
+    // Only conditional-object entries (e.g. "." -> { import, require }); skip
+    // plain string entries like "./package.json".
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+        continue;
+    }
+
+    // The ESM target is whatever the "import" condition resolves to.
+    const esmTarget = entry.import;
+    if (!esmTarget) {
+        continue;
+    }
+
+    // Rebuild the entry so the worker conditions come first. Drop any previously
+    // injected worker conditions to stay idempotent.
+    const rest = {};
+    for (const [condition, value] of Object.entries(entry)) {
+        if (!WORKER_CONDITIONS.includes(condition)) {
+            rest[condition] = value;
+        }
+    }
+
+    const rebuilt = {};
+    for (const condition of WORKER_CONDITIONS) {
+        // Deep-clone the ESM target so each condition is an independent value.
+        rebuilt[condition] = JSON.parse(JSON.stringify(esmTarget));
+    }
+    Object.assign(rebuilt, rest);
+
+    pkg.exports[subpath] = rebuilt;
+    patched++;
+}
+
+writeFileSync(PKG_PATH, JSON.stringify(pkg, null, 2) + "\n");
+// Log to stderr so it never pollutes stdout of `npm pack --silent` (which is
+// parsed to obtain the tarball filename in CI).
+console.error(`addWorkerCondition: injected ${WORKER_CONDITIONS.join("/")} into ${patched} export(s).`);

--- a/scripts/addWorkerCondition.mjs
+++ b/scripts/addWorkerCondition.mjs
@@ -57,6 +57,17 @@ for (const [subpath, entry] of Object.entries(pkg.exports)) {
     patched++;
 }
 
+// Fail the build loudly if nothing was patched. tshy rewrites the whole "exports"
+// map on every build, so if its output shape ever changes (e.g. the "import"
+// condition is renamed or nested differently) this script would silently produce a
+// package.json without the workerd/worker conditions and ship a broken package.
+if (patched === 0) {
+    throw new Error(
+        "addWorkerCondition: patched 0 export entries -- no entry exposed an 'import' condition to mirror. "
+        + "tshy's 'exports' shape likely changed; the workerd/worker conditions were NOT injected. "
+        + "Refusing to leave package.json without them.");
+}
+
 writeFileSync(PKG_PATH, JSON.stringify(pkg, null, 2) + "\n");
 // Log to stderr so it never pollutes stdout of `npm pack --silent` (which is
 // parsed to obtain the tarball filename in CI).

--- a/src/Http/RavenCommand.ts
+++ b/src/Http/RavenCommand.ts
@@ -151,7 +151,10 @@ export abstract class RavenCommand<TResult> {
     public async send(agent: Dispatcher,
         requestOptions: HttpRequestParameters): Promise<{ response: HttpResponse, bodyStream: Readable }> {
 
-        const { body, uri, fetcher, ...restOptions } = requestOptions;
+        // `dispatcher` is pulled out here so it never leaks into `restOptions`: the
+        // normal path re-adds it explicitly (see below), while the Bun and workerd
+        // paths must not carry an undici dispatcher into their fetch init.
+        const { body, uri, fetcher, dispatcher, ...restOptions } = requestOptions;
 
         log.info(`Send command ${this.constructor.name} to ${uri}${body ? " with body " + body : ""}.`);
 
@@ -167,8 +170,8 @@ export abstract class RavenCommand<TResult> {
             // dispatcher here is meaningless and can confuse the runtime.
             optionsToUse = { body: bodyToUse, ...restOptions } as RequestInit;
         } else {
-            if (requestOptions.dispatcher) { // support for fiddler
-                agent = requestOptions.dispatcher;
+            if (dispatcher) { // support for fiddler
+                agent = dispatcher;
             }
             optionsToUse = { body: bodyToUse, ...restOptions, dispatcher: agent } as RequestInit;
         }
@@ -184,13 +187,20 @@ export abstract class RavenCommand<TResult> {
         const fetchFn = fetcher ?? fetch; // support for custom fetcher
         const response = await fetchFn(uri, optionsToUse);
 
-        const effectiveStream: Stream =
-            response.body
-                ? Readable.fromWeb(response.body)
-                : new Stream();
+        // `Readable.fromWeb` / `new Stream()` / `.pipe` are all `node:stream` APIs,
+        // so an incomplete edge polyfill (Nitro/unenv) can throw here just like
+        // `new PassThrough()` above. Guard them so the actionable error is raised.
+        try {
+            const effectiveStream: Stream =
+                response.body
+                    ? Readable.fromWeb(response.body)
+                    : new Stream();
 
-        effectiveStream
-            .pipe(passthrough);
+            effectiveStream
+                .pipe(passthrough);
+        } catch (err) {
+            throw RavenCommand._maybeNodeStreamUnavailableError(err as Error);
+        }
 
         return {
             response,

--- a/src/Http/RavenCommand.ts
+++ b/src/Http/RavenCommand.ts
@@ -4,7 +4,7 @@ import { StatusCodes } from "./StatusCode.js";
 import { Stream, Readable, PassThrough } from "node:stream";
 import { HttpRequestParameters, HttpResponse } from "../Primitives/Http.js";
 import { getLogger } from "../Utility/LogUtil.js";
-import { throwError } from "../Exceptions/index.js";
+import { getError, throwError } from "../Exceptions/index.js";
 import { IRavenObject } from "../Types/IRavenObject.js";
 import { getEtagHeader, HeadersBuilder, closeHttpResponse } from "../Utility/HttpUtil.js";
 import { TypeInfo } from "../Mapping/ObjectMapper.js";
@@ -161,6 +161,11 @@ export abstract class RavenCommand<TResult> {
 
         if (RuntimeUtil.isBun()) {
             optionsToUse = { body: bodyToUse, ...restOptions } as BunFetchRequestInit;
+        } else if (RuntimeUtil.isWorkerd()) {
+            // Cloudflare Workers' fetch has no undici `dispatcher` concept; mTLS is
+            // handled by the custom fetch (an mtls_certificate binding). Passing a
+            // dispatcher here is meaningless and can confuse the runtime.
+            optionsToUse = { body: bodyToUse, ...restOptions } as RequestInit;
         } else {
             if (requestOptions.dispatcher) { // support for fiddler
                 agent = requestOptions.dispatcher;
@@ -168,7 +173,12 @@ export abstract class RavenCommand<TResult> {
             optionsToUse = { body: bodyToUse, ...restOptions, dispatcher: agent } as RequestInit;
         }
 
-        const passthrough = new PassThrough();
+        let passthrough: PassThrough;
+        try {
+            passthrough = new PassThrough();
+        } catch (err) {
+            throw RavenCommand._maybeNodeStreamUnavailableError(err as Error);
+        }
         passthrough.pause();
 
         const fetchFn = fetcher ?? fetch; // support for custom fetcher
@@ -186,6 +196,23 @@ export abstract class RavenCommand<TResult> {
             response,
             bodyStream: passthrough
         };
+    }
+
+    private static _maybeNodeStreamUnavailableError(err: Error): Error {
+        // Some edge bundlers ship an incomplete `node:stream` where PassThrough throws
+        // "not implemented" (e.g. Nitro/unenv, used by TanStack Start & Nuxt). Turn that
+        // cryptic stub error into an actionable one pointing at the real fix.
+        if (RuntimeUtil.isWorkerd()) {
+            return getError(
+                "InvalidOperationException",
+                "The RavenDB client requires a working node:stream on Cloudflare Workers, but this "
+                + "runtime provided an incomplete polyfill. Enable Node.js compatibility by adding "
+                + `compatibility_flags = ["nodejs_compat"] (and a recent compatibility_date) to your `
+                + "wrangler configuration. For framework bundlers such as Nitro / TanStack Start / Nuxt "
+                + "this makes node: built-ins resolve to the workerd runtime instead of unenv stubs.",
+                err);
+        }
+        return err;
     }
 
     private static maybeWrapBody(body: any) {

--- a/src/Http/RavenCommand.ts
+++ b/src/Http/RavenCommand.ts
@@ -162,35 +162,33 @@ export abstract class RavenCommand<TResult> {
 
         let optionsToUse: RequestInit | BunFetchRequestInit;
 
-        if (RuntimeUtil.isBun()) {
-            optionsToUse = { body: bodyToUse, ...restOptions } as BunFetchRequestInit;
-        } else if (RuntimeUtil.isWorkerd()) {
-            // Cloudflare Workers' fetch has no undici `dispatcher` concept; mTLS is
-            // handled by the custom fetch (an mtls_certificate binding). Passing a
-            // dispatcher here is meaningless and can confuse the runtime.
-            optionsToUse = { body: bodyToUse, ...restOptions } as RequestInit;
-        } else {
+        if (RuntimeUtil.supportsUndiciDispatcher()) {
             if (dispatcher) { // support for fiddler
                 agent = dispatcher;
             }
             optionsToUse = { body: bodyToUse, ...restOptions, dispatcher: agent } as RequestInit;
+        } else {
+            // Bun and Cloudflare Workers (workerd) have no undici `dispatcher` concept, so
+            // one must never leak into their fetch init. On workerd mTLS is handled by the
+            // custom fetch (an mtls_certificate binding); Bun manages TLS itself.
+            optionsToUse = { body: bodyToUse, ...restOptions } as RequestInit;
         }
 
-        let passthrough: PassThrough;
-        try {
-            passthrough = new PassThrough();
-        } catch (err) {
-            throw RavenCommand._maybeNodeStreamUnavailableError(err as Error);
-        }
-        passthrough.pause();
+        // `new PassThrough()`, `Readable.fromWeb`, `new Stream()` and `.pipe` are all
+        // `node:stream` APIs; an incomplete edge polyfill (Nitro/unenv) can throw from any
+        // of them. `_guardNodeStream` turns those into an actionable error. PassThrough is
+        // built BEFORE the fetch on purpose: on a broken polyfill we fail fast without
+        // issuing the (possibly state-mutating) request.
+        const passthrough = RavenCommand._guardNodeStream(() => {
+            const pt = new PassThrough();
+            pt.pause();
+            return pt;
+        });
 
         const fetchFn = fetcher ?? fetch; // support for custom fetcher
         const response = await fetchFn(uri, optionsToUse);
 
-        // `Readable.fromWeb` / `new Stream()` / `.pipe` are all `node:stream` APIs,
-        // so an incomplete edge polyfill (Nitro/unenv) can throw here just like
-        // `new PassThrough()` above. Guard them so the actionable error is raised.
-        try {
+        RavenCommand._guardNodeStream(() => {
             const effectiveStream: Stream =
                 response.body
                     ? Readable.fromWeb(response.body)
@@ -198,9 +196,7 @@ export abstract class RavenCommand<TResult> {
 
             effectiveStream
                 .pipe(passthrough);
-        } catch (err) {
-            throw RavenCommand._maybeNodeStreamUnavailableError(err as Error);
-        }
+        });
 
         return {
             response,
@@ -208,18 +204,39 @@ export abstract class RavenCommand<TResult> {
         };
     }
 
+    // Runs a `node:stream` operation, translating an incomplete-polyfill failure into an
+    // actionable error. Shared by every node:stream call site in send() so none can be
+    // added without the guard, and the translation logic lives in one place.
+    private static _guardNodeStream<T>(fn: () => T): T {
+        try {
+            return fn();
+        } catch (err) {
+            throw RavenCommand._maybeNodeStreamUnavailableError(err as Error);
+        }
+    }
+
     private static _maybeNodeStreamUnavailableError(err: Error): Error {
-        // Some edge bundlers ship an incomplete `node:stream` where PassThrough throws
-        // "not implemented" (e.g. Nitro/unenv, used by TanStack Start & Nuxt). Turn that
-        // cryptic stub error into an actionable one pointing at the real fix.
-        if (RuntimeUtil.isWorkerd()) {
+        // The failure is signalled by the polyfill itself, not by the runtime: unenv
+        // (used by Nitro-based presets -- TanStack Start, Nuxt -- and edge targets such as
+        // Cloudflare Workers, Vercel Edge, Deno Deploy) ships `node:stream` stubs that
+        // throw e.g. "[unenv] PassThrough is not implemented yet!". We match that signature
+        // rather than the runtime so (a) every affected runtime gets the guidance, not just
+        // workerd, and (b) an unrelated node:stream error on a correctly configured runtime
+        // is NOT mislabeled as a polyfill problem. The original error is kept as the cause.
+        const message = err?.message ?? "";
+        const isIncompletePolyfill = message.includes("[unenv]")
+            || /\bnot implemented\b/i.test(message);
+
+        if (isIncompletePolyfill) {
             return getError(
                 "InvalidOperationException",
-                "The RavenDB client requires a working node:stream on Cloudflare Workers, but this "
-                + "runtime provided an incomplete polyfill. Enable Node.js compatibility by adding "
-                + `compatibility_flags = ["nodejs_compat"] (and a recent compatibility_date) to your `
-                + "wrangler configuration. For framework bundlers such as Nitro / TanStack Start / Nuxt "
-                + "this makes node: built-ins resolve to the workerd runtime instead of unenv stubs.",
+                "The RavenDB client requires a working node:stream, but this runtime provided an "
+                + "incomplete polyfill (unenv). On Cloudflare Workers, enable Node.js compatibility by "
+                + `adding compatibility_flags = ["nodejs_compat"] (and a recent compatibility_date) to `
+                + "your wrangler configuration; for framework bundlers such as Nitro / TanStack Start / "
+                + "Nuxt this makes node: built-ins resolve to the runtime instead of unenv stubs. On "
+                + "other edge runtimes (e.g. Vercel Edge, Deno Deploy) enable the equivalent Node.js "
+                + "compatibility so node:stream is backed by a real implementation.",
                 err);
         }
         return err;

--- a/src/Http/RequestExecutor.ts
+++ b/src/Http/RequestExecutor.ts
@@ -344,6 +344,12 @@ export class RequestExecutor implements IDisposable {
             return null;
         }
 
+        if (RuntimeUtil.isWorkerd()) {
+            // Cloudflare Workers has no undici Agent / Node https agent.
+            // mTLS is provided via conventions.customFetch (an mtls_certificate binding).
+            return null;
+        }
+
         if (this._httpAgent) {
             return this._httpAgent;
         }

--- a/src/Http/RequestExecutor.ts
+++ b/src/Http/RequestExecutor.ts
@@ -340,17 +340,14 @@ export class RequestExecutor implements IDisposable {
             return null;
         }
 
-        if (RuntimeUtil.isBun()) {
-            return null;
-        }
-
-        if (RuntimeUtil.isWorkerd()) {
-            // Cloudflare Workers has no undici Agent / Node https agent.
-            // mTLS is provided via conventions.customFetch (an mtls_certificate binding).
-            // If a certificate was configured (the Node way) but no customFetch was set
-            // (checked above), the cert can never be presented -- fail fast with an
-            // actionable message instead of silently issuing an uncertified request.
-            if (this._certificate) {
+        // Runtimes whose fetch has no undici dispatcher (Bun, Cloudflare Workers) can't use
+        // an http agent -- there is nothing to build.
+        if (!RuntimeUtil.supportsUndiciDispatcher()) {
+            // On workerd a client certificate configured the Node way can never be presented
+            // (no Node https agent) unless mTLS is wired through conventions.customFetch
+            // (checked above). Fail fast with an actionable message instead of silently
+            // issuing an uncertified request.
+            if (RuntimeUtil.isWorkerd() && this._certificate) {
                 throwError("InvalidOperationException",
                     "A client certificate was configured via authOptions, but Cloudflare Workers has no Node "
                     + "https agent to present it. On workerd, X.509 mTLS must be provided through a Cloudflare "

--- a/src/Http/RequestExecutor.ts
+++ b/src/Http/RequestExecutor.ts
@@ -347,6 +347,16 @@ export class RequestExecutor implements IDisposable {
         if (RuntimeUtil.isWorkerd()) {
             // Cloudflare Workers has no undici Agent / Node https agent.
             // mTLS is provided via conventions.customFetch (an mtls_certificate binding).
+            // If a certificate was configured (the Node way) but no customFetch was set
+            // (checked above), the cert can never be presented -- fail fast with an
+            // actionable message instead of silently issuing an uncertified request.
+            if (this._certificate) {
+                throwError("InvalidOperationException",
+                    "A client certificate was configured via authOptions, but Cloudflare Workers has no Node "
+                    + "https agent to present it. On workerd, X.509 mTLS must be provided through a Cloudflare "
+                    + "mtls_certificate binding wired into conventions.customFetch (see the \"Cloudflare Workers\" "
+                    + "section of the README). Remove the certificate from authOptions and set conventions.customFetch.");
+            }
             return null;
         }
 

--- a/src/Utility/RuntimeUtil.ts
+++ b/src/Utility/RuntimeUtil.ts
@@ -18,13 +18,17 @@ export class RuntimeUtil {
     /**
      * Detects if the code is running in the Cloudflare Workers (workerd) runtime.
      *
-     * workerd exposes the Web `navigator.userAgent` as the fixed string
+     * workerd exposes the Web `navigator.userAgent` as the string
      * "Cloudflare-Workers", which is the officially documented way to detect it.
+     * We match by prefix so a future version suffix (e.g. "Cloudflare-Workers/1")
+     * still resolves to workerd instead of failing closed into the Node path
+     * (which would then crash trying to build an undici agent that workerd lacks).
      */
     public static isWorkerd(): boolean {
         if (this._isWorkerd === null) {
             const nav = (globalThis as unknown as { navigator?: { userAgent?: string } }).navigator;
-            this._isWorkerd = !!nav && nav.userAgent === "Cloudflare-Workers";
+            this._isWorkerd = !!nav && typeof nav.userAgent === "string"
+                && nav.userAgent.startsWith("Cloudflare-Workers");
         }
         return this._isWorkerd;
     }

--- a/src/Utility/RuntimeUtil.ts
+++ b/src/Utility/RuntimeUtil.ts
@@ -10,6 +10,10 @@ export class RuntimeUtil {
      */
     public static isBun(): boolean {
         if (this._isBun === null) {
+            // `process` is absent on some edge runtimes (e.g. Cloudflare Workers/workerd),
+            // where a bare reference would throw a ReferenceError at module-load time and
+            // crash the very load path this detection protects. Keep the `typeof` guard --
+            // do not "simplify" it away. See isWorkerd().
             this._isBun = typeof process !== "undefined" && !!process.versions?.bun;
         }
         return this._isBun;
@@ -31,5 +35,19 @@ export class RuntimeUtil {
                 && nav.userAgent.startsWith("Cloudflare-Workers");
         }
         return this._isWorkerd;
+    }
+
+    /**
+     * Whether the current runtime can accept an undici `Dispatcher` (Node's undici
+     * Agent) in a `fetch` init. Node can; Bun and Cloudflare Workers (workerd) cannot --
+     * their `fetch` has no dispatcher concept, so building or passing one is meaningless.
+     *
+     * Centralized here so the two consumers -- request send (RavenCommand.send) and http
+     * agent creation (RequestExecutor.getHttpAgent) -- stay in lockstep: if they drift
+     * (an agent is built but the dispatcher is dropped on send, or vice versa) the
+     * original workerd failure returns. A future dispatcher-less runtime is added once.
+     */
+    public static supportsUndiciDispatcher(): boolean {
+        return !this.isBun() && !this.isWorkerd();
     }
 }

--- a/src/Utility/RuntimeUtil.ts
+++ b/src/Utility/RuntimeUtil.ts
@@ -3,14 +3,29 @@
  */
 export class RuntimeUtil {
     private static _isBun: boolean = null;
+    private static _isWorkerd: boolean = null;
 
     /**
      * Detects if the code is running in Bun runtime
      */
     public static isBun(): boolean {
         if (this._isBun === null) {
-            this._isBun = !!process.versions.bun;
+            this._isBun = typeof process !== "undefined" && !!process.versions?.bun;
         }
         return this._isBun;
+    }
+
+    /**
+     * Detects if the code is running in the Cloudflare Workers (workerd) runtime.
+     *
+     * workerd exposes the Web `navigator.userAgent` as the fixed string
+     * "Cloudflare-Workers", which is the officially documented way to detect it.
+     */
+    public static isWorkerd(): boolean {
+        if (this._isWorkerd === null) {
+            const nav = (globalThis as unknown as { navigator?: { userAgent?: string } }).navigator;
+            this._isWorkerd = !!nav && nav.userAgent === "Cloudflare-Workers";
+        }
+        return this._isWorkerd;
     }
 }

--- a/test/cloudflare-nitro/.gitignore
+++ b/test/cloudflare-nitro/.gitignore
@@ -1,0 +1,8 @@
+node_modules/
+package-lock.json
+.output/
+.nitro/
+.wrangler/
+dist/
+*.tgz
+*.log

--- a/test/cloudflare-nitro/README.md
+++ b/test/cloudflare-nitro/README.md
@@ -1,0 +1,28 @@
+# Nitro / TanStack Start Cloudflare example + tests
+
+TanStack Start deploys to Cloudflare through [Nitro](https://nitro.build) (Rollup + `unenv`).
+This project mirrors that toolchain and doubles as the RDBC-1083 regression coverage.
+
+`ravendb` is resolved from the repo root (`file:../..`), so it tests the locally built client.
+`wrangler.toml` sets `nodejs_compat` so Nitro defers `node:` built-ins to workerd instead of
+`unenv` stubs (required for `node:stream` — see the "Cloudflare Workers" section of the top-level
+`readme.md`).
+
+## Load test (no server)
+
+```bash
+npm ci                 # from the repo root, builds the client
+cd test/cloudflare-nitro
+npm install
+npm run build
+npm run smoke          # boots the built worker in workerd, asserts the client loads
+```
+
+## End-to-end test (needs a RavenDB server)
+
+Start an (insecure) RavenDB on `http://127.0.0.1:8080`, then:
+
+```bash
+npm run build
+RAVENDB_URL=http://127.0.0.1:8080 npm run e2e   # stores + loads a document from inside workerd
+```

--- a/test/cloudflare-nitro/e2e.mjs
+++ b/test/cloudflare-nitro/e2e.mjs
@@ -1,0 +1,26 @@
+// End-to-end test: boots the built Nitro worker in workerd and performs a real
+// store + load against a RavenDB server (default http://127.0.0.1:8080, override
+// with RAVENDB_URL). Run after `npm run build` with a RavenDB server available.
+import { unstable_dev } from "wrangler";
+
+const ravenUrl = process.env.RAVENDB_URL || "http://127.0.0.1:8080";
+
+const worker = await unstable_dev(".output/server/index.mjs", {
+    experimental: { disableExperimentalWarning: true },
+    compatibilityDate: "2024-12-30",
+    compatibilityFlags: ["nodejs_compat"],
+    logLevel: "warn"
+});
+
+try {
+    const res = await worker.fetch("/e2e?url=" + encodeURIComponent(ravenUrl));
+    const body = await res.json();
+    if (res.status !== 200 || !body.ok) {
+        console.error(`E2E FAILED [HTTP ${res.status}]: ${JSON.stringify(body)}`);
+        process.exitCode = 1;
+    } else {
+        console.log(`E2E OK: ${JSON.stringify(body)}`);
+    }
+} finally {
+    await worker.stop();
+}

--- a/test/cloudflare-nitro/nitro.config.ts
+++ b/test/cloudflare-nitro/nitro.config.ts
@@ -1,0 +1,7 @@
+import { defineNitroConfig } from "nitropack/config";
+
+// TanStack Start deploys to Cloudflare through Nitro; this mirrors that toolchain.
+export default defineNitroConfig({
+    compatibilityDate: "2024-12-30",
+    preset: "cloudflare-module"
+});

--- a/test/cloudflare-nitro/package.json
+++ b/test/cloudflare-nitro/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "ravendb-nitro-cf-example",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "description": "Nitro (TanStack Start-style) Cloudflare example + tests for the RavenDB client (RDBC-1083).",
+  "scripts": {
+    "build": "nitro build",
+    "smoke": "node smoke.mjs",
+    "e2e": "node e2e.mjs"
+  },
+  "dependencies": {
+    "ravendb": "file:../.."
+  },
+  "devDependencies": {
+    "nitropack": "^2.10.0",
+    "wrangler": "^4.106.0"
+  }
+}

--- a/test/cloudflare-nitro/routes/e2e.get.ts
+++ b/test/cloudflare-nitro/routes/e2e.get.ts
@@ -1,0 +1,34 @@
+import { DocumentStore, CreateDatabaseOperation } from "ravendb";
+
+// Real end-to-end data path: store a document and load it back from a RavenDB
+// server, entirely from inside workerd. Exercises the request + response-stream
+// pipeline (PassThrough / Readable.fromWeb) that node:stream must provide.
+export default defineEventHandler(async (event) => {
+    const url = (getQuery(event).url as string) || "http://127.0.0.1:8080";
+    const database = "workers-e2e";
+    const store = new DocumentStore([url], database);
+    store.initialize();
+    try {
+        try {
+            await store.maintenance.server.send(new CreateDatabaseOperation({ databaseName: database }));
+        } catch {
+            // database already exists -- fine
+        }
+
+        const id = "items/1";
+        const payload = { message: "hello from workerd", at: "e2e" };
+        {
+            const session = store.openSession();
+            await session.store(payload, id);
+            await session.saveChanges();
+        }
+        const session = store.openSession();
+        const loaded = await session.load<typeof payload>(id);
+
+        return { ok: loaded?.message === payload.message, loaded };
+    } catch (err) {
+        return { ok: false, error: `${(err as Error).name}: ${(err as Error).message}` };
+    } finally {
+        store.dispose();
+    }
+});

--- a/test/cloudflare-nitro/routes/load.get.ts
+++ b/test/cloudflare-nitro/routes/load.get.ts
@@ -1,0 +1,9 @@
+import { DocumentStore } from "ravendb";
+
+// Load-only check (no server needed): constructs a DocumentStore so the whole
+// client module graph is evaluated inside workerd via the Nitro/Rollup bundle.
+export default defineEventHandler(() => {
+    const store = new DocumentStore(["https://a.example"], "Test");
+    store.dispose();
+    return { ok: true, loaded: typeof DocumentStore };
+});

--- a/test/cloudflare-nitro/smoke.mjs
+++ b/test/cloudflare-nitro/smoke.mjs
@@ -1,0 +1,23 @@
+// Load smoke test: boots the built Nitro worker in workerd and asserts the
+// RavenDB client module graph loads (no server needed). Run after `npm run build`.
+import { unstable_dev } from "wrangler";
+
+const worker = await unstable_dev(".output/server/index.mjs", {
+    experimental: { disableExperimentalWarning: true },
+    compatibilityDate: "2024-12-30",
+    compatibilityFlags: ["nodejs_compat"],
+    logLevel: "warn"
+});
+
+try {
+    const res = await worker.fetch("/load");
+    const body = await res.json();
+    if (res.status !== 200 || !body.ok) {
+        console.error(`SMOKE FAILED [HTTP ${res.status}]: ${JSON.stringify(body)}`);
+        process.exitCode = 1;
+    } else {
+        console.log(`SMOKE OK: ${JSON.stringify(body)}`);
+    }
+} finally {
+    await worker.stop();
+}

--- a/test/cloudflare-nitro/wrangler.toml
+++ b/test/cloudflare-nitro/wrangler.toml
@@ -1,0 +1,6 @@
+# Read by Nitro at build time. nodejs_compat makes Nitro defer node: built-ins to
+# workerd's real implementation instead of unenv stubs -- required so node:stream
+# (PassThrough / Readable.fromWeb) works at request time. See readme.md.
+name = "ravendb-nitro-cf-example"
+compatibility_date = "2024-12-30"
+compatibility_flags = ["nodejs_compat"]

--- a/test/cloudflare-vite/.gitignore
+++ b/test/cloudflare-vite/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+package-lock.json
+.wrangler/
+dist/
+*.tgz
+*.log

--- a/test/cloudflare-vite/README.md
+++ b/test/cloudflare-vite/README.md
@@ -1,0 +1,14 @@
+# Vite + Cloudflare example + load test
+
+Vite/Rollup build via [`@cloudflare/vite-plugin`](https://developers.cloudflare.com/workers/vite-plugin/),
+one of the toolchains used to deploy to Cloudflare Workers. Doubles as RDBC-1083 load coverage.
+
+`ravendb` is resolved from the repo root (`file:../..`), so it tests the locally built client.
+
+```bash
+npm ci                 # from the repo root, builds the client
+cd test/cloudflare-vite
+npm install
+npm run build
+npm run smoke          # boots the Vite-built worker in workerd, asserts the client loads
+```

--- a/test/cloudflare-vite/package.json
+++ b/test/cloudflare-vite/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "ravendb-vite-cf-example",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "description": "Vite + @cloudflare/vite-plugin (Rollup) Cloudflare example + load test for the RavenDB client (RDBC-1083).",
+  "scripts": {
+    "build": "vite build",
+    "smoke": "node smoke.mjs"
+  },
+  "dependencies": {
+    "ravendb": "file:../.."
+  },
+  "devDependencies": {
+    "@cloudflare/vite-plugin": "^1.0.0",
+    "vite": "^6.0.0",
+    "wrangler": "^4.106.0"
+  }
+}

--- a/test/cloudflare-vite/smoke.mjs
+++ b/test/cloudflare-vite/smoke.mjs
@@ -1,0 +1,22 @@
+// Load smoke test: boots the Vite/Rollup-built worker in workerd and asserts the
+// RavenDB client module graph loads. Run after `npm run build`.
+import { unstable_dev } from "wrangler";
+
+const worker = await unstable_dev("dist/ravendb_vite_cf_example/index.js", {
+    config: "dist/ravendb_vite_cf_example/wrangler.json",
+    experimental: { disableExperimentalWarning: true },
+    logLevel: "warn"
+});
+
+try {
+    const res = await worker.fetch("/");
+    const body = await res.json();
+    if (res.status !== 200 || !body.ok) {
+        console.error(`SMOKE FAILED [HTTP ${res.status}]: ${JSON.stringify(body)}`);
+        process.exitCode = 1;
+    } else {
+        console.log(`SMOKE OK: ${JSON.stringify(body)}`);
+    }
+} finally {
+    await worker.stop();
+}

--- a/test/cloudflare-vite/src/worker.ts
+++ b/test/cloudflare-vite/src/worker.ts
@@ -1,0 +1,15 @@
+// Vite + Rollup (via @cloudflare/vite-plugin) load check for the RavenDB client.
+// Importing + constructing forces the whole module graph to evaluate in workerd.
+import { DocumentStore } from "ravendb";
+
+export default {
+    async fetch(): Promise<Response> {
+        try {
+            const store = new DocumentStore(["https://a.example"], "Test");
+            store.dispose();
+            return Response.json({ ok: true, loaded: typeof DocumentStore });
+        } catch (err) {
+            return new Response("FAILED: " + ((err && (err as Error).stack) || String(err)), { status: 500 });
+        }
+    }
+};

--- a/test/cloudflare-vite/vite.config.ts
+++ b/test/cloudflare-vite/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from "vite";
+import { cloudflare } from "@cloudflare/vite-plugin";
+
+export default defineConfig({
+    plugins: [cloudflare()]
+});

--- a/test/cloudflare-vite/wrangler.jsonc
+++ b/test/cloudflare-vite/wrangler.jsonc
@@ -1,0 +1,6 @@
+{
+  "name": "ravendb-vite-cf-example",
+  "main": "src/worker.ts",
+  "compatibility_date": "2024-12-30",
+  "compatibility_flags": ["nodejs_compat"]
+}

--- a/test/cloudflare-worker/.gitignore
+++ b/test/cloudflare-worker/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+package-lock.json
+.wrangler/
+dist-bundle/
+*.tgz
+*.log

--- a/test/cloudflare-worker/README.md
+++ b/test/cloudflare-worker/README.md
@@ -1,0 +1,31 @@
+# Cloudflare Workers load smoke test
+
+Minimal [Cloudflare Workers](https://developers.cloudflare.com/workers/) project that
+imports the RavenDB client and constructs a `DocumentStore` inside a real `workerd`
+instance. It guards against [RDBC-1083](https://issues.hibernatingrhinos.com/issue/RDBC-1083)
+— a module-graph / bundler-interop load crash (`Class extends value [object Module]
+is not a constructor or null`).
+
+It resolves `ravendb` from the repository root (`file:../..`), so it always tests the
+locally built client, including the `workerd`/`worker` export conditions.
+
+## Run it
+
+```bash
+# from the repository root: build the client first
+npm ci
+
+# then run the smoke test
+cd test/cloudflare-worker
+npm install
+npm run smoke
+```
+
+`npm run smoke` boots the worker via wrangler's programmatic API, sends one request,
+and exits non-zero unless the client loaded and a `DocumentStore` was constructed.
+
+For interactive debugging use `npx wrangler dev` and open the printed URL.
+
+This is a **load** test only — it does not talk to a RavenDB server. For the mTLS
+recipe (talking to a secure RavenDB from a Worker) see the "Cloudflare Workers"
+section of the top-level `readme.md`.

--- a/test/cloudflare-worker/package.json
+++ b/test/cloudflare-worker/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "ravendb-cf-repro",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Minimal Cloudflare Worker reproduction / smoke test for the RavenDB client (RDBC-1083).",
+  "type": "module",
+  "scripts": {
+    "smoke": "node smoke.mjs"
+  },
+  "devDependencies": {
+    "wrangler": "^4.106.0"
+  },
+  "dependencies": {
+    "ravendb": "file:../.."
+  }
+}

--- a/test/cloudflare-worker/smoke.mjs
+++ b/test/cloudflare-worker/smoke.mjs
@@ -1,0 +1,26 @@
+// Non-interactive Cloudflare Workers load smoke test for CI (RDBC-1083).
+//
+// Boots the worker in a real workerd instance via wrangler's programmatic API,
+// hits it once, and asserts the RavenDB client loaded and a DocumentStore was
+// constructed. Exits non-zero on any failure so CI fails loudly if a future
+// change reintroduces a bundler-interop / module-graph load crash.
+import { unstable_dev } from "wrangler";
+
+const worker = await unstable_dev("src/worker.ts", {
+    experimental: { disableExperimentalWarning: true },
+    logLevel: "warn"
+});
+
+try {
+    const res = await worker.fetch("/");
+    const text = await res.text();
+
+    if (res.status !== 200 || !text.startsWith("ok:")) {
+        console.error(`SMOKE FAILED [HTTP ${res.status}]: ${text}`);
+        process.exitCode = 1;
+    } else {
+        console.log(`SMOKE OK: ${text}`);
+    }
+} finally {
+    await worker.stop();
+}

--- a/test/cloudflare-worker/src/worker.ts
+++ b/test/cloudflare-worker/src/worker.ts
@@ -1,0 +1,23 @@
+// Minimal Cloudflare Workers smoke test for the RavenDB client (RDBC-1083).
+//
+// Importing the package pulls in its entire module graph, so if any
+// `class ... extends ...` were to resolve to `[object Module]` (the reported
+// bundler-interop failure) it would throw here, at module evaluation time.
+// A 200 response means the package loaded and a DocumentStore was constructed
+// inside workerd.
+import { DocumentStore } from "ravendb";
+
+export default {
+    async fetch(): Promise<Response> {
+        try {
+            const store = new DocumentStore(["https://a.example"], "Test");
+            store.dispose();
+            return new Response("ok: ravendb loaded in workerd (" + typeof DocumentStore + ")");
+        } catch (err) {
+            return new Response(
+                "FAILED: " + ((err && (err as Error).stack) || String(err)),
+                { status: 500 }
+            );
+        }
+    }
+};

--- a/test/cloudflare-worker/wrangler.toml
+++ b/test/cloudflare-worker/wrangler.toml
@@ -1,0 +1,4 @@
+name = "ravendb-cf-repro"
+main = "src/worker.ts"
+compatibility_date = "2024-09-23"
+compatibility_flags = ["nodejs_compat"]


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RDBC-1083/RavenDB-NodeJS-client-cant-run-under-Cloudflare-Workers-even-with-node-compat

### Additional description

Enables the client under Cloudflare Workers, including TanStack Start (Vite + Nitro/Rollup). As reported by the user

> strife] could not read content: Class extends value [object Module] is not a constructor or null
The ravendb npm package is Node-only. Even with nodejs_compat, it doesn't work in Cloudflare Workers where the site runs — partly because the package's internal require() chain gets broken by the ESM bundler (error above), and partly because X.509 mTLS against RavenDB requires Node's https agent, which Workers doesn't have.

The real blocker on Nitro is at request time: it polyfills Node with `unenv`, whose `node:stream` is incomplete, so `RavenCommand.send()`'s `new PassThrough()` throws `[unenv] PassThrough is not implemented yet!`.

Changes:

1. Add `workerd`/`worker` export conditions pointing at the ESM build (`scripts/addWorkerCondition.mjs`, run in `prepare`). Additive; Node and Bun resolution are unchanged.
2. Add `RuntimeUtil.isWorkerd()`; on workerd skip the undici agent/dispatcher and harden `isBun()`.
3. When `node:stream` is stubbed, re-throw an `InvalidOperationException` explaining how to enable `nodejs_compat` (original error kept as cause).
4. Add a "Cloudflare Workers" README section: `nodejs_compat`, the Nitro/`unenv` note, and mTLS via a Cloudflare `mtls_certificate` binding through `conventions.customFetch`.
5. Add `.github/workflows/Cloudflare.yml` and `test/cloudflare-{worker,vite,nitro}`: a GH Actions matrix (Node 22/24 x wrangler/Vite/Nitro) and a Nitro to RavenDB store/load e2e, both run in workerd.

Verified locally: load smokes pass and the Nitro e2e stores and loads a document against RavenDB 7.2 in workerd. mTLS over TLS is not testable in self-contained CI (workerd rejects self-signed certs; `mtls_certificate` bindings need a Cloudflare account), so it is covered by the docs and the runtime error.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low
- [ ] Moderate
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [x] Ensured. Please explain how has it been implemented?

Export conditions are additive and new behavior is gated by `isWorkerd()`, so Node and Bun are unaffected.

### Is it platform specific issue?

- [x] Yes. Please list the affected platforms.
- [ ] No

Cloudflare Workers / workerd and edge bundlers (wrangler, `@cloudflare/vite-plugin`, Nitro, OpenNext).

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed

`readme.md` is updated; public docs should get the same guidance.

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`)
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

Load smokes plus a Nitro to RavenDB e2e in `.github/workflows/Cloudflare.yml`, verified locally in workerd.

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

Runtime changes are workerd-only.

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
