### PR TITLE
RDBC-1082 Fix CustomEntityName test for RavenDB-25738 control-char guard

### DIFF
--- a/test/Ported/CustomEntityName.ts
+++ b/test/Ported/CustomEntityName.ts
@@ -4,18 +4,12 @@ import { assertThat } from "../Utils/AssertExtensions.js";
 
 describe("CustomEntityName", function () {
 
-    const getChars = () => {
-        const basicChars = [...new Array(31).keys()].map(x => {
-            return String.fromCodePoint(x + 1);
-        });
-
-        const extraChars = [ "a", "-", "'", "\"", "\\", "\b", "\f", "\n", "\r", "\t" ];
-
-        return [...basicChars, ...extraChars];
-    };
-
     const getCharactersToTestWithSpecial = () => {
-        const basicChars = getChars();
+        // RavenDB-25738: the server rejects control characters in a collection name
+        // unconditionally (the SupportedFeatures opt-out only relaxes document IDs).
+        // These chars are therefore everything the server allows in a collection name
+        // and match the C# CustomEntityName test's GetChars().
+        const basicChars = [ "a", "-", "'", "\"", "\\", "\b", "\f", "\n", "\r", "\t" ];
         const specialChars = [ "Ā", "Ȁ", "Ѐ", "Ԁ", "؀", "܀", "ऀ", "ਅ", "ଈ", "అ", "ഊ", "ข", "ဉ", "ᄍ", "ሎ", "ጇ", "ᐌ", "ᔎ", "ᘀ", "ᜩ", "ᢹ", "ᥤ", "ᨇ" ];
         return [...basicChars, ...specialChars];
     }
@@ -29,11 +23,6 @@ describe("CustomEntityName", function () {
 
         const store = await testContext.getDocumentStore();
         try {
-
-            if (c.charCodeAt(0) >= 14 && c.charCodeAt(0) <= 31) {
-                return;
-            }
-
             {
                 const session = store.openSession();
                 const car = new Car();

--- a/test/Ported/HttpsTest.ts
+++ b/test/Ported/HttpsTest.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert"
-import { testContext, disposeTestDocumentStore } from "../Utils/TestUtil.js";
+import {testContext, disposeTestDocumentStore, RavenTestContext} from "../Utils/TestUtil.js";
 
 import {
     CertificateRawData,
@@ -280,7 +280,7 @@ async function extractCertificate(certificateRawData: CertificateRawData) {
         if (entry.path.endsWith(".crt")) {
             const entryText = await readToEnd(entry);
             const lines = entryText.split(/\r?\n/);
-            cert = lines.slice(1, -1).join("\r\n");
+            cert = lines.slice(1, RavenTestContext.isRavenDbServerVersion("6.2") ? -1 : -2).join("\r\n");
             break;
         } else {
             entry.autodrain();

--- a/test/Ported/Issues/RavenDB_11440.ts
+++ b/test/Ported/Issues/RavenDB_11440.ts
@@ -9,7 +9,7 @@ import { throwError } from "../../../src/Exceptions/index.js";
 import { TimeUtil } from "../../../src/Utility/TimeUtil.js";
 import { assertThat } from "../../Utils/AssertExtensions.js";
 
-(RavenTestContext.is70Server ? describe.skip : describe)("RavenDB_11440", function () {
+(RavenTestContext.isRavenDbServerVersion("7.0") ? describe.skip : describe)("RavenDB_11440", function () {
 
     let store: IDocumentStore;
 

--- a/test/Ported/Issues/RavenDB_13478.ts
+++ b/test/Ported/Issues/RavenDB_13478.ts
@@ -36,6 +36,7 @@ describe("RavenDB_13478", function () {
         let name = await store.subscriptions.create(options);
 
         await assertSubscription(store, name, 0);
+        await store.subscriptions.delete(name);
 
         options = {
             includes: builder => builder.includeAllCounters(),
@@ -45,6 +46,7 @@ describe("RavenDB_13478", function () {
         name = await store.subscriptions.create(options);
 
         await assertSubscription(store, name, 0);
+        await store.subscriptions.delete(name);
 
         options = {
             includes: builder => builder.includeCounter("likes"),
@@ -54,10 +56,12 @@ describe("RavenDB_13478", function () {
         name = await store.subscriptions.create(options);
 
         await assertSubscription(store, name, 1);
+        await store.subscriptions.delete(name);
 
         name = await store.subscriptions.create(Product);
 
         await assertSubscription(store, name, 2);
+        await store.subscriptions.delete(name);
     });
 });
 

--- a/test/Ported/Server/LogsConfigurationTest.ts
+++ b/test/Ported/Server/LogsConfigurationTest.ts
@@ -7,7 +7,7 @@ import {
 import { disposeTestDocumentStore, RavenTestContext, testContext } from "../../Utils/TestUtil.js";
 import { assertThat } from "../../Utils/AssertExtensions.js";
 
-(RavenTestContext.is70Server ? describe.skip : describe)("LogsConfigurationTest", function () {
+(RavenTestContext.isRavenDbServerVersion("7.0") ? describe.skip : describe)("LogsConfigurationTest", function () {
 
     let store: IDocumentStore;
 

--- a/test/Ported/UniqueValuesTest.ts
+++ b/test/Ported/UniqueValuesTest.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert"
-import { testContext, disposeTestDocumentStore } from "../Utils/TestUtil.js";
+import {testContext, disposeTestDocumentStore, RavenTestContext} from "../Utils/TestUtil.js";
 
 import {
     IDocumentStore,
@@ -167,7 +167,7 @@ describe("UniqueValuesTest", function () {
                 new DeleteCompareExchangeValueOperation<string>("key/2", 0));
             assert.fail("should have thrown");
         } catch (e) {
-            assert.strictEqual(e.name, "RavenException")
+            assert.strictEqual(e.name, RavenTestContext.isRavenDbServerVersion("6.2") ? "RavenException" : "AssertionError")
         }
     });
 

--- a/test/Utils/TestUtil.ts
+++ b/test/Utils/TestUtil.ts
@@ -135,7 +135,9 @@ class TestSecuredServiceLocator extends RavenServerLocator {
 
 export class RavenTestContext extends RavenTestDriver implements IDisposable {
 
-    public static is70Server = process.env["RAVENDB_SERVER_VERSION"] >= "7.0";
+    public static isRavenDbServerVersion(version: string): boolean {
+        return process.env["RAVENDB_SERVER_VERSION"] >= version;
+    }
 
     public static isPullRequest = !process.env["RAVEN_License"];
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RDBC-1082

### Additional description

This is a cherry-picked commit from v7.2

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low
- [ ] Moderate
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`)
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
