### PR TITLE
RDBC-1083 - RavenDB NodeJS client can't run under Cloudflare Workers (even with node compat)

### DIFF
--- a/.github/workflows/Deno.yml
+++ b/.github/workflows/Deno.yml
@@ -1,0 +1,106 @@
+name: tests/deno
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches: [ v7.2 ]
+  pull_request:
+    branches: [ v7.2 ]
+  schedule:
+    - cron: '0 10 * * *'
+  workflow_dispatch:
+
+jobs:
+  # Full mTLS data-path end-to-end on Deno: the client configured with a PEM
+  # certificate via authOptions performs a real store + load against a *secured*
+  # RavenDB server (guards the RDBC-1083 mTLS family - before the fix Deno
+  # silently sent uncertified requests that failed with a bare 403).
+  e2e-mtls:
+    name: e2e mTLS (deno -> secured RavenDB)
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        deno-version: [v2.x]
+        serverVersion: ["7.2"]
+    env:
+      RAVEN_License: ${{ secrets.RAVEN_LICENSE }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+
+      - name: Setup Deno ${{ matrix.deno-version }}
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: ${{ matrix.deno-version }}
+
+      # A mini PKI: CA + one leaf used as both the server certificate (pfx) and the
+      # client certificate (pem) - RavenDB trusts its own certificate as ClusterAdmin.
+      # The key is converted to PKCS#1 because the client's PEM parsing expects
+      # a "BEGIN RSA PRIVATE KEY" block.
+      - name: Generate certificates
+        run: |
+          mkdir certs && cd certs
+          openssl req -x509 -newkey rsa:2048 -keyout ca-key.pem -out ca.pem -days 2 -nodes \
+            -subj "/CN=deno-smoke-ca" -addext "basicConstraints=critical,CA:TRUE" \
+            -addext "keyUsage=critical,keyCertSign,cRLSign"
+          openssl genrsa -out key-pkcs8.pem 2048
+          openssl rsa -in key-pkcs8.pem -out key.pem -traditional
+          openssl req -new -key key.pem -subj "/CN=localhost" -out leaf.csr
+          printf "subjectAltName=DNS:localhost,IP:127.0.0.1\nkeyUsage=digitalSignature,keyEncipherment\nextendedKeyUsage=serverAuth,clientAuth\nbasicConstraints=CA:FALSE\n" > leaf.ext
+          openssl x509 -req -in leaf.csr -CA ca.pem -CAkey ca-key.pem -CAcreateserial -days 2 -extfile leaf.ext -out cert.pem
+          openssl pkcs12 -export -out server.pfx -inkey key.pem -in cert.pem -certfile ca.pem -passout pass:
+          cat cert.pem key.pem > client.pem
+
+      - name: Download RavenDB Server
+        run: wget -O RavenDB.tar.bz2 "https://hibernatingrhinos.com/downloads/RavenDB%20for%20Linux%20x64/latest?buildType=nightly&version=${{ matrix.serverVersion }}"
+
+      - name: Extract RavenDB Server
+        run: tar xjf RavenDB.tar.bz2
+
+      - name: Start RavenDB (secured, in-memory)
+        run: |
+          chmod +x ./RavenDB/Server/Raven.Server
+          ./RavenDB/Server/Raven.Server \
+            --non-interactive \
+            --ServerUrl=https://0.0.0.0:8080 \
+            --PublicServerUrl=https://localhost:8080 \
+            --Setup.Mode=None \
+            --Security.Certificate.Path="$PWD/certs/server.pfx" \
+            --License.Eula.Accepted=true \
+            --RunInMemory=true &
+          for i in $(seq 1 60); do
+            if curl -sf --cert certs/client.pem --cacert certs/ca.pem https://localhost:8080/build/version > /dev/null; then echo "RavenDB up"; exit 0; fi
+            sleep 1
+          done
+          echo "RavenDB did not start in time" && exit 1
+
+      - name: Create the smoke database
+        run: |
+          curl -sf -X PUT "https://localhost:8080/admin/databases?name=smoke&replicationFactor=1" \
+            --cert certs/client.pem --cacert certs/ca.pem \
+            -H "Content-Type: application/json" -d '{"DatabaseName":"smoke"}' > /dev/null
+
+      # `npm ci` runs `prepare` (tshy build): builds dist/ the example resolves.
+      - name: Build the client
+        run: npm ci
+
+      - name: Install example deps (resolves ravendb from repo root)
+        working-directory: test/deno
+        run: npm install
+
+      - name: End-to-end mTLS store/load on Deno against RavenDB
+        working-directory: test/deno
+        env:
+          RAVENDB_URL: https://localhost:8080
+          RAVENDB_DATABASE: smoke
+          RAVENDB_CLIENT_CERT: ${{ github.workspace }}/certs/client.pem
+          RAVENDB_CA: ${{ github.workspace }}/certs/ca.pem
+        run: npm run smoke

--- a/.github/workflows/Deno.yml
+++ b/.github/workflows/Deno.yml
@@ -43,16 +43,15 @@ jobs:
 
       # A mini PKI: CA + one leaf used as both the server certificate (pfx) and the
       # client certificate (pem) - RavenDB trusts its own certificate as ClusterAdmin.
-      # The key is converted to PKCS#1 because the client's PEM parsing expects
-      # a "BEGIN RSA PRIVATE KEY" block.
+      # The key stays PKCS#8 ("BEGIN PRIVATE KEY", the OpenSSL 3 default) on purpose:
+      # it is the format users get from openssl and the client must accept it.
       - name: Generate certificates
         run: |
           mkdir certs && cd certs
           openssl req -x509 -newkey rsa:2048 -keyout ca-key.pem -out ca.pem -days 2 -nodes \
             -subj "/CN=deno-smoke-ca" -addext "basicConstraints=critical,CA:TRUE" \
             -addext "keyUsage=critical,keyCertSign,cRLSign"
-          openssl genrsa -out key-pkcs8.pem 2048
-          openssl rsa -in key-pkcs8.pem -out key.pem -traditional
+          openssl genrsa -out key.pem 2048
           openssl req -new -key key.pem -subj "/CN=localhost" -out leaf.csr
           printf "subjectAltName=DNS:localhost,IP:127.0.0.1\nkeyUsage=digitalSignature,keyEncipherment\nextendedKeyUsage=serverAuth,clientAuth\nbasicConstraints=CA:FALSE\n" > leaf.ext
           openssl x509 -req -in leaf.csr -CA ca.pem -CAkey ca-key.pem -CAcreateserial -days 2 -extfile leaf.ext -out cert.pem

--- a/.mocharc.jsonc
+++ b/.mocharc.jsonc
@@ -2,11 +2,12 @@
   "slow": 1000,
   "timeout": 40000,
 
-  // The test/cloudflare-* dirs are self-contained Cloudflare example projects
+  // The test/cloudflare-* and test/deno dirs are self-contained example projects
   // (with their own deps); they must not be picked up by the "test/**/*.ts"
   // runner or it fails to resolve their bundler deps (e.g. nitropack).
   "ignore": [
-    "test/cloudflare-*/**"
+    "test/cloudflare-*/**",
+    "test/deno/**"
   ],
 
   "node-option": [

--- a/README.md
+++ b/README.md
@@ -2366,10 +2366,12 @@ You can confirm it worked: the built bundle no longer inlines `unenv` `node:*` s
 and requests stream responses successfully.
 
 **3. mTLS is done with a Cloudflare `mtls_certificate` binding, not `authOptions`.**
-Workers has no Node `https` agent, so X.509 client-certificate authentication cannot
-use the usual `authOptions` certificate. Instead, upload the client certificate to
-Cloudflare and hand the client a `fetch` bound to that certificate via
-`conventions.customFetch`:
+Workers cannot present an X.509 client certificate from JavaScript — not via `fetch`,
+not via `cloudflare:sockets`, not via `node:tls` under `nodejs_compat`. Configuring a
+certificate through `authOptions` therefore fails fast: `DocumentStore.initialize()`
+throws an error explaining the options. The supported mechanism is an
+`mtls_certificate` binding: upload the client certificate to Cloudflare and hand the
+client a `fetch` bound to that certificate via `conventions.customFetch`:
 
 ```bash
 # Upload the RavenDB client certificate (PEM: cert + key) once:
@@ -2403,8 +2405,74 @@ export default {
 };
 ```
 
+Creating the binding requires access to the Cloudflare account that owns the
+deployment (`wrangler.toml` plus an "SSL and Certificates Edit" API token). If the app
+is deployed through a platform that owns the account for you (e.g. Lovable), export
+the project to your own Cloudflare account — a free plan is enough — or move the
+RavenDB calls to a backend you host that supports mTLS and call that backend from the
+worker.
+
+**4. Features that need raw sockets do not work on workerd.** The Changes API uses a
+WebSocket client (`ws`) and subscriptions use a raw TCP (`node:tls`) connection —
+neither is available on Cloudflare Workers, regardless of how mTLS is provided. Use
+the document/query APIs from workers, and run Changes API consumers and subscription
+workers on a Node process.
+
 A minimal, runnable load check lives in [`test/cloudflare-worker`](./test/cloudflare-worker)
 and runs in CI.
+
+## Deno
+
+The client runs on [Deno](https://deno.com) (2.x), including X.509
+client-certificate authentication: configure `authOptions` with a **PEM** certificate
+exactly like on Node, and the client presents it through `Deno.createHttpClient`.
+
+```javascript
+import { DocumentStore } from "ravendb";
+
+const authOptions = {
+    type: "pem",
+    certificate: Deno.readTextFileSync("client.pem"), // certificate + private key
+    ca: Deno.readTextFileSync("ca.pem")               // optional, for a private CA
+};
+
+const store = new DocumentStore("https://a.free.example.ravendb.cloud", "MyDatabase", authOptions);
+store.initialize();
+```
+
+Deno-specific notes:
+
+- **PEM only.** `Deno.createHttpClient` does not accept PKCS#12 archives or encrypted
+  keys, so a PFX certificate or a PEM with a passphrase throws an actionable error —
+  convert with `openssl pkcs12 -in cert.pfx -out cert.pem -nodes`.
+- **`authOptions.ca` is passed as `caCerts`**, so a server behind a private CA works
+  without `DENO_CERT` / `--cert`.
+- On Deno-based platforms that remove `Deno.createHttpClient`, the client throws an
+  actionable error instead of sending uncertified requests; provide the transport via
+  `conventions.customFetch` (see below) in that case.
+- Like on workerd, the Changes API (WebSocket) and subscriptions (raw TCP) are not
+  supported — use the document/query APIs.
+
+An end-to-end smoke test lives in [`test/deno`](./test/deno).
+
+## Custom fetch: bring your own transport
+
+On runtimes where the client cannot provide authentication itself,
+`conventions.customFetch` replaces the transport with any fetch-compatible function.
+The client calls it exactly like the global `fetch` — `customFetch(url, init)` — for
+every HTTP request (document operations, queries, topology updates). Set it before
+`initialize()`:
+
+```javascript
+const store = new DocumentStore(urls, database);
+store.conventions.customFetch = myFetch; // e.g. a Cloudflare mtls_certificate binding's fetch
+store.initialize();
+```
+
+When `customFetch` is set the client does not build an HTTP(S) agent and does not
+require a certificate in `authOptions` — the supplied fetch owns connection handling
+and authentication (mTLS, a relay with its own credentials, request signing, and so
+on).
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -2299,6 +2299,9 @@ let authOptions = {
 };
 ``` 
 
+The private key block may be PKCS#1 (`BEGIN RSA PRIVATE KEY`), PKCS#8 (`BEGIN PRIVATE KEY`,
+what OpenSSL 3 emits by default) or SEC1 (`BEGIN EC PRIVATE KEY`).
+
 PFX certificates content should be passed as a `Buffer` object:
 
 ```javascript
@@ -2444,7 +2447,9 @@ Deno-specific notes:
 
 - **PEM only.** `Deno.createHttpClient` does not accept PKCS#12 archives or encrypted
   keys, so a PFX certificate or a PEM with a passphrase throws an actionable error —
-  convert with `openssl pkcs12 -in cert.pfx -out cert.pem -nodes`.
+  convert with `openssl pkcs12 -in cert.pfx -out cert.pem -nodes` (the PKCS#8
+  `BEGIN PRIVATE KEY` block it writes is accepted as-is). A PEM without a private key
+  block throws as well.
 - **`authOptions.ca` is passed as `caCerts`**, so a server behind a private CA works
   without `DENO_CERT` / `--cert`.
 - On Deno-based platforms that remove `Deno.createHttpClient`, the client throws an

--- a/README.md
+++ b/README.md
@@ -2452,8 +2452,12 @@ Deno-specific notes:
   `conventions.customFetch` (see below) in that case. [Bunny Edge
   Scripting](https://bunny.net/edge-scripting/) keeps the API available — the client is
   verified end-to-end there (store + load against RavenDB Cloud over mTLS).
-- Like on workerd, the Changes API (WebSocket) and subscriptions (raw TCP) are not
-  supported — use the document/query APIs.
+- **The Changes API and subscriptions are untested on Deno.** Both bypass
+  `Deno.createHttpClient`: the Changes API opens a `ws` WebSocket and subscriptions a
+  `node:tls` socket, each handed the certificate as Node `tls` options through Deno's
+  Node compatibility layer. Only the fetch-based document/query APIs are verified
+  end-to-end; run Changes API consumers and subscription workers on Node unless you
+  have verified them on your Deno version.
 
 An end-to-end smoke test lives in [`test/deno`](./test/deno).
 

--- a/README.md
+++ b/README.md
@@ -2449,7 +2449,9 @@ Deno-specific notes:
   without `DENO_CERT` / `--cert`.
 - On Deno-based platforms that remove `Deno.createHttpClient`, the client throws an
   actionable error instead of sending uncertified requests; provide the transport via
-  `conventions.customFetch` (see below) in that case.
+  `conventions.customFetch` (see below) in that case. [Bunny Edge
+  Scripting](https://bunny.net/edge-scripting/) keeps the API available — the client is
+  verified end-to-end there (store + load against RavenDB Cloud over mTLS).
 - Like on workerd, the Changes API (WebSocket) and subscriptions (raw TCP) are not
   supported — use the document/query APIs.
 

--- a/src/Auth/Certificate.ts
+++ b/src/Auth/Certificate.ts
@@ -127,7 +127,12 @@ export abstract class Certificate implements ICertificate {
 
 export class PemCertificate extends Certificate {
     private readonly _certToken: string = "CERTIFICATE";
-    private readonly _keyToken: string = "RSA PRIVATE KEY";
+    /**
+     * Private key PEM labels accepted, in lookup order: PKCS#1 (RSA), SEC1 (EC),
+     * PKCS#8 - what OpenSSL 3 emits by default (openssl genrsa, openssl pkcs12 -nodes) -
+     * and encrypted PKCS#8.
+     */
+    private readonly _keyTokens: string[] = ["RSA PRIVATE KEY", "EC PRIVATE KEY", "PRIVATE KEY", "ENCRYPTED PRIVATE KEY"];
     protected _key: string;
 
     constructor(certificate: string | Buffer, passphrase?: string, ca?: string | Buffer) {
@@ -137,7 +142,7 @@ export class PemCertificate extends Certificate {
             this._certificate = certificate.toString();
         }
 
-        this._key = this._fetchPart(this._keyToken);
+        this._key = this._keyTokens.map(token => this._fetchPart(token)).find(Boolean) ?? null;
         this._certificate = this._fetchPart(this._certToken);
 
         if (!this._key && !this._certificate) {
@@ -189,6 +194,14 @@ export class PemCertificate extends Certificate {
 
     public toDenoHttpClientOptions(): DenoHttpClientOptions {
         const options = super.toDenoHttpClientOptions();
+
+        if (!this._key) {
+            throwError("InvalidArgumentException",
+                "The PEM certificate has no private key block, so it cannot authenticate the client on Deno. "
+                + "Put the certificate and its private key (\"BEGIN PRIVATE KEY\", \"BEGIN RSA PRIVATE KEY\" "
+                + "or \"BEGIN EC PRIVATE KEY\") in authOptions.certificate.");
+        }
+
         return {
             ...options,
             cert: this._certificate as string,

--- a/src/Auth/Certificate.ts
+++ b/src/Auth/Certificate.ts
@@ -8,11 +8,22 @@ import { BunTlsOptions } from "../Types/BunTypes.js";
 
 export type CertificateType = "pem" | "pfx";
 
+/**
+ * Subset of Deno.CreateHttpClientOptions the client cares about
+ * (mirrored here so the Node build does not depend on Deno types).
+ */
+export interface DenoHttpClientOptions {
+    cert?: string;
+    key?: string;
+    caCerts?: string[];
+}
+
 export interface ICertificate {
     toAgentOptions(): Agent.Options;
     toSocketOptions(): ConnectionOptions;
     toWebSocketOptions(): ClientOptions;
     toBunTlsOptions(): BunTlsOptions;
+    toDenoHttpClientOptions(): DenoHttpClientOptions;
 }
 
 export abstract class Certificate implements ICertificate {
@@ -101,6 +112,17 @@ export abstract class Certificate implements ICertificate {
 
         return {};
     }
+
+    public toDenoHttpClientOptions(): DenoHttpClientOptions {
+        if (this._passphrase) {
+            throwError("InvalidArgumentException",
+                "Deno.createHttpClient does not support encrypted private keys, so a certificate "
+                + "with a passphrase cannot be used on Deno. Decrypt the key "
+                + "(e.g. openssl rsa -in encrypted.key -out decrypted.key) and configure the decrypted PEM.");
+        }
+
+        return {};
+    }
 }
 
 export class PemCertificate extends Certificate {
@@ -162,6 +184,16 @@ export class PemCertificate extends Certificate {
             cert: this._certificate,
             key: this._key,
             ca: this._ca
+        };
+    }
+
+    public toDenoHttpClientOptions(): DenoHttpClientOptions {
+        const options = super.toDenoHttpClientOptions();
+        return {
+            ...options,
+            cert: this._certificate as string,
+            key: this._key,
+            caCerts: this._ca ? [this._ca.toString()] : undefined
         };
     }
 
@@ -237,5 +269,13 @@ export class PfxCertificate extends Certificate {
             pfx: this._certificate as Buffer,
             ca: this._ca
         };
+    }
+
+    public toDenoHttpClientOptions(): DenoHttpClientOptions {
+        return throwError("InvalidArgumentException",
+            "PFX (PKCS#12) client certificates are not supported on Deno - Deno.createHttpClient "
+            + "accepts PEM only. Convert the certificate to PEM "
+            + "(e.g. openssl pkcs12 -in cert.pfx -out cert.pem -nodes) "
+            + "and configure authOptions with type \"pem\".");
     }
 }

--- a/src/Documents/DocumentStore.ts
+++ b/src/Documents/DocumentStore.ts
@@ -289,6 +289,7 @@ export class DocumentStore extends DocumentStoreBase {
         this._assertValidConfiguration();
 
         RequestExecutor.validateUrls(this.urls, this.authOptions);
+        RequestExecutor.validateCertificateRuntimeSupport(this.authOptions, this.conventions);
 
         try {
             if (!this.conventions.documentIdGenerator) { // don't overwrite what the user is doing

--- a/src/Http/RavenCommand.ts
+++ b/src/Http/RavenCommand.ts
@@ -168,9 +168,11 @@ export abstract class RavenCommand<TResult> {
             }
             optionsToUse = { body: bodyToUse, ...restOptions, dispatcher: agent } as RequestInit;
         } else {
-            // Bun and Cloudflare Workers (workerd) have no undici `dispatcher` concept, so
-            // one must never leak into their fetch init. On workerd mTLS is handled by the
-            // custom fetch (an mtls_certificate binding); Bun manages TLS itself.
+            // Bun, Cloudflare Workers (workerd) and Deno have no undici `dispatcher`
+            // concept, so one must never leak into their fetch init. On workerd mTLS is
+            // handled by the custom fetch (an mtls_certificate binding); Bun manages TLS
+            // itself (`tls` request option); Deno presents the certificate through a
+            // Deno.HttpClient (`client` request option).
             optionsToUse = { body: bodyToUse, ...restOptions } as RequestInit;
         }
 

--- a/src/Http/RequestExecutor.ts
+++ b/src/Http/RequestExecutor.ts
@@ -50,7 +50,7 @@ import { Dispatcher, Agent } from "undici-types";
 import { EOL } from "../Utility/OsUtil.js";
 import { importFix } from "../Utility/ImportUtil.js";
 import { RuntimeUtil } from "../Utility/RuntimeUtil.js";
-import { createDenoHttpClient } from "../Utility/DenoHttpUtil.js";
+import { createDenoHttpClient, DenoHttpClient, validateDenoCertificateSupport } from "../Utility/DenoHttpUtil.js";
 
 const DEFAULT_REQUEST_OPTIONS = {};
 
@@ -244,6 +244,9 @@ export class RequestExecutor implements IDisposable {
 
     protected _defaultRequestOptions: HttpRequestParametersWithoutUri;
 
+    /** Deno only: the Deno.HttpClient presenting the client certificate, built lazily in _getDenoHttpClient(). */
+    private _denoHttpClient: DenoHttpClient = null;
+
     public static requestPostProcessor: (req: HttpRequestParameters) => void = null;
 
     public get customHttpRequestOptions(): HttpRequestParametersWithoutUri {
@@ -359,8 +362,9 @@ export class RequestExecutor implements IDisposable {
 
         // Runtimes whose fetch has no undici dispatcher (Bun, Cloudflare Workers, Deno)
         // can't use an http agent -- there is nothing to build. A configured certificate
-        // is presented another way there: Bun via the `tls` request option, Deno via a
-        // Deno.HttpClient `client` request option (both set in _setDefaultRequestOptions).
+        // is presented another way there: Bun via the `tls` request option (set in
+        // _setDefaultRequestOptions), Deno via a Deno.HttpClient `client` request option
+        // (set in _createRequest).
         if (!RuntimeUtil.supportsUndiciDispatcher()) {
             // On workerd a client certificate can never be presented from user-space
             // unless mTLS is wired through conventions.customFetch (checked above).
@@ -387,7 +391,7 @@ export class RequestExecutor implements IDisposable {
             if (RequestExecutor.HTTPS_AGENT_CACHE.has(cacheKey)) {
                 return RequestExecutor.HTTPS_AGENT_CACHE.get(cacheKey);
             } else {
-                const agent = await RequestExecutor.createAgent(agentOptions, true);
+                const agent = await RequestExecutor.createAgent(agentOptions, { requiredForCertificate: true });
 
                 RequestExecutor.HTTPS_AGENT_CACHE.set(cacheKey, agent);
                 return agent;
@@ -401,9 +405,10 @@ export class RequestExecutor implements IDisposable {
 
     /**
      * Throws when an X.509 client certificate is configured on a runtime that cannot
-     * present it (and no conventions.customFetch is set to take over the transport).
-     * Called from DocumentStore.initialize() so misconfiguration surfaces at startup
-     * instead of on the first request.
+     * present it (and no conventions.customFetch is set to take over the transport):
+     * workerd never can; Deno cannot without Deno.createHttpClient, nor for a PFX
+     * archive or a passphrase-protected key. Called from DocumentStore.initialize() so
+     * misconfiguration surfaces at startup instead of on the first request.
      */
     public static validateCertificateRuntimeSupport(
         authOptions: IAuthOptions,
@@ -415,6 +420,10 @@ export class RequestExecutor implements IDisposable {
 
         if (RuntimeUtil.isWorkerd()) {
             throwError("InvalidOperationException", WORKERD_MTLS_ERROR);
+        }
+
+        if (RuntimeUtil.isDeno()) {
+            validateDenoCertificateSupport(Certificate.createFromOptions(authOptions));
         }
     }
 
@@ -431,7 +440,9 @@ export class RequestExecutor implements IDisposable {
         }
     }
 
-    private static async createAgent(options: Agent.Options, requiredForCertificate = false) {
+    private static async createAgent(
+        options: Agent.Options,
+        { requiredForCertificate = false }: { requiredForCertificate?: boolean } = {}) {
         try {
             let UndiciAgent;
 
@@ -1487,6 +1498,16 @@ export class RequestExecutor implements IDisposable {
         }
 
         const req = Object.assign(request, this._defaultRequestOptions);
+
+        // Deno presents a client certificate through a Deno.HttpClient passed as the
+        // `client` fetch init option - the undici agent path is a silent no-op there.
+        // Built lazily, once per executor (mirroring getHttpAgent's agent cache) and
+        // closed in dispose(). When conventions.customFetch owns the transport mTLS is
+        // its job - the same rule getHttpAgent applies.
+        if (RuntimeUtil.isDeno() && this._certificate && !this.conventions.customFetch) {
+            req.client = this._getDenoHttpClient();
+        }
+
         urlRef(req.uri);
         req.headers = req.headers || {};
 
@@ -2004,19 +2025,25 @@ export class RequestExecutor implements IDisposable {
 
 
     private _setDefaultRequestOptions(): void {
+        // Object.assign mutates its target: copying into a fresh object keeps one
+        // executor's options (custom options, Bun `tls`) from leaking into every other
+        // executor in the process through the shared module-level default.
         this._defaultRequestOptions = Object.assign(
+            {},
             DEFAULT_REQUEST_OPTIONS,
             this._customHttpRequestOptions);
 
         if (RuntimeUtil.isBun() && this._certificate) {
             this._defaultRequestOptions.tls = this._certificate.toBunTlsOptions();
         }
+    }
 
-        // Deno's fetch presents a client certificate through a Deno.HttpClient passed
-        // as the `client` init option - the undici agent path is a silent no-op there.
-        if (RuntimeUtil.isDeno() && this._certificate) {
-            this._defaultRequestOptions.client = createDenoHttpClient(this._certificate);
+    private _getDenoHttpClient(): DenoHttpClient {
+        if (!this._denoHttpClient) {
+            this._denoHttpClient = createDenoHttpClient(this._certificate);
         }
+
+        return this._denoHttpClient;
     }
 
     public dispose(): void {
@@ -2040,6 +2067,10 @@ export class RequestExecutor implements IDisposable {
         this._nodeSelector?.dispose();
 
         this._disposeAllFailedNodesTimers();
+
+        // Deno only: release the connection pool behind the client certificate.
+        this._denoHttpClient?.close();
+        this._denoHttpClient = null;
     }
 
     public async getRequestedNode(nodeTag: string, throwIfContainsFailures = false): Promise<CurrentIndexAndNode> {

--- a/src/Http/RequestExecutor.ts
+++ b/src/Http/RequestExecutor.ts
@@ -50,8 +50,27 @@ import { Dispatcher, Agent } from "undici-types";
 import { EOL } from "../Utility/OsUtil.js";
 import { importFix } from "../Utility/ImportUtil.js";
 import { RuntimeUtil } from "../Utility/RuntimeUtil.js";
+import { createDenoHttpClient } from "../Utility/DenoHttpUtil.js";
 
 const DEFAULT_REQUEST_OPTIONS = {};
+
+// RDBC-1083: thrown both at DocumentStore.initialize() (validateCertificateRuntimeSupport)
+// and on the request path (getHttpAgent) when an X.509 client certificate is configured on
+// workerd, where user-space code cannot present one. Deliberately lists ways out that do
+// not require access to the Cloudflare account owning the deployment.
+const WORKERD_MTLS_ERROR =
+    "A client certificate was configured via authOptions, but Cloudflare Workers (workerd) cannot "
+    + "present an X.509 client certificate from JavaScript - mTLS on workerd works only through a "
+    + "Cloudflare mtls_certificate binding. "
+    + "If you control the Cloudflare account: upload the certificate "
+    + "(npx wrangler mtls-certificate upload --cert client.crt --key client.key --name ravendb), "
+    + "bind it in wrangler.toml (mtls_certificates = [...]), remove the certificate from authOptions "
+    + "and set conventions.customFetch = env.<BINDING>.fetch.bind(env.<BINDING>) - see the "
+    + "\"Cloudflare Workers\" section of the README. "
+    + "If the app is deployed through a platform that owns the Cloudflare account (e.g. Lovable): "
+    + "export the project to your own Cloudflare account (a free plan is enough) to gain wrangler.toml "
+    + "access, or move the RavenDB calls to a backend you host that supports mTLS and call that "
+    + "backend from the worker.";
 
 const log = getLogger({ module: "RequestExecutor" });
 
@@ -338,19 +357,18 @@ export class RequestExecutor implements IDisposable {
             return null;
         }
 
-        // Runtimes whose fetch has no undici dispatcher (Bun, Cloudflare Workers) can't use
-        // an http agent -- there is nothing to build.
+        // Runtimes whose fetch has no undici dispatcher (Bun, Cloudflare Workers, Deno)
+        // can't use an http agent -- there is nothing to build. A configured certificate
+        // is presented another way there: Bun via the `tls` request option, Deno via a
+        // Deno.HttpClient `client` request option (both set in _setDefaultRequestOptions).
         if (!RuntimeUtil.supportsUndiciDispatcher()) {
-            // On workerd a client certificate configured the Node way can never be presented
-            // (no Node https agent) unless mTLS is wired through conventions.customFetch
-            // (checked above). Fail fast with an actionable message instead of silently
-            // issuing an uncertified request.
+            // On workerd a client certificate can never be presented from user-space
+            // unless mTLS is wired through conventions.customFetch (checked above).
+            // Fail fast with an actionable message instead of silently issuing an
+            // uncertified request. Normally initialize() already threw this
+            // (validateCertificateRuntimeSupport) -- this guards direct RequestExecutor use.
             if (RuntimeUtil.isWorkerd() && this._certificate) {
-                throwError("InvalidOperationException",
-                    "A client certificate was configured via authOptions, but Cloudflare Workers has no Node "
-                    + "https agent to present it. On workerd, X.509 mTLS must be provided through a Cloudflare "
-                    + "mtls_certificate binding wired into conventions.customFetch (see the \"Cloudflare Workers\" "
-                    + "section of the README). Remove the certificate from authOptions and set conventions.customFetch.");
+                throwError("InvalidOperationException", WORKERD_MTLS_ERROR);
             }
             return null;
         }
@@ -369,7 +387,7 @@ export class RequestExecutor implements IDisposable {
             if (RequestExecutor.HTTPS_AGENT_CACHE.has(cacheKey)) {
                 return RequestExecutor.HTTPS_AGENT_CACHE.get(cacheKey);
             } else {
-                const agent = await RequestExecutor.createAgent(agentOptions);
+                const agent = await RequestExecutor.createAgent(agentOptions, true);
 
                 RequestExecutor.HTTPS_AGENT_CACHE.set(cacheKey, agent);
                 return agent;
@@ -378,6 +396,25 @@ export class RequestExecutor implements IDisposable {
             return RequestExecutor.KEEP_ALIVE_HTTP_AGENT ??= await RequestExecutor.createAgent({
                 pipelining: 0
             });
+        }
+    }
+
+    /**
+     * Throws when an X.509 client certificate is configured on a runtime that cannot
+     * present it (and no conventions.customFetch is set to take over the transport).
+     * Called from DocumentStore.initialize() so misconfiguration surfaces at startup
+     * instead of on the first request.
+     */
+    public static validateCertificateRuntimeSupport(
+        authOptions: IAuthOptions,
+        conventions: DocumentConventions): void {
+
+        if (!authOptions?.certificate || conventions?.customFetch) {
+            return;
+        }
+
+        if (RuntimeUtil.isWorkerd()) {
+            throwError("InvalidOperationException", WORKERD_MTLS_ERROR);
         }
     }
 
@@ -394,7 +431,7 @@ export class RequestExecutor implements IDisposable {
         }
     }
 
-    private static async createAgent(options: Agent.Options) {
+    private static async createAgent(options: Agent.Options, requiredForCertificate = false) {
         try {
             let UndiciAgent;
 
@@ -416,7 +453,17 @@ export class RequestExecutor implements IDisposable {
 
             return new UndiciAgent(options);
         } catch (err) {
-            // If we can't import undici - we might be in cloudflare env - simply return no-agent.
+            // A missing undici only costs keep-alive tuning on a plain (uncertified)
+            // connection - degrade silently. But when the agent is what would present a
+            // configured client certificate, degrading would send uncertified requests
+            // that fail with a bare 401/403 (RDBC-1083) - fail loudly instead.
+            if (requiredForCertificate) {
+                throwError("InvalidOperationException",
+                    "A client certificate was configured via authOptions, but the undici Agent needed to "
+                    + "present it could not be loaded in this runtime, so the certificate cannot be "
+                    + "presented. No uncertified request was sent. Make the undici package resolvable, or "
+                    + "provide a fetch that performs mTLS via conventions.customFetch.", err);
+            }
             return null;
         }
     }
@@ -1963,6 +2010,12 @@ export class RequestExecutor implements IDisposable {
 
         if (RuntimeUtil.isBun() && this._certificate) {
             this._defaultRequestOptions.tls = this._certificate.toBunTlsOptions();
+        }
+
+        // Deno's fetch presents a client certificate through a Deno.HttpClient passed
+        // as the `client` init option - the undici agent path is a silent no-op there.
+        if (RuntimeUtil.isDeno() && this._certificate) {
+            this._defaultRequestOptions.client = createDenoHttpClient(this._certificate);
         }
     }
 

--- a/src/Primitives/Http.ts
+++ b/src/Primitives/Http.ts
@@ -4,10 +4,14 @@ export type HttpRequestParameters = RequestInit & {
   uri: string;
   fetcher?: any;
   tls?: BunTlsOptions;
+  /** Deno only: a Deno.HttpClient presenting the configured client certificate. */
+  client?: unknown;
 };
 export type HttpRequestParametersWithoutUri = RequestInit & {
   fetcher?: any;
   tls?: BunTlsOptions;
+  /** Deno only: a Deno.HttpClient presenting the configured client certificate. */
+  client?: unknown;
 };
 export type HttpResponse = Response;
 export type HttpRequest = Request;

--- a/src/Utility/DenoHttpUtil.ts
+++ b/src/Utility/DenoHttpUtil.ts
@@ -2,16 +2,17 @@ import { ICertificate } from "../Auth/Certificate.js";
 import { throwError } from "../Exceptions/index.js";
 
 /**
- * Builds a Deno HttpClient presenting the configured X.509 client certificate,
- * for passing as the (Deno-specific) `client` option of `fetch`. This is the
- * only way to do mTLS on Deno - its fetch has no undici dispatcher concept and
- * silently ignores one, which is exactly how certificates used to get dropped
- * (RDBC-1083).
- *
- * `Deno.HttpClient` is opaque to this (Node-compiled) codebase, hence `unknown`.
+ * The slice of `Deno.HttpClient` this (Node-compiled) codebase relies on: an opaque
+ * handle owning a connection pool, so whoever creates one must `close()` it.
  */
-export function createDenoHttpClient(certificate: ICertificate): unknown {
-    const deno = (globalThis as { Deno?: { createHttpClient?: (options: unknown) => unknown } }).Deno;
+export interface DenoHttpClient {
+    close(): void;
+}
+
+type DenoCreateHttpClient = (options: unknown) => DenoHttpClient;
+
+function getDenoCreateHttpClient(): DenoCreateHttpClient {
+    const deno = (globalThis as { Deno?: { createHttpClient?: DenoCreateHttpClient } }).Deno;
 
     if (typeof deno?.createHttpClient !== "function") {
         throwError("InvalidOperationException",
@@ -22,5 +23,27 @@ export function createDenoHttpClient(certificate: ICertificate): unknown {
             + "or route the RavenDB calls through a backend that supports mTLS.");
     }
 
-    return deno.createHttpClient(certificate.toDenoHttpClientOptions());
+    return options => deno.createHttpClient(options);
+}
+
+/**
+ * Throws when the configured X.509 client certificate cannot be presented on this Deno
+ * runtime: no `Deno.createHttpClient` (gated or stripped), a PFX archive, or a
+ * passphrase-protected key. Builds nothing - RequestExecutor.validateCertificateRuntimeSupport
+ * runs it at DocumentStore.initialize() so misconfiguration surfaces at startup.
+ */
+export function validateDenoCertificateSupport(certificate: ICertificate): void {
+    getDenoCreateHttpClient();
+    certificate.toDenoHttpClientOptions();
+}
+
+/**
+ * Builds a Deno HttpClient presenting the configured X.509 client certificate,
+ * for passing as the (Deno-specific) `client` option of `fetch`. This is the
+ * only way to do mTLS on Deno - its fetch has no undici dispatcher concept and
+ * silently ignores one, which is exactly how certificates used to get dropped
+ * (RDBC-1083). The caller owns the returned client and must `close()` it.
+ */
+export function createDenoHttpClient(certificate: ICertificate): DenoHttpClient {
+    return getDenoCreateHttpClient()(certificate.toDenoHttpClientOptions());
 }

--- a/src/Utility/DenoHttpUtil.ts
+++ b/src/Utility/DenoHttpUtil.ts
@@ -1,0 +1,26 @@
+import { ICertificate } from "../Auth/Certificate.js";
+import { throwError } from "../Exceptions/index.js";
+
+/**
+ * Builds a Deno HttpClient presenting the configured X.509 client certificate,
+ * for passing as the (Deno-specific) `client` option of `fetch`. This is the
+ * only way to do mTLS on Deno - its fetch has no undici dispatcher concept and
+ * silently ignores one, which is exactly how certificates used to get dropped
+ * (RDBC-1083).
+ *
+ * `Deno.HttpClient` is opaque to this (Node-compiled) codebase, hence `unknown`.
+ */
+export function createDenoHttpClient(certificate: ICertificate): unknown {
+    const deno = (globalThis as { Deno?: { createHttpClient?: (options: unknown) => unknown } }).Deno;
+
+    if (typeof deno?.createHttpClient !== "function") {
+        throwError("InvalidOperationException",
+            "A client certificate was configured via authOptions, but Deno.createHttpClient is not "
+            + "available in this runtime (older Deno versions gate it behind an --unstable flag, and some "
+            + "Deno-based edge platforms remove it), so the certificate cannot be presented. "
+            + "Upgrade Deno, provide a fetch that performs mTLS via conventions.customFetch, "
+            + "or route the RavenDB calls through a backend that supports mTLS.");
+    }
+
+    return deno.createHttpClient(certificate.toDenoHttpClientOptions());
+}

--- a/src/Utility/RuntimeUtil.ts
+++ b/src/Utility/RuntimeUtil.ts
@@ -38,9 +38,22 @@ export class RuntimeUtil {
     }
 
     /**
+     * Detects if the code is running in the Deno runtime.
+     *
+     * Not cached: unlike `process`/`navigator` sniffing this is a cheap property
+     * probe, and tests fake `globalThis.Deno` around single calls.
+     */
+    public static isDeno(): boolean {
+        const deno = (globalThis as { Deno?: { version?: { deno?: unknown } } }).Deno;
+        return !!deno && typeof deno.version?.deno === "string";
+    }
+
+    /**
      * Whether the current runtime can accept an undici `Dispatcher` (Node's undici
-     * Agent) in a `fetch` init. Node can; Bun and Cloudflare Workers (workerd) cannot --
-     * their `fetch` has no dispatcher concept, so building or passing one is meaningless.
+     * Agent) in a `fetch` init. Node can; Bun, Cloudflare Workers (workerd) and Deno
+     * cannot -- their `fetch` has no dispatcher concept, so building or passing one is
+     * meaningless (Deno's fetch silently ignores it, which used to drop a configured
+     * client certificate on the floor).
      *
      * Centralized here so the two consumers -- request send (RavenCommand.send) and http
      * agent creation (RequestExecutor.getHttpAgent) -- stay in lockstep: if they drift
@@ -48,6 +61,6 @@ export class RuntimeUtil {
      * original workerd failure returns. A future dispatcher-less runtime is added once.
      */
     public static supportsUndiciDispatcher(): boolean {
-        return !this.isBun() && !this.isWorkerd();
+        return !this.isBun() && !this.isWorkerd() && !this.isDeno();
     }
 }

--- a/test/Auth/CertificateDenoOptionsTest.ts
+++ b/test/Auth/CertificateDenoOptionsTest.ts
@@ -1,0 +1,53 @@
+import { Certificate } from "../../src/Auth/Certificate.js";
+import assert from "node:assert";
+
+const PEM_CERT = "-----BEGIN CERTIFICATE-----\nMIIcert\n-----END CERTIFICATE-----";
+const PEM_KEY = "-----BEGIN RSA PRIVATE KEY-----\nMIIkey\n-----END RSA PRIVATE KEY-----";
+const PEM_BUNDLE = PEM_CERT + "\n" + PEM_KEY + "\n";
+const PEM_CA = "-----BEGIN CERTIFICATE-----\nMIIca\n-----END CERTIFICATE-----";
+
+describe("Certificate.toDenoHttpClientOptions", function () {
+
+    it("maps a PEM certificate to Deno.createHttpClient options", function () {
+        const certificate = Certificate.createPem(PEM_BUNDLE);
+        const options = certificate.toDenoHttpClientOptions();
+
+        assert.strictEqual(options.cert, PEM_CERT);
+        assert.strictEqual(options.key, PEM_KEY);
+        assert.strictEqual(options.caCerts, undefined);
+    });
+
+    it("passes the CA bundle through caCerts", function () {
+        const certificate = Certificate.createPem(PEM_BUNDLE, undefined, PEM_CA);
+        const options = certificate.toDenoHttpClientOptions();
+
+        assert.deepStrictEqual(options.caCerts, [PEM_CA]);
+    });
+
+    it("converts a Buffer CA to a string", function () {
+        const certificate = Certificate.createPem(PEM_BUNDLE, undefined, Buffer.from(PEM_CA));
+        const options = certificate.toDenoHttpClientOptions();
+
+        assert.deepStrictEqual(options.caCerts, [PEM_CA]);
+    });
+
+    it("throws an actionable error for an encrypted (passphrase) key", function () {
+        const certificate = Certificate.createPem(PEM_BUNDLE, "secret");
+
+        assert.throws(() => certificate.toDenoHttpClientOptions(), (err: Error) => {
+            assert.match(err.message, /passphrase/i);
+            assert.match(err.message, /decrypt/i);
+            return true;
+        });
+    });
+
+    it("throws an actionable error for a PFX certificate", function () {
+        const certificate = Certificate.createPfx(Buffer.from("pfx-bytes"));
+
+        assert.throws(() => certificate.toDenoHttpClientOptions(), (err: Error) => {
+            assert.match(err.message, /PFX/);
+            assert.match(err.message, /PEM/);
+            return true;
+        });
+    });
+});

--- a/test/Auth/CertificateDenoOptionsTest.ts
+++ b/test/Auth/CertificateDenoOptionsTest.ts
@@ -41,6 +41,16 @@ describe("Certificate.toDenoHttpClientOptions", function () {
         });
     });
 
+    it("throws an actionable error when the PEM has no private key block", function () {
+        const certificate = Certificate.createPem(PEM_CERT);
+
+        assert.throws(() => certificate.toDenoHttpClientOptions(), (err: Error) => {
+            assert.match(err.message, /private key/i);
+            assert.match(err.message, /BEGIN PRIVATE KEY/);
+            return true;
+        });
+    });
+
     it("throws an actionable error for a PFX certificate", function () {
         const certificate = Certificate.createPfx(Buffer.from("pfx-bytes"));
 

--- a/test/Auth/PemCertificateTest.ts
+++ b/test/Auth/PemCertificateTest.ts
@@ -1,0 +1,78 @@
+import { Certificate } from "../../src/Auth/Certificate.js";
+import { Agent } from "undici-types";
+import { createPrivateKey, generateKeyPairSync } from "node:crypto";
+import assert from "node:assert";
+
+const PEM_CERT = "-----BEGIN CERTIFICATE-----\nMIIcert\n-----END CERTIFICATE-----";
+const PKCS1_KEY = "-----BEGIN RSA PRIVATE KEY-----\nMIIkey\n-----END RSA PRIVATE KEY-----";
+const PKCS8_KEY = "-----BEGIN PRIVATE KEY-----\nMIIkey\n-----END PRIVATE KEY-----";
+const SEC1_KEY = "-----BEGIN EC PRIVATE KEY-----\nMIIkey\n-----END EC PRIVATE KEY-----";
+const ENCRYPTED_PKCS8_KEY = "-----BEGIN ENCRYPTED PRIVATE KEY-----\nMIIkey\n-----END ENCRYPTED PRIVATE KEY-----";
+
+function connectKey(certificate: ReturnType<typeof Certificate.createPem>): string {
+    return (certificate.toAgentOptions().connect as Agent.Options["connect"] & { key: string }).key;
+}
+
+describe("PemCertificate private key parsing", function () {
+
+    it("extracts a PKCS#1 key (BEGIN RSA PRIVATE KEY)", function () {
+        const certificate = Certificate.createPem(PEM_CERT + "\n" + PKCS1_KEY + "\n");
+
+        assert.strictEqual(connectKey(certificate), PKCS1_KEY);
+        assert.strictEqual(certificate.toDenoHttpClientOptions().key, PKCS1_KEY);
+    });
+
+    it("extracts a PKCS#8 key (BEGIN PRIVATE KEY), the OpenSSL 3 default", function () {
+        const certificate = Certificate.createPem(PEM_CERT + "\n" + PKCS8_KEY + "\n");
+
+        assert.strictEqual(connectKey(certificate), PKCS8_KEY);
+        assert.strictEqual(certificate.toSocketOptions().key, PKCS8_KEY);
+        assert.strictEqual(certificate.toBunTlsOptions().key, PKCS8_KEY);
+        assert.strictEqual(certificate.toDenoHttpClientOptions().key, PKCS8_KEY);
+    });
+
+    it("extracts a SEC1 key (BEGIN EC PRIVATE KEY)", function () {
+        const certificate = Certificate.createPem(SEC1_KEY + "\n" + PEM_CERT + "\n");
+
+        assert.strictEqual(connectKey(certificate), SEC1_KEY);
+        assert.strictEqual(certificate.toDenoHttpClientOptions().key, SEC1_KEY);
+    });
+
+    it("extracts an encrypted PKCS#8 key (BEGIN ENCRYPTED PRIVATE KEY)", function () {
+        const certificate = Certificate.createPem(PEM_CERT + "\n" + ENCRYPTED_PKCS8_KEY + "\n", "secret");
+
+        assert.strictEqual(connectKey(certificate), ENCRYPTED_PKCS8_KEY);
+    });
+
+    it("extracts a key Node can load from a real PKCS#8 bundle", function () {
+        const { privateKey } = generateKeyPairSync("rsa", {
+            modulusLength: 2048,
+            privateKeyEncoding: { type: "pkcs8", format: "pem" },
+            publicKeyEncoding: { type: "spki", format: "pem" }
+        });
+        assert.match(privateKey, /^-----BEGIN PRIVATE KEY-----/);
+
+        const certificate = Certificate.createPem(PEM_CERT + "\n" + privateKey);
+
+        assert.strictEqual(createPrivateKey(connectKey(certificate)).asymmetricKeyType, "rsa");
+    });
+
+    it("extracts a key Node can load from a real SEC1 bundle", function () {
+        const { privateKey } = generateKeyPairSync("ec", {
+            namedCurve: "P-256",
+            privateKeyEncoding: { type: "sec1", format: "pem" },
+            publicKeyEncoding: { type: "spki", format: "pem" }
+        });
+        assert.match(privateKey, /^-----BEGIN EC PRIVATE KEY-----/);
+
+        const certificate = Certificate.createPem(PEM_CERT + "\n" + privateKey);
+
+        assert.strictEqual(createPrivateKey(connectKey(certificate)).asymmetricKeyType, "ec");
+    });
+
+    it("leaves the key null when the PEM has no private key block", function () {
+        const certificate = Certificate.createPem(PEM_CERT);
+
+        assert.strictEqual(connectKey(certificate), null);
+    });
+});

--- a/test/Executor/RequestExecutorDenoTests.ts
+++ b/test/Executor/RequestExecutorDenoTests.ts
@@ -1,0 +1,178 @@
+import { RequestExecutor } from "../../src/Http/RequestExecutor.js";
+import { DocumentConventions } from "../../src/Documents/Conventions/DocumentConventions.js";
+import { GetNextOperationIdCommand } from "../../src/Documents/Commands/GetNextOperationIdCommand.js";
+import { IAuthOptions } from "../../src/Auth/AuthOptions.js";
+import { HttpRequestParameters } from "../../src/Primitives/Http.js";
+import { TypeUtil } from "../../src/Utility/TypeUtil.js";
+import assert from "node:assert";
+
+const PEM_BUNDLE = "-----BEGIN CERTIFICATE-----\nMIIcert\n-----END CERTIFICATE-----\n"
+    + "-----BEGIN RSA PRIVATE KEY-----\nMIIkey\n-----END RSA PRIVATE KEY-----\n";
+const PEM_AUTH: IAuthOptions = { type: "pem", certificate: PEM_BUNDLE };
+const PFX_AUTH: IAuthOptions = { type: "pfx", certificate: Buffer.from("pfx-bytes") };
+
+// Fake of the Deno global: counts Deno.HttpClient creations and closes.
+class FakeDeno {
+    public created = 0;
+    public closed = 0;
+    public seenOptions: any = null;
+
+    public install(withCreateHttpClient = true): void {
+        const deno: any = { version: { deno: "2.9.5" } };
+        if (withCreateHttpClient) {
+            deno.createHttpClient = (options: any) => {
+                this.created++;
+                this.seenOptions = options;
+                return { close: () => { this.closed++; } };
+            };
+        }
+        (globalThis as any).Deno = deno;
+    }
+}
+
+function createExecutor(authOptions?: IAuthOptions, conventions = new DocumentConventions()): RequestExecutor {
+    return RequestExecutor.createForSingleNodeWithoutConfigurationUpdates(
+        "https://localhost:8080", "db", { authOptions, documentConventions: conventions });
+}
+
+function createRequest(executor: RequestExecutor): HttpRequestParameters {
+    const node = executor.getTopologyNodes()[0];
+    return (executor as any)._createRequest(node, new GetNextOperationIdCommand(), TypeUtil.NOOP);
+}
+
+describe("RequestExecutor on Deno", function () {
+
+    let deno: FakeDeno;
+
+    beforeEach(() => {
+        deno = new FakeDeno();
+    });
+
+    afterEach(() => {
+        delete (globalThis as { Deno?: unknown }).Deno;
+    });
+
+    describe("client certificate", function () {
+
+        it("presents the certificate through one Deno.HttpClient per executor, closed on dispose", function () {
+            deno.install();
+            // the factory already issues its topology request, so the client exists here
+            const executor = createExecutor(PEM_AUTH);
+
+            const first = createRequest(executor);
+            const second = createRequest(executor);
+
+            assert.ok(first.client, "request carries the Deno.HttpClient");
+            assert.strictEqual(second.client, first.client, "one client per executor");
+            assert.strictEqual(deno.created, 1, "built once, on the request path");
+            assert.match(deno.seenOptions.cert, /BEGIN CERTIFICATE/);
+            assert.match(deno.seenOptions.key, /BEGIN RSA PRIVATE KEY/);
+
+            executor.dispose();
+            assert.strictEqual(deno.closed, 1, "dispose() closes the Deno.HttpClient");
+        });
+
+        it("keeps the same Deno.HttpClient when customHttpRequestOptions are re-applied", function () {
+            deno.install();
+            const executor = createExecutor(PEM_AUTH);
+
+            try {
+                const before = createRequest(executor).client;
+                executor.customHttpRequestOptions = { keepalive: true };
+                const after = createRequest(executor);
+
+                assert.strictEqual(after.client, before);
+                assert.strictEqual(after.keepalive, true);
+                assert.strictEqual(deno.created, 1);
+            } finally {
+                executor.dispose();
+            }
+        });
+
+        it("builds no Deno.HttpClient when conventions.customFetch owns the transport", function () {
+            deno.install(false); // as on platforms that strip Deno.createHttpClient
+            const conventions = new DocumentConventions();
+            const customFetch = () => Promise.reject(new Error("not called"));
+            conventions.customFetch = customFetch;
+
+            // must not throw: the custom fetch performs mTLS, the certificate is not our job
+            const executor = createExecutor(PEM_AUTH, conventions);
+
+            try {
+                const request = createRequest(executor);
+
+                assert.strictEqual(request.client, undefined);
+                assert.strictEqual(request.fetcher, customFetch);
+                assert.strictEqual(deno.created, 0);
+            } finally {
+                executor.dispose();
+            }
+        });
+
+        it("builds no Deno.HttpClient without a certificate", function () {
+            deno.install();
+            const executor = createExecutor();
+
+            try {
+                assert.strictEqual(createRequest(executor).client, undefined);
+                assert.strictEqual(deno.created, 0);
+            } finally {
+                executor.dispose();
+            }
+        });
+
+        it("reports an unsupported certificate on the request path, not from the constructor", function () {
+            deno.install();
+            const executor = createExecutor(PFX_AUTH);
+
+            try {
+                assert.throws(() => createRequest(executor), /PFX/);
+            } finally {
+                executor.dispose();
+            }
+        });
+    });
+
+    describe("validateCertificateRuntimeSupport", function () {
+
+        it("accepts a PEM certificate", function () {
+            deno.install();
+            RequestExecutor.validateCertificateRuntimeSupport(PEM_AUTH, new DocumentConventions());
+            assert.strictEqual(deno.created, 0, "validation must not build a client");
+        });
+
+        it("throws for a PFX certificate", function () {
+            deno.install();
+            assert.throws(
+                () => RequestExecutor.validateCertificateRuntimeSupport(PFX_AUTH, new DocumentConventions()),
+                /PFX/);
+        });
+
+        it("throws for a passphrase-protected key", function () {
+            deno.install();
+            assert.throws(
+                () => RequestExecutor.validateCertificateRuntimeSupport(
+                    { ...PEM_AUTH, password: "secret" }, new DocumentConventions()),
+                /passphrase/i);
+        });
+
+        it("throws when Deno.createHttpClient is unavailable", function () {
+            deno.install(false);
+            assert.throws(
+                () => RequestExecutor.validateCertificateRuntimeSupport(PEM_AUTH, new DocumentConventions()),
+                /Deno\.createHttpClient/);
+        });
+
+        it("skips the check when conventions.customFetch owns the transport", function () {
+            deno.install(false);
+            const conventions = new DocumentConventions();
+            conventions.customFetch = () => Promise.reject(new Error("not called"));
+
+            RequestExecutor.validateCertificateRuntimeSupport(PFX_AUTH, conventions);
+        });
+
+        it("does not apply off Deno", function () {
+            RequestExecutor.validateCertificateRuntimeSupport(PFX_AUTH, new DocumentConventions());
+        });
+    });
+});

--- a/test/Executor/RequestExecutorRequestOptionsTests.ts
+++ b/test/Executor/RequestExecutorRequestOptionsTests.ts
@@ -1,0 +1,39 @@
+import { RequestExecutor } from "../../src/Http/RequestExecutor.js";
+import { DocumentConventions } from "../../src/Documents/Conventions/DocumentConventions.js";
+import { GetNextOperationIdCommand } from "../../src/Documents/Commands/GetNextOperationIdCommand.js";
+import { HttpRequestParameters } from "../../src/Primitives/Http.js";
+import { TypeUtil } from "../../src/Utility/TypeUtil.js";
+import assert from "node:assert";
+
+function createExecutor(): RequestExecutor {
+    return RequestExecutor.createForSingleNodeWithoutConfigurationUpdates(
+        "https://localhost:8080", "db", { documentConventions: new DocumentConventions() });
+}
+
+function createRequest(executor: RequestExecutor): HttpRequestParameters {
+    const node = executor.getTopologyNodes()[0];
+    return (executor as any)._createRequest(node, new GetNextOperationIdCommand(), TypeUtil.NOOP);
+}
+
+describe("RequestExecutor default request options", function () {
+
+    it("keeps customHttpRequestOptions per executor - they must not leak across stores", function () {
+        const first = createExecutor();
+        const second = createExecutor();
+        let third: RequestExecutor;
+
+        try {
+            first.customHttpRequestOptions = { keepalive: true };
+            // an executor created after the options were set must not inherit them either
+            third = createExecutor();
+
+            assert.strictEqual(createRequest(first).keepalive, true);
+            assert.strictEqual(createRequest(second).keepalive, undefined);
+            assert.strictEqual(createRequest(third).keepalive, undefined);
+        } finally {
+            first.dispose();
+            second.dispose();
+            third?.dispose();
+        }
+    });
+});

--- a/test/Utility/DenoHttpUtilTest.ts
+++ b/test/Utility/DenoHttpUtilTest.ts
@@ -1,42 +1,84 @@
-import { createDenoHttpClient } from "../../src/Utility/DenoHttpUtil.js";
+import { createDenoHttpClient, validateDenoCertificateSupport } from "../../src/Utility/DenoHttpUtil.js";
 import { Certificate } from "../../src/Auth/Certificate.js";
 import assert from "node:assert";
 
 const PEM_BUNDLE = "-----BEGIN CERTIFICATE-----\nMIIcert\n-----END CERTIFICATE-----\n"
     + "-----BEGIN RSA PRIVATE KEY-----\nMIIkey\n-----END RSA PRIVATE KEY-----\n";
 
-describe("createDenoHttpClient", function () {
+describe("DenoHttpUtil", function () {
 
     afterEach(() => {
         delete (globalThis as { Deno?: unknown }).Deno;
     });
 
-    it("builds a Deno HttpClient from the certificate options", function () {
-        const sentinel = { close: () => { /* Deno.HttpClient shape */ } };
-        let seenOptions: any;
-        (globalThis as any).Deno = {
-            version: { deno: "2.9.5" },
-            createHttpClient: (options: any) => {
-                seenOptions = options;
-                return sentinel;
-            }
-        };
+    describe("createDenoHttpClient", function () {
 
-        const client = createDenoHttpClient(Certificate.createPem(PEM_BUNDLE));
+        it("builds a Deno HttpClient from the certificate options", function () {
+            const sentinel = { close: () => { /* Deno.HttpClient shape */ } };
+            let seenOptions: any;
+            (globalThis as any).Deno = {
+                version: { deno: "2.9.5" },
+                createHttpClient: (options: any) => {
+                    seenOptions = options;
+                    return sentinel;
+                }
+            };
 
-        assert.strictEqual(client, sentinel);
-        assert.match(seenOptions.cert, /BEGIN CERTIFICATE/);
-        assert.match(seenOptions.key, /BEGIN RSA PRIVATE KEY/);
+            const client = createDenoHttpClient(Certificate.createPem(PEM_BUNDLE));
+
+            assert.strictEqual(client, sentinel);
+            assert.match(seenOptions.cert, /BEGIN CERTIFICATE/);
+            assert.match(seenOptions.key, /BEGIN RSA PRIVATE KEY/);
+        });
+
+        it("throws an actionable error when Deno.createHttpClient is unavailable", function () {
+            (globalThis as any).Deno = { version: { deno: "1.0.0" } };
+
+            assert.throws(() => createDenoHttpClient(Certificate.createPem(PEM_BUNDLE)), (err: Error) => {
+                assert.match(err.message, /Deno\.createHttpClient/);
+                assert.match(err.message, /client certificate/i);
+                assert.match(err.message, /customFetch/);
+                return true;
+            });
+        });
     });
 
-    it("throws an actionable error when Deno.createHttpClient is unavailable", function () {
-        (globalThis as any).Deno = { version: { deno: "1.0.0" } };
+    describe("validateDenoCertificateSupport", function () {
 
-        assert.throws(() => createDenoHttpClient(Certificate.createPem(PEM_BUNDLE)), (err: Error) => {
-            assert.match(err.message, /Deno\.createHttpClient/);
-            assert.match(err.message, /client certificate/i);
-            assert.match(err.message, /customFetch/);
-            return true;
+        it("accepts a PEM certificate without building a client", function () {
+            let created = 0;
+            (globalThis as any).Deno = {
+                version: { deno: "2.9.5" },
+                createHttpClient: () => {
+                    created++;
+                    return { close: () => { /* noop */ } };
+                }
+            };
+
+            validateDenoCertificateSupport(Certificate.createPem(PEM_BUNDLE));
+
+            assert.strictEqual(created, 0);
+        });
+
+        it("throws when Deno.createHttpClient is unavailable", function () {
+            (globalThis as any).Deno = { version: { deno: "1.0.0" } };
+
+            assert.throws(() => validateDenoCertificateSupport(Certificate.createPem(PEM_BUNDLE)),
+                /Deno\.createHttpClient/);
+        });
+
+        it("throws for a PFX certificate", function () {
+            (globalThis as any).Deno = { version: { deno: "2.9.5" }, createHttpClient: () => ({ close: () => { /* noop */ } }) };
+
+            assert.throws(() => validateDenoCertificateSupport(Certificate.createPfx(Buffer.from("pfx-bytes"))),
+                /PFX/);
+        });
+
+        it("throws for a passphrase-protected key", function () {
+            (globalThis as any).Deno = { version: { deno: "2.9.5" }, createHttpClient: () => ({ close: () => { /* noop */ } }) };
+
+            assert.throws(() => validateDenoCertificateSupport(Certificate.createPem(PEM_BUNDLE, "secret")),
+                /passphrase/i);
         });
     });
 });

--- a/test/Utility/DenoHttpUtilTest.ts
+++ b/test/Utility/DenoHttpUtilTest.ts
@@ -1,0 +1,42 @@
+import { createDenoHttpClient } from "../../src/Utility/DenoHttpUtil.js";
+import { Certificate } from "../../src/Auth/Certificate.js";
+import assert from "node:assert";
+
+const PEM_BUNDLE = "-----BEGIN CERTIFICATE-----\nMIIcert\n-----END CERTIFICATE-----\n"
+    + "-----BEGIN RSA PRIVATE KEY-----\nMIIkey\n-----END RSA PRIVATE KEY-----\n";
+
+describe("createDenoHttpClient", function () {
+
+    afterEach(() => {
+        delete (globalThis as { Deno?: unknown }).Deno;
+    });
+
+    it("builds a Deno HttpClient from the certificate options", function () {
+        const sentinel = { close: () => { /* Deno.HttpClient shape */ } };
+        let seenOptions: any;
+        (globalThis as any).Deno = {
+            version: { deno: "2.9.5" },
+            createHttpClient: (options: any) => {
+                seenOptions = options;
+                return sentinel;
+            }
+        };
+
+        const client = createDenoHttpClient(Certificate.createPem(PEM_BUNDLE));
+
+        assert.strictEqual(client, sentinel);
+        assert.match(seenOptions.cert, /BEGIN CERTIFICATE/);
+        assert.match(seenOptions.key, /BEGIN RSA PRIVATE KEY/);
+    });
+
+    it("throws an actionable error when Deno.createHttpClient is unavailable", function () {
+        (globalThis as any).Deno = { version: { deno: "1.0.0" } };
+
+        assert.throws(() => createDenoHttpClient(Certificate.createPem(PEM_BUNDLE)), (err: Error) => {
+            assert.match(err.message, /Deno\.createHttpClient/);
+            assert.match(err.message, /client certificate/i);
+            assert.match(err.message, /customFetch/);
+            return true;
+        });
+    });
+});

--- a/test/Utility/RuntimeUtilTest.ts
+++ b/test/Utility/RuntimeUtilTest.ts
@@ -1,0 +1,36 @@
+import { RuntimeUtil } from "../../src/Utility/RuntimeUtil.js";
+import assert from "node:assert";
+
+describe("RuntimeUtil", function () {
+
+    afterEach(() => {
+        delete (globalThis as { Deno?: unknown }).Deno;
+    });
+
+    describe("isDeno", function () {
+        it("is false when the Deno global is absent", function () {
+            assert.strictEqual(RuntimeUtil.isDeno(), false);
+        });
+
+        it("detects the Deno global", function () {
+            (globalThis as { Deno?: unknown }).Deno = { version: { deno: "2.9.5" } };
+            assert.strictEqual(RuntimeUtil.isDeno(), true);
+        });
+
+        it("ignores a Deno global without a version marker", function () {
+            (globalThis as { Deno?: unknown }).Deno = {};
+            assert.strictEqual(RuntimeUtil.isDeno(), false);
+        });
+    });
+
+    describe("supportsUndiciDispatcher", function () {
+        it("is true on Node", function () {
+            assert.strictEqual(RuntimeUtil.supportsUndiciDispatcher(), true);
+        });
+
+        it("is false on Deno - its fetch silently ignores an undici dispatcher", function () {
+            (globalThis as { Deno?: unknown }).Deno = { version: { deno: "2.9.5" } };
+            assert.strictEqual(RuntimeUtil.supportsUndiciDispatcher(), false);
+        });
+    });
+});

--- a/test/cloudflare-worker/smoke.mjs
+++ b/test/cloudflare-worker/smoke.mjs
@@ -12,14 +12,16 @@ const worker = await unstable_dev("src/worker.ts", {
 });
 
 try {
-    const res = await worker.fetch("/");
-    const text = await res.text();
+    for (const path of ["/", "/initialize-mtls"]) {
+        const res = await worker.fetch(path);
+        const text = await res.text();
 
-    if (res.status !== 200 || !text.startsWith("ok:")) {
-        console.error(`SMOKE FAILED [HTTP ${res.status}]: ${text}`);
-        process.exitCode = 1;
-    } else {
-        console.log(`SMOKE OK: ${text}`);
+        if (res.status !== 200 || !text.startsWith("ok:")) {
+            console.error(`SMOKE FAILED [${path}] [HTTP ${res.status}]: ${text}`);
+            process.exitCode = 1;
+        } else {
+            console.log(`SMOKE OK [${path}]: ${text}`);
+        }
     }
 } finally {
     await worker.stop();

--- a/test/cloudflare-worker/src/worker.ts
+++ b/test/cloudflare-worker/src/worker.ts
@@ -1,18 +1,57 @@
 // Minimal Cloudflare Workers smoke test for the RavenDB client (RDBC-1083).
 //
-// Importing the package pulls in its entire module graph, so if any
-// `class ... extends ...` were to resolve to `[object Module]` (the reported
-// bundler-interop failure) it would throw here, at module evaluation time.
-// A 200 response means the package loaded and a DocumentStore was constructed
-// inside workerd.
+// `/` - load check. Importing the package pulls in its entire module graph, so
+// if any `class ... extends ...` were to resolve to `[object Module]` (the
+// reported bundler-interop failure) it would throw here, at module evaluation
+// time. A 200 response means the package loaded and a DocumentStore was
+// constructed inside workerd.
+//
+// `/initialize-mtls` - configuration-time mTLS check. workerd cannot present an
+// X.509 client certificate from user-space, so a store configured with
+// authOptions and no conventions.customFetch must throw an actionable error
+// already at initialize(), not on the first request.
 import { DocumentStore } from "ravendb";
 
+const DUMMY_PEM =
+    "-----BEGIN CERTIFICATE-----\nMIIdummy\n-----END CERTIFICATE-----\n"
+    + "-----BEGIN RSA PRIVATE KEY-----\nMIIdummy\n-----END RSA PRIVATE KEY-----\n";
+
+function loadCheck(): Response {
+    const store = new DocumentStore(["https://a.example"], "Test");
+    store.dispose();
+    return new Response("ok: ravendb loaded in workerd (" + typeof DocumentStore + ")");
+}
+
+function initializeMtlsCheck(): Response {
+    const store = new DocumentStore(["https://a.example"], "Test", {
+        type: "pem",
+        certificate: DUMMY_PEM
+    });
+
+    try {
+        store.initialize();
+    } catch (err) {
+        const message = (err as Error).message || "";
+        if (message.includes("mtls_certificate") && message.includes("customFetch")) {
+            return new Response("ok: initialize() threw the workerd mTLS error");
+        }
+        return new Response("FAILED: initialize() threw an unexpected error: " + message, { status: 500 });
+    } finally {
+        store.dispose();
+    }
+
+    return new Response(
+        "FAILED: initialize() accepted a client certificate workerd cannot present",
+        { status: 500 });
+}
+
 export default {
-    async fetch(): Promise<Response> {
+    async fetch(request: Request): Promise<Response> {
         try {
-            const store = new DocumentStore(["https://a.example"], "Test");
-            store.dispose();
-            return new Response("ok: ravendb loaded in workerd (" + typeof DocumentStore + ")");
+            const { pathname } = new URL(request.url);
+            return pathname === "/initialize-mtls"
+                ? initializeMtlsCheck()
+                : loadCheck();
         } catch (err) {
             return new Response(
                 "FAILED: " + ((err && (err as Error).stack) || String(err)),

--- a/test/deno/README.md
+++ b/test/deno/README.md
@@ -35,7 +35,7 @@ docker run -d --name ravendb-smoke -p 8080:8080 -v "$PWD/server.pfx:/certs/serve
   -e RAVEN_Setup_Mode=None -e RAVEN_License_Eula_Accepted=true \
   -e RAVEN_Security_Certificate_Path=/certs/server.pfx \
   -e RAVEN_ServerUrl=https://0.0.0.0:8080 -e RAVEN_PublicServerUrl=https://localhost:8080 \
-  -e RAVEN_RunInMemory=true ravendb/ravendb:7.1-latest
+  -e RAVEN_RunInMemory=true ravendb/ravendb:7.2-latest
 
 # 3. the database
 curl -s -X PUT "https://localhost:8080/admin/databases?name=smoke&replicationFactor=1" \

--- a/test/deno/README.md
+++ b/test/deno/README.md
@@ -1,0 +1,60 @@
+# Deno mTLS end-to-end smoke test
+
+Minimal [Deno](https://deno.com) project that runs a real store + load against a
+**secured** RavenDB server using an X.509 client certificate configured via
+`authOptions`. It guards against
+[RDBC-1083](https://issues.hibernatingrhinos.com/issue/RDBC-1083) — on Deno the
+client used to silently send uncertified requests (the undici agent path is a no-op
+there), producing a bare 403 with no hint that the configured certificate was
+dropped. The client now presents the certificate through `Deno.createHttpClient`.
+
+It resolves `ravendb` from the repository root (`file:../..`), so it always tests the
+locally built client.
+
+## Run it
+
+Needs a secured RavenDB server and a PEM client certificate the server trusts. A
+throwaway setup with Docker and OpenSSL:
+
+```bash
+# 1. a mini PKI: CA + a leaf certificate (SANs for both hostnames used below);
+#    the private key must be PKCS#1 ("BEGIN RSA PRIVATE KEY") for authOptions PEM parsing
+openssl req -x509 -newkey rsa:2048 -keyout ca-key.pem -out ca.pem -days 365 -nodes \
+  -subj "/CN=smoke-ca" -addext "basicConstraints=critical,CA:TRUE" \
+  -addext "keyUsage=critical,keyCertSign,cRLSign"
+openssl genrsa -out key-pkcs8.pem 2048
+openssl rsa -in key-pkcs8.pem -out key.pem -traditional
+openssl req -new -key key.pem -subj "/CN=ravendb" -out leaf.csr
+printf "subjectAltName=DNS:localhost,DNS:ravendb,IP:127.0.0.1\nkeyUsage=digitalSignature,keyEncipherment\nextendedKeyUsage=serverAuth,clientAuth\nbasicConstraints=CA:FALSE\n" > leaf.ext
+openssl x509 -req -in leaf.csr -CA ca.pem -CAkey ca-key.pem -CAcreateserial -days 365 -extfile leaf.ext -out cert.pem
+openssl pkcs12 -export -out server.pfx -inkey key.pem -in cert.pem -certfile ca.pem -passout pass:
+cat cert.pem key.pem > client.pem
+
+# 2. a secured RavenDB (the server trusts its own certificate as a ClusterAdmin client certificate)
+docker run -d --name ravendb-smoke -p 8080:8080 -v "$PWD/server.pfx:/certs/server.pfx:ro" \
+  -e RAVEN_Setup_Mode=None -e RAVEN_License_Eula_Accepted=true \
+  -e RAVEN_Security_Certificate_Path=/certs/server.pfx \
+  -e RAVEN_ServerUrl=https://0.0.0.0:8080 -e RAVEN_PublicServerUrl=https://localhost:8080 \
+  -e RAVEN_RunInMemory=true ravendb/ravendb:7.1-latest
+
+# 3. the database
+curl -s -X PUT "https://localhost:8080/admin/databases?name=smoke&replicationFactor=1" \
+  --cert client.pem --cacert ca.pem -H "Content-Type: application/json" -d '{"DatabaseName":"smoke"}'
+```
+
+Then, from the repository root:
+
+```bash
+# build the client first
+npm ci
+
+# install the example deps and run the smoke test
+cd test/deno
+npm install
+RAVENDB_URL=https://localhost:8080 RAVENDB_DATABASE=smoke \
+  RAVENDB_CLIENT_CERT=client.pem RAVENDB_CA=ca.pem npm run smoke
+```
+
+`npm run smoke` stores a document and loads it back over mTLS, and exits non-zero on
+any failure — including the historical failure mode (a 403 `AuthorizationException`
+saying no certificate was provided).

--- a/test/deno/README.md
+++ b/test/deno/README.md
@@ -17,13 +17,11 @@ Needs a secured RavenDB server and a PEM client certificate the server trusts. A
 throwaway setup with Docker and OpenSSL:
 
 ```bash
-# 1. a mini PKI: CA + a leaf certificate (SANs for both hostnames used below);
-#    the private key must be PKCS#1 ("BEGIN RSA PRIVATE KEY") for authOptions PEM parsing
+# 1. a mini PKI: CA + a leaf certificate (SANs for both hostnames used below)
 openssl req -x509 -newkey rsa:2048 -keyout ca-key.pem -out ca.pem -days 365 -nodes \
   -subj "/CN=smoke-ca" -addext "basicConstraints=critical,CA:TRUE" \
   -addext "keyUsage=critical,keyCertSign,cRLSign"
-openssl genrsa -out key-pkcs8.pem 2048
-openssl rsa -in key-pkcs8.pem -out key.pem -traditional
+openssl genrsa -out key.pem 2048
 openssl req -new -key key.pem -subj "/CN=ravendb" -out leaf.csr
 printf "subjectAltName=DNS:localhost,DNS:ravendb,IP:127.0.0.1\nkeyUsage=digitalSignature,keyEncipherment\nextendedKeyUsage=serverAuth,clientAuth\nbasicConstraints=CA:FALSE\n" > leaf.ext
 openssl x509 -req -in leaf.csr -CA ca.pem -CAkey ca-key.pem -CAcreateserial -days 365 -extfile leaf.ext -out cert.pem

--- a/test/deno/package.json
+++ b/test/deno/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "ravendb-deno-smoke",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Deno end-to-end smoke test for the RavenDB client with X.509 client-certificate authentication (RDBC-1083).",
+  "type": "module",
+  "scripts": {
+    "smoke": "deno run --allow-net --allow-env --allow-read smoke.mjs"
+  },
+  "dependencies": {
+    "ravendb": "file:../.."
+  }
+}

--- a/test/deno/smoke.mjs
+++ b/test/deno/smoke.mjs
@@ -1,0 +1,46 @@
+// Deno end-to-end smoke test for X.509 client-certificate authentication (RDBC-1083).
+//
+// Runs a real store + load against a secured RavenDB server using a PEM client
+// certificate configured via authOptions. Before the Deno mTLS support this
+// silently sent uncertified requests (the server answered 403 with no hint that
+// the configured certificate was dropped); with it, the client presents the
+// certificate through Deno.createHttpClient. Exits non-zero on any failure.
+//
+// Environment:
+//   RAVENDB_URL          server url, e.g. https://ravendb:8080
+//   RAVENDB_DATABASE     database name (must exist), e.g. smoke
+//   RAVENDB_CLIENT_CERT  path to a PEM file holding the client certificate + key
+//   RAVENDB_CA           optional path to a PEM CA bundle for the server certificate
+import { DocumentStore } from "ravendb";
+import { readFileSync } from "node:fs";
+
+const url = Deno.env.get("RAVENDB_URL") ?? "https://ravendb:8080";
+const database = Deno.env.get("RAVENDB_DATABASE") ?? "smoke";
+const certPath = Deno.env.get("RAVENDB_CLIENT_CERT") ?? "/certs/client.pem";
+const caPath = Deno.env.get("RAVENDB_CA");
+
+const authOptions = {
+    type: "pem",
+    certificate: readFileSync(certPath, "utf8"),
+    ca: caPath ? readFileSync(caPath, "utf8") : undefined
+};
+
+const store = new DocumentStore(url, database, authOptions);
+store.initialize();
+
+try {
+    const id = "deno-smoke/" + crypto.randomUUID();
+
+    const writeSession = store.openSession();
+    await writeSession.store({ name: "deno-smoke" }, id);
+    await writeSession.saveChanges();
+
+    const loaded = await store.openSession().load(id);
+    if (!loaded || loaded.name !== "deno-smoke") {
+        throw new Error(`load mismatch: ${JSON.stringify(loaded)}`);
+    }
+
+    console.log(`SMOKE OK: stored and loaded ${id}`);
+} finally {
+    store.dispose();
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RDBC-1083

### Additional description

- **Deno mTLS support.** `RuntimeUtil.isDeno()`; `supportsUndiciDispatcher()` is now
  `false` on Deno — its `fetch` silently ignores an undici dispatcher, which was exactly
  how the certificate got dropped. The certificate is presented natively instead:
  `Certificate.toDenoHttpClientOptions()` (PEM → `{ cert, key, caCerts }`) feeds
  `Deno.createHttpClient`, injected as the Deno-specific `client` fetch option in
  `RequestExecutor._setDefaultRequestOptions()` (same pattern as Bun's `tls`).
- **Never send an uncertified request.** `createAgent` now throws when the undici agent
  needed to present a configured certificate cannot be loaded (silent `null` remains only
  for the plain keep-alive agent); missing `Deno.createHttpClient` (gated platforms),
  PFX archives and passphrase-protected keys on Deno throw actionable errors with
  conversion commands / `conventions.customFetch` as the escape hatch.
- **Configuration-time validation.** `certificate + workerd + no customFetch` now throws
  at `DocumentStore.initialize()` (`RequestExecutor.validateCertificateRuntimeSupport`);
  the request-path check stays as defense for direct `RequestExecutor` use.
- **Rewritten workerd error.** Lists options that need no Cloudflare account access
  (export to your own free CF account, move calls to a backend) alongside the binding
  recipe.
- **README.** New "Deno" section, workerd feature limits (Changes API / subscriptions /
  TCP), and `conventions.customFetch` documented as a supported transport.
- **CI.** New `tests/deno` workflow: full mTLS store/load e2e on Deno against a secured
  server (mini PKI generated in the job; uses the existing `RAVEN_LICENSE` secret). The
  `test/cloudflare-worker` smoke gains an `/initialize-mtls` case asserting the
  initialize-time throw in real workerd. New self-contained `test/deno` example project
  (excluded from the mocha glob in `.mocharc.jsonc`).

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low
- [ ] Moderate
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`)
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
