### PR TITLE
RDBC-1101 RDBC-1100 Port RavenDB-19585 - fetch topology from all member nodes in the update topology timer

### DIFF
--- a/src/Http/RequestExecutor.ts
+++ b/src/Http/RequestExecutor.ts
@@ -766,36 +766,28 @@ export class RequestExecutor implements IDisposable {
         }
     }
 
-    private _updateTopologyCallback(): Promise<void> {
-        const time = new Date();
-        const fiveMinutes = 5 * 60 * 1000;
-        if (time.valueOf() - this._lastReturnedResponse.valueOf() <= fiveMinutes) {
+    private async _updateTopologyCallback(): Promise<void> {
+        const selector = this._nodeSelector;
+        if (!selector || !selector.getTopology()) {
             return;
         }
 
-        let serverNode: ServerNode;
+        for (const serverNode of selector.getTopology().nodes) {
+            try {
+                if (serverNode.serverRole !== "Member") {
+                    continue;
+                }
 
-        try {
-            const selector = this._nodeSelector;
-            if (!selector) {
-                return;
+                const updateParameters = new UpdateTopologyParameters(serverNode);
+                updateParameters.timeoutInMs = 0;
+                updateParameters.debugTag = "timer-callback-node-" + serverNode.clusterTag;
+
+                await this.updateTopology(updateParameters);
+            } catch (err) {
+                this._log.warn(err,
+                    "Couldn't update topology from _updateTopologyTimer task when fetching from node " + serverNode.clusterTag);
             }
-            const preferredNode: CurrentIndexAndNode = selector.getPreferredNode();
-            serverNode = preferredNode.currentNode;
-        } catch (err) {
-            this._log.warn(err, "Couldn't get preferred node Topology from _updateTopologyTimer");
-            return;
         }
-
-        const updateParameters = new UpdateTopologyParameters(serverNode);
-        updateParameters.timeoutInMs = 0;
-        updateParameters.debugTag = "timer-callback";
-
-        return this.updateTopology(updateParameters)
-            .catch(err => {
-                this._log.error(err, "Couldn't update topology from _updateTopologyTimer");
-                return null;
-            });
     }
 
     protected async _singleTopologyUpdateAsync(initialUrls: string[], applicationIdentifier: string): Promise<void> {

--- a/src/Http/RequestExecutor.ts
+++ b/src/Http/RequestExecutor.ts
@@ -1857,7 +1857,7 @@ export class RequestExecutor implements IDisposable {
             .then(() => {
                 return Promise.resolve(this._performHealthCheck(serverNode, nodeIndex))
                     .then(() => {
-                            status = this._failedNodesTimers[nodeIndex];
+                            status = this._failedNodesTimers.get(nodeStatus.node);
                             if (status) {
                                 this._failedNodesTimers.delete(nodeStatus.node);
                                 status.dispose();

--- a/src/Http/RequestExecutor.ts
+++ b/src/Http/RequestExecutor.ts
@@ -161,8 +161,6 @@ export class RequestExecutor implements IDisposable {
     protected _databaseName: string;
     protected _certificate: ICertificate = null;
 
-    private _lastReturnedResponse: Date;
-
     private readonly _cache: HttpCache;
 
     private _topologyTakenFromNode: ServerNode;
@@ -437,7 +435,6 @@ export class RequestExecutor implements IDisposable {
 
         this._cache = new HttpCache(conventions.maxHttpCacheSize);
         this._databaseName = database;
-        this._lastReturnedResponse = new Date();
         this._conventions = conventions.clone();
         this._authOptions = authOptions;
         this._certificate = Certificate.createFromOptions(this._authOptions);
@@ -767,17 +764,17 @@ export class RequestExecutor implements IDisposable {
     }
 
     private async _updateTopologyCallback(): Promise<void> {
-        const selector = this._nodeSelector;
-        if (!selector || !selector.getTopology()) {
+        const topology = this._nodeSelector?.getTopology();
+        if (!topology) {
             return;
         }
 
-        for (const serverNode of selector.getTopology().nodes) {
-            try {
-                if (serverNode.serverRole !== "Member") {
-                    continue;
-                }
+        for (const serverNode of topology.nodes) {
+            if (serverNode.serverRole !== "Member") {
+                continue;
+            }
 
+            try {
                 const updateParameters = new UpdateTopologyParameters(serverNode);
                 updateParameters.timeoutInMs = 0;
                 updateParameters.debugTag = "timer-callback-node-" + serverNode.clusterTag;
@@ -1080,7 +1077,6 @@ export class RequestExecutor implements IDisposable {
             this._emitter.emit("succeedRequest", new SucceedRequestEventArgs(this._databaseName, url, response, req, attemptNum));
 
             responseDispose = await command.processResponse(this._cache, response, bodyStream, req.uri as string);
-            this._lastReturnedResponse = new Date();
         } finally {
             if (responseDispose === "Automatic") {
                 closeHttpResponse(response);
@@ -1840,6 +1836,7 @@ export class RequestExecutor implements IDisposable {
             if (e.name === "DatabaseDoesNotExistException" || e.name === "RequestedNodeUnavailableException") {
                 status = this._failedNodesTimers.get(nodeStatus.node);
                 if (status) {
+                    this._failedNodesTimers.delete(nodeStatus.node);
                     status.dispose();
                 }
 

--- a/src/Http/ServerNode.ts
+++ b/src/Http/ServerNode.ts
@@ -20,6 +20,7 @@ export class ServerNode {
             this.database = opts.database;
             this.url = opts.url;
             this.clusterTag = opts.clusterTag;
+            this.serverRole = opts.serverRole;
         }
     }
 

--- a/test/Ported/Issues/RDBC_1100.ts
+++ b/test/Ported/Issues/RDBC_1100.ts
@@ -1,0 +1,70 @@
+﻿import { NodeSelector } from "../../../src/Http/NodeSelector.js";
+import { NodeStatus, RequestExecutor } from "../../../src/Http/RequestExecutor.js";
+import { ServerNode } from "../../../src/Http/ServerNode.js";
+import { Topology } from "../../../src/Http/Topology.js";
+import { assertThat } from "../../Utils/AssertExtensions.js";
+
+describe("RDBC_1100", function () {
+
+    function createNode(clusterTag: string): ServerNode {
+        return new ServerNode({
+            url: "http://" + clusterTag.toLowerCase() + ".example.com",
+            database: "db",
+            clusterTag,
+            serverRole: "Member"
+        });
+    }
+
+    function createExecutorStub(node: ServerNode, healthCheckError?: Error) {
+        const executor = Object.create(RequestExecutor.prototype) as RequestExecutor;
+
+        const failedNodesTimers = new Map<ServerNode, NodeStatus>();
+        (executor as any)._failedNodesTimers = failedNodesTimers;
+        (executor as any)._nodeSelector = new NodeSelector(new Topology(1, [node]));
+        (executor as any)._log = { error: () => {}, warn: () => {}, info: () => {} };
+        (executor as any)._performHealthCheck = async () => {
+            if (healthCheckError) {
+                throw healthCheckError;
+            }
+        };
+
+        const timerCalls = { disposed: false, changed: false };
+        const nodeStatus = new NodeStatus(node, executor, () => Promise.resolve());
+        (nodeStatus as any)._timer = {
+            dispose: () => timerCalls.disposed = true,
+            change: () => timerCalls.changed = true
+        };
+        failedNodesTimers.set(node, nodeStatus);
+
+        return { executor, failedNodesTimers, nodeStatus, timerCalls };
+    }
+
+    it("recovered node is removed from failed nodes timers, so future health checks can spawn", async () => {
+        const node = createNode("A");
+        const { executor, failedNodesTimers, nodeStatus, timerCalls } = createExecutorStub(node);
+
+        await (executor as any)._checkNodeStatusCallback(nodeStatus);
+
+        assertThat(failedNodesTimers.has(node))
+            .isFalse();
+        assertThat(failedNodesTimers.size)
+            .isEqualTo(0);
+        assertThat(timerCalls.disposed)
+            .isTrue();
+    });
+
+    it("still-down node stays in failed nodes timers and its timer is rescheduled", async () => {
+        const node = createNode("A");
+        const { executor, failedNodesTimers, nodeStatus, timerCalls } =
+            createExecutorStub(node, new Error("Node is still down"));
+
+        await (executor as any)._checkNodeStatusCallback(nodeStatus);
+
+        assertThat(failedNodesTimers.has(node))
+            .isTrue();
+        assertThat(timerCalls.changed)
+            .isTrue();
+        assertThat(timerCalls.disposed)
+            .isFalse();
+    });
+});

--- a/test/Ported/Issues/RDBC_1100.ts
+++ b/test/Ported/Issues/RDBC_1100.ts
@@ -1,8 +1,15 @@
-﻿import { NodeSelector } from "../../../src/Http/NodeSelector.js";
-import { NodeStatus, RequestExecutor } from "../../../src/Http/RequestExecutor.js";
+import { NodeSelector } from "../../../src/Http/NodeSelector.js";
+import { NodeStatus } from "../../../src/Http/RequestExecutor.js";
 import { ServerNode } from "../../../src/Http/ServerNode.js";
 import { Topology } from "../../../src/Http/Topology.js";
+import { Timer } from "../../../src/Primitives/Timer.js";
 import { assertThat } from "../../Utils/AssertExtensions.js";
+import {
+    createBareRequestExecutor,
+    createNoopLogger,
+    internals,
+    nodeStatusInternals
+} from "../../Utils/RequestExecutorInternals.js";
 
 describe("RDBC_1100", function () {
 
@@ -16,13 +23,14 @@ describe("RDBC_1100", function () {
     }
 
     function createExecutorStub(node: ServerNode, healthCheckError?: Error) {
-        const executor = Object.create(RequestExecutor.prototype) as RequestExecutor;
+        const executor = createBareRequestExecutor();
+        const executorInternals = internals(executor);
 
         const failedNodesTimers = new Map<ServerNode, NodeStatus>();
-        (executor as any)._failedNodesTimers = failedNodesTimers;
-        (executor as any)._nodeSelector = new NodeSelector(new Topology(1, [node]));
-        (executor as any)._log = { error: () => {}, warn: () => {}, info: () => {} };
-        (executor as any)._performHealthCheck = async () => {
+        executorInternals._failedNodesTimers = failedNodesTimers;
+        executorInternals._nodeSelector = new NodeSelector(new Topology(1, [node]));
+        executorInternals._log = createNoopLogger();
+        executorInternals._performHealthCheck = async () => {
             if (healthCheckError) {
                 throw healthCheckError;
             }
@@ -30,20 +38,20 @@ describe("RDBC_1100", function () {
 
         const timerCalls = { disposed: false, changed: false };
         const nodeStatus = new NodeStatus(node, executor, () => Promise.resolve());
-        (nodeStatus as any)._timer = {
+        nodeStatusInternals(nodeStatus)._timer = {
             dispose: () => timerCalls.disposed = true,
             change: () => timerCalls.changed = true
-        };
+        } as unknown as Timer;
         failedNodesTimers.set(node, nodeStatus);
 
-        return { executor, failedNodesTimers, nodeStatus, timerCalls };
+        return { executorInternals, failedNodesTimers, nodeStatus, timerCalls };
     }
 
     it("recovered node is removed from failed nodes timers, so future health checks can spawn", async () => {
         const node = createNode("A");
-        const { executor, failedNodesTimers, nodeStatus, timerCalls } = createExecutorStub(node);
+        const { executorInternals, failedNodesTimers, nodeStatus, timerCalls } = createExecutorStub(node);
 
-        await (executor as any)._checkNodeStatusCallback(nodeStatus);
+        await executorInternals._checkNodeStatusCallback(nodeStatus);
 
         assertThat(failedNodesTimers.has(node))
             .isFalse();
@@ -55,10 +63,10 @@ describe("RDBC_1100", function () {
 
     it("still-down node stays in failed nodes timers and its timer is rescheduled", async () => {
         const node = createNode("A");
-        const { executor, failedNodesTimers, nodeStatus, timerCalls } =
+        const { executorInternals, failedNodesTimers, nodeStatus, timerCalls } =
             createExecutorStub(node, new Error("Node is still down"));
 
-        await (executor as any)._checkNodeStatusCallback(nodeStatus);
+        await executorInternals._checkNodeStatusCallback(nodeStatus);
 
         assertThat(failedNodesTimers.has(node))
             .isTrue();

--- a/test/Ported/Issues/RDBC_1101.ts
+++ b/test/Ported/Issues/RDBC_1101.ts
@@ -25,7 +25,6 @@ describe("RDBC_1101", function () {
 
         (executor as any)._nodeSelector = new NodeSelector(new Topology(1, nodes));
         (executor as any)._log = { error: () => {}, warn: () => {}, info: () => {} };
-        (executor as any)._lastReturnedResponse = new Date();
 
         executor.updateTopology = async (parameters: UpdateTopologyParameters) => {
             polled.push(parameters);

--- a/test/Ported/Issues/RDBC_1101.ts
+++ b/test/Ported/Issues/RDBC_1101.ts
@@ -1,0 +1,206 @@
+import { NodeSelector } from "../../../src/Http/NodeSelector.js";
+import { RequestExecutor } from "../../../src/Http/RequestExecutor.js";
+import { ServerNode, ServerNodeRole } from "../../../src/Http/ServerNode.js";
+import { Topology } from "../../../src/Http/Topology.js";
+import { UpdateTopologyParameters } from "../../../src/Http/UpdateTopologyParameters.js";
+import { DocumentStore, GetDatabaseTopologyCommand } from "../../../src/index.js";
+import { delay } from "../../../src/Utility/PromiseUtil.js";
+import { assertThat } from "../../Utils/AssertExtensions.js";
+import { ClusterTestContext, RavenTestContext } from "../../Utils/TestUtil.js";
+
+describe("RDBC_1101", function () {
+
+    function createNode(clusterTag: string, serverRole: ServerNodeRole): ServerNode {
+        return new ServerNode({
+            url: "http://" + clusterTag.toLowerCase() + ".example.com",
+            database: "db",
+            clusterTag,
+            serverRole
+        });
+    }
+
+    function createExecutorStub(nodes: ServerNode[], failingTags: Set<string> = new Set()) {
+        const executor = Object.create(RequestExecutor.prototype) as RequestExecutor;
+        const polled: UpdateTopologyParameters[] = [];
+
+        (executor as any)._nodeSelector = new NodeSelector(new Topology(1, nodes));
+        (executor as any)._log = { error: () => {}, warn: () => {}, info: () => {} };
+        (executor as any)._lastReturnedResponse = new Date();
+
+        executor.updateTopology = async (parameters: UpdateTopologyParameters) => {
+            polled.push(parameters);
+            if (failingTags.has(parameters.node.clusterTag)) {
+                throw new Error("Node " + parameters.node.clusterTag + " is down");
+            }
+            return true;
+        };
+
+        return { executor, polled };
+    }
+
+    it("serverNode constructor keeps serverRole", () => {
+        const node = createNode("A", "Member");
+        assertThat(node.serverRole)
+            .isEqualTo("Member");
+    });
+
+    it("topology timer polls every member node, even while requests are flowing", async () => {
+        const { executor, polled } = createExecutorStub([
+            createNode("A", "Member"),
+            createNode("B", "Member"),
+            createNode("C", "Member")
+        ]);
+
+        await (executor as any)._updateTopologyCallback();
+
+        assertThat(polled.map(x => x.node.clusterTag).join(","))
+            .isEqualTo("A,B,C");
+
+        for (const parameters of polled) {
+            assertThat(parameters.timeoutInMs)
+                .isEqualTo(0);
+            assertThat(parameters.debugTag)
+                .isEqualTo("timer-callback-node-" + parameters.node.clusterTag);
+        }
+    });
+
+    it("topology timer skips non-member nodes", async () => {
+        const { executor, polled } = createExecutorStub([
+            createNode("A", "Member"),
+            createNode("B", "Rehab"),
+            createNode("C", "Promotable"),
+            createNode("D", "Member")
+        ]);
+
+        await (executor as any)._updateTopologyCallback();
+
+        assertThat(polled.map(x => x.node.clusterTag).join(","))
+            .isEqualTo("A,D");
+    });
+
+    it("topology timer keeps polling remaining nodes when one fails", async () => {
+        const { executor, polled } = createExecutorStub([
+            createNode("A", "Member"),
+            createNode("B", "Member"),
+            createNode("C", "Member")
+        ], new Set(["A"]));
+
+        await (executor as any)._updateTopologyCallback();
+
+        assertThat(polled.map(x => x.node.clusterTag).join(","))
+            .isEqualTo("A,B,C");
+    });
+
+    it("topology timer is a no-op without a node selector", async () => {
+        const executor = Object.create(RequestExecutor.prototype) as RequestExecutor;
+        (executor as any)._nodeSelector = null;
+
+        await (executor as any)._updateTopologyCallback();
+    });
+});
+
+(RavenTestContext.isPullRequest ? describe.skip : describe)("RDBC_1101 - cluster", function () {
+
+    let testContext: ClusterTestContext;
+
+    beforeEach(async function () {
+        testContext = new ClusterTestContext();
+    });
+
+    afterEach(async () => testContext.dispose());
+
+    it("clientShouldFailoverWhenTalkingToLoneDisconnectedNode", async () => {
+        const cluster = await testContext.createRaftCluster(3, {
+            "Cluster.TimeBeforeMovingToRehabInSec": "1",
+            "Cluster.StatsStabilizationTimeInSec": "1"
+        });
+
+        try {
+            const databaseName = testContext.getDatabaseName();
+            await cluster.createDatabase(databaseName, 3, cluster.getInitialLeader().url);
+
+            const store = new DocumentStore(cluster.getInitialLeader().url, databaseName);
+            try {
+                store.initialize();
+
+                const executor = store.getRequestExecutor(databaseName);
+
+                // make sure we have an updated topology in the executor
+                const serverNode = new ServerNode({
+                    clusterTag: cluster.getInitialLeader().nodeTag,
+                    database: databaseName,
+                    url: cluster.getInitialLeader().url
+                });
+
+                const updateTopologyParameters = new UpdateTopologyParameters(serverNode);
+                updateTopologyParameters.timeoutInMs = 5000;
+                updateTopologyParameters.forceUpdate = true;
+                await executor.updateTopology(updateTopologyParameters);
+
+                let topology = new Topology();
+                while (!topology.nodes || topology.nodes.length !== 3) {
+                    const topologyGetCommand = new GetDatabaseTopologyCommand();
+                    await executor.execute(topologyGetCommand);
+                    topology = topologyGetCommand.result;
+                    await delay(50);
+                }
+
+                const selector = (executor as any)._nodeSelector as NodeSelector;
+
+                // kill the node the timer would poll - the preferred one
+                const preferredNode = selector.getPreferredNode().currentNode;
+                await cluster.disposeServer(cluster.getNodeByUrl(preferredNode.url).nodeTag);
+
+                // wait until the surviving nodes report 2 members + 1 rehab
+                const healthyUrl = cluster.getWorkingServer().url;
+                await waitForClusterTopologyOnServer(healthyUrl, databaseName, 2, 1);
+
+                // executor still thinks we have 3 members
+                const nodesBefore = selector.getTopology().nodes;
+                assertThat(nodesBefore.filter(x => x.serverRole === "Member"))
+                    .hasSize(3);
+
+                // artificially call the timer func
+                await (executor as any)._updateTopologyCallback();
+
+                // we expect the topology fetched from the healthy nodes, despite the dead preferred node
+                const nodesAfter = ((executor as any)._nodeSelector as NodeSelector).getTopology().nodes;
+                assertThat(nodesAfter.filter(x => x.serverRole === "Member"))
+                    .hasSize(2);
+                assertThat(nodesAfter.filter(x => x.serverRole === "Rehab"))
+                    .hasSize(1);
+            } finally {
+                store.dispose();
+            }
+        } finally {
+            cluster.dispose();
+        }
+    });
+
+    async function waitForClusterTopologyOnServer(serverUrl: string, databaseName: string, memberCount: number, rehabCount: number) {
+        const tempStore = new DocumentStore(serverUrl, databaseName);
+        try {
+            tempStore.conventions.disableTopologyUpdates = true;
+            tempStore.initialize();
+
+            const value = await ClusterTestContext.waitForValue<[number, number]>(async () => {
+                const topologyGetCommand = new GetDatabaseTopologyCommand();
+                await tempStore.getRequestExecutor().execute(topologyGetCommand);
+                const topo = topologyGetCommand.result;
+
+                return [
+                    topo.nodes.filter(x => x.serverRole === "Member").length,
+                    topo.nodes.filter(x => x.serverRole === "Rehab").length
+                ];
+            }, [memberCount, rehabCount], {
+                timeout: 60_000,
+                equal: (a, b) => a[0] === b[0] && a[1] === b[1]
+            });
+
+            assertThat(value[0]).isEqualTo(memberCount);
+            assertThat(value[1]).isEqualTo(rehabCount);
+        } finally {
+            tempStore.dispose();
+        }
+    }
+});

--- a/test/Ported/Issues/RDBC_1101.ts
+++ b/test/Ported/Issues/RDBC_1101.ts
@@ -1,11 +1,15 @@
 import { NodeSelector } from "../../../src/Http/NodeSelector.js";
-import { RequestExecutor } from "../../../src/Http/RequestExecutor.js";
 import { ServerNode, ServerNodeRole } from "../../../src/Http/ServerNode.js";
 import { Topology } from "../../../src/Http/Topology.js";
 import { UpdateTopologyParameters } from "../../../src/Http/UpdateTopologyParameters.js";
 import { DocumentStore, GetDatabaseTopologyCommand } from "../../../src/index.js";
 import { delay } from "../../../src/Utility/PromiseUtil.js";
 import { assertThat } from "../../Utils/AssertExtensions.js";
+import {
+    createBareRequestExecutor,
+    createNoopLogger,
+    internals
+} from "../../Utils/RequestExecutorInternals.js";
 import { ClusterTestContext, RavenTestContext } from "../../Utils/TestUtil.js";
 
 describe("RDBC_1101", function () {
@@ -20,11 +24,12 @@ describe("RDBC_1101", function () {
     }
 
     function createExecutorStub(nodes: ServerNode[], failingTags: Set<string> = new Set()) {
-        const executor = Object.create(RequestExecutor.prototype) as RequestExecutor;
+        const executor = createBareRequestExecutor();
+        const executorInternals = internals(executor);
         const polled: UpdateTopologyParameters[] = [];
 
-        (executor as any)._nodeSelector = new NodeSelector(new Topology(1, nodes));
-        (executor as any)._log = { error: () => {}, warn: () => {}, info: () => {} };
+        executorInternals._nodeSelector = new NodeSelector(new Topology(1, nodes));
+        executorInternals._log = createNoopLogger();
 
         executor.updateTopology = async (parameters: UpdateTopologyParameters) => {
             polled.push(parameters);
@@ -34,7 +39,7 @@ describe("RDBC_1101", function () {
             return true;
         };
 
-        return { executor, polled };
+        return { executorInternals, polled };
     }
 
     it("serverNode constructor keeps serverRole", () => {
@@ -44,13 +49,13 @@ describe("RDBC_1101", function () {
     });
 
     it("topology timer polls every member node, even while requests are flowing", async () => {
-        const { executor, polled } = createExecutorStub([
+        const { executorInternals, polled } = createExecutorStub([
             createNode("A", "Member"),
             createNode("B", "Member"),
             createNode("C", "Member")
         ]);
 
-        await (executor as any)._updateTopologyCallback();
+        await executorInternals._updateTopologyCallback();
 
         assertThat(polled.map(x => x.node.clusterTag).join(","))
             .isEqualTo("A,B,C");
@@ -64,37 +69,37 @@ describe("RDBC_1101", function () {
     });
 
     it("topology timer skips non-member nodes", async () => {
-        const { executor, polled } = createExecutorStub([
+        const { executorInternals, polled } = createExecutorStub([
             createNode("A", "Member"),
             createNode("B", "Rehab"),
             createNode("C", "Promotable"),
             createNode("D", "Member")
         ]);
 
-        await (executor as any)._updateTopologyCallback();
+        await executorInternals._updateTopologyCallback();
 
         assertThat(polled.map(x => x.node.clusterTag).join(","))
             .isEqualTo("A,D");
     });
 
     it("topology timer keeps polling remaining nodes when one fails", async () => {
-        const { executor, polled } = createExecutorStub([
+        const { executorInternals, polled } = createExecutorStub([
             createNode("A", "Member"),
             createNode("B", "Member"),
             createNode("C", "Member")
         ], new Set(["A"]));
 
-        await (executor as any)._updateTopologyCallback();
+        await executorInternals._updateTopologyCallback();
 
         assertThat(polled.map(x => x.node.clusterTag).join(","))
             .isEqualTo("A,B,C");
     });
 
     it("topology timer is a no-op without a node selector", async () => {
-        const executor = Object.create(RequestExecutor.prototype) as RequestExecutor;
-        (executor as any)._nodeSelector = null;
+        const executorInternals = internals(createBareRequestExecutor());
+        executorInternals._nodeSelector = null;
 
-        await (executor as any)._updateTopologyCallback();
+        await executorInternals._updateTopologyCallback();
     });
 });
 
@@ -144,7 +149,8 @@ describe("RDBC_1101", function () {
                     await delay(50);
                 }
 
-                const selector = (executor as any)._nodeSelector as NodeSelector;
+                const executorInternals = internals(executor);
+                const selector = executorInternals._nodeSelector;
 
                 // kill the node the timer would poll - the preferred one
                 const preferredNode = selector.getPreferredNode().currentNode;
@@ -160,10 +166,10 @@ describe("RDBC_1101", function () {
                     .hasSize(3);
 
                 // artificially call the timer func
-                await (executor as any)._updateTopologyCallback();
+                await executorInternals._updateTopologyCallback();
 
                 // we expect the topology fetched from the healthy nodes, despite the dead preferred node
-                const nodesAfter = ((executor as any)._nodeSelector as NodeSelector).getTopology().nodes;
+                const nodesAfter = executorInternals._nodeSelector.getTopology().nodes;
                 assertThat(nodesAfter.filter(x => x.serverRole === "Member"))
                     .hasSize(2);
                 assertThat(nodesAfter.filter(x => x.serverRole === "Rehab"))

--- a/test/Utils/RequestExecutorInternals.ts
+++ b/test/Utils/RequestExecutorInternals.ts
@@ -1,0 +1,46 @@
+import { NodeSelector } from "../../src/Http/NodeSelector.js";
+import { NodeStatus, RequestExecutor } from "../../src/Http/RequestExecutor.js";
+import { ServerNode } from "../../src/Http/ServerNode.js";
+import { ILogger } from "../../src/Utility/LogUtil.js";
+import { Timer } from "../../src/Primitives/Timer.js";
+
+export interface RequestExecutorInternals {
+    _nodeSelector: NodeSelector;
+    _failedNodesTimers: Map<ServerNode, NodeStatus>;
+    _log: ILogger;
+    _performHealthCheck(serverNode: ServerNode, nodeIndex: number): Promise<void>;
+    _checkNodeStatusCallback(nodeStatus: NodeStatus): Promise<void>;
+    _updateTopologyCallback(): Promise<void>;
+}
+
+export interface NodeStatusInternals {
+    _timer: Timer;
+}
+
+export function internals(executor: RequestExecutor): RequestExecutorInternals {
+    return executor as unknown as RequestExecutorInternals;
+}
+
+export function nodeStatusInternals(nodeStatus: NodeStatus): NodeStatusInternals {
+    return nodeStatus as unknown as NodeStatusInternals;
+}
+
+/**
+ * A RequestExecutor that skips the constructor, so tests can drive a single private
+ * callback without spinning up connections, topology updates or timers.
+ */
+export function createBareRequestExecutor(): RequestExecutor {
+    return Object.create(RequestExecutor.prototype) as RequestExecutor;
+}
+
+export function createNoopLogger(): ILogger {
+    const noop = () => {
+        // logging is irrelevant for these tests
+    };
+
+    return {
+        error: noop,
+        warn: noop,
+        info: noop
+    };
+}


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RDBC-1101
https://issues.hibernatingrhinos.com/issue/RDBC-1100

### Additional description

The timer callback no longer skips the refresh while requests are flowing (five-minute _lastReturnedResponse guard removed) and polls every Member node instead of only the preferred one, ignoring per-node failures, so a stalled preferred node can no longer block topology updates indefinitely.

Also fix ServerNode constructor discarding the serverRole option.


### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low
- [ ] Moderate
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`)
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
