### PR TITLE
RDBC-1106 Fix failing tests

### DIFF
--- a/src/Http/RequestExecutor.ts
+++ b/src/Http/RequestExecutor.ts
@@ -399,7 +399,11 @@ export class RequestExecutor implements IDisposable {
             let UndiciAgent;
 
             try {
-                const undiciModule = await import(importFix("undici"));
+                // Keep the importFix() call out of the import() argument: terser >= 5.51.1
+                // inlines it there as an unparenthesized sequence expression, which esbuild
+                // (wrangler) then reads as a two-argument import() and refuses to bundle.
+                const undiciSpecifier = importFix("undici");
+                const undiciModule = await import(undiciSpecifier);
                 UndiciAgent = undiciModule.Agent;
             } catch (err) {
                 const undiciModule = await import("undici");


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RDBC-1106

### Additional description

Hoist the undici import specifier out of import() so terser 5.51.1 started compressing the argument of dynamic import() again, but its printer does not parenthesize a sequence expression there (the PARENS(AST_Sequence) rule lists AST_Call, not AST_DynamicImport). Inlining importFix("undici") therefore produced `import(s="undici",s+"")`, a two-argument import(), which esbuild inside wrangler rejects: "Using an arbitrary value as the second argument to import() is not possible in the configured target environment". Nitro's cloudflare-module preset minifies with terser, so the nightly Cloudflare load/e2e jobs for test/cloudflare-nitro have been failing since 2026-08-27 with the worker never becoming ready and the smoke fetch dying on a 5-minute headers timeout.

Computing the specifier into a const first keeps the import() argument a plain identifier; terser 5.48.0, 5.51.0 and 5.51.2 all emit `import(e)` for it. Verified with the Nitro and esbuild worker smoke tests in workerd.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low
- [ ] Moderate
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`)
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
