### PR TITLE
RDBC-1107 sync 7.2.5 -> 7.2.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -951,12 +951,18 @@ const summary = await chat.runWithSchema({
 });
 console.log(summary.answer.oneLineSummary);
 
-// Or pass an explicit JSON schema string
+// Or pass an explicit schema: the OpenAI-style wrapper { name, strict, schema } as a JSON string
+// (a bare JSON schema is not accepted by the model endpoint)
 chat.setUserPrompt("Rate the top performer from 1 to 10");
 const rated = await chat.runWithSchema(JSON.stringify({
-    type: "object",
-    properties: { score: { type: "number" } },
-    required: ["score"]
+    name: "performer_rating",
+    strict: true,
+    schema: {
+        type: "object",
+        properties: { score: { type: "number" } },
+        required: ["score"],
+        additionalProperties: false
+    }
 }));
 console.log(rated.answer.score); // 8
 

--- a/README.md
+++ b/README.md
@@ -2284,6 +2284,19 @@ session.advanced.patch("users/1", "underAge", false);
 await session.saveChanges();
 ```
 
+Session patches are sent as RFC 6902 JsonPatch commands when the path is a plain member/index chain
+(`"address.city"`, `"tags[1]"`) and the value is `null`, a string, a number or a boolean; `patchArray`
+`push()`/`removeAt()` and `patchObject` `set()`/`remove()` follow the same rule. Object and `Date` values,
+`increment()` and anything else keep using a JavaScript patch. JsonPatch is strict: removing a missing key or
+an out-of-range index fails `saveChanges()`. `patch()` on an array index that does not exist yet, or on
+JavaScript-only members such as `array.length`, also fails instead of extending or mutating the array. To keep
+the legacy JavaScript behaviour:
+
+```javascript
+// Before store.initialize()
+store.conventions.sessionPatchBehavior = "JavaScript"; // default: "JsonPatch"
+```
+
 >##### Related tests:
 > <small>[can use advanced.patch](https://github.com/ravendb/ravendb-nodejs-client/blob/5c14565d0c307d22e134530c8d63b09dfddcfb5b/test/Documents/ReadmeSamples.ts#L708)</small>  
 > <small>[can patch](https://github.com/ravendb/ravendb-nodejs-client/blob/5c14565d0c307d22e134530c8d63b09dfddcfb5b/test/Ported/FirstClassPatchTest.ts#L18)</small>  

--- a/README.md
+++ b/README.md
@@ -919,6 +919,55 @@ console.log("chunkedText", chunkedText);
 console.log("Final answer:", answer);
 ```
 
+#### Get a plain text answer (no output schema)
+Skip the agent's output schema for a single turn and get the model's answer as free-form text.
+
+```javascript
+const chat = store.ai.conversation(agent.identifier, "Performers/", {
+    parameters: {country: "France"}
+});
+
+chat.setUserPrompt("Summarize the top performer in two sentences");
+
+// noSchema: the answer is a plain string instead of an object shaped by the agent's schema
+const { answer } = await chat.run({ noSchema: true });
+console.log(answer); // "The employee with the largest profit is ..."
+
+// Stream the raw text as it is generated
+chat.setUserPrompt("Now do the same for Germany");
+await chat.stream(chunk => process.stdout.write(chunk));
+```
+
+#### Override the output schema for one turn
+Replace the agent's default output schema for a single turn with a sample object or an explicit JSON schema.
+The agent-level schema is used again on the next turn.
+
+```javascript
+// Derive the schema from a sample object
+chat.setUserPrompt("Give me a one line summary of the top performer");
+const summary = await chat.runWithSchema({
+    employeeID: "the ID of the top performer",
+    oneLineSummary: "one sentence about the performer"
+});
+console.log(summary.answer.oneLineSummary);
+
+// Or pass an explicit JSON schema string
+chat.setUserPrompt("Rate the top performer from 1 to 10");
+const rated = await chat.runWithSchema(JSON.stringify({
+    type: "object",
+    properties: { score: { type: "number" } },
+    required: ["score"]
+}));
+console.log(rated.answer.score); // 8
+
+// The same overrides work with streaming (the streamed property must exist in the override)
+chat.setUserPrompt("Give me a one line summary of the top performer");
+await chat.streamWithSchema("oneLineSummary", chunk => process.stdout.write(chunk), {
+    employeeID: "the ID of the top performer",
+    oneLineSummary: "one sentence about the performer"
+});
+```
+
 #### Read conversation messages
 Read back the messages of a stored conversation, with optional paging and detail filtering.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ravendb",
-  "version": "7.2.7",
+  "version": "7.2.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ravendb",
-      "version": "7.2.7",
+      "version": "7.2.8",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^22.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ravendb",
-  "version": "7.2.8",
+  "version": "7.2.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ravendb",
-      "version": "7.2.8",
+      "version": "7.2.7",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^22.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ravendb",
-  "version": "7.2.7",
+  "version": "7.2.8",
   "description": "RavenDB client for Node.js",
   "files": [
     "dist"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ravendb",
-  "version": "7.2.8",
+  "version": "7.2.7",
   "description": "RavenDB client for Node.js",
   "files": [
     "dist"

--- a/src/Documents/Commands/Batches/JsonPatchCommandData.ts
+++ b/src/Documents/Commands/Batches/JsonPatchCommandData.ts
@@ -1,0 +1,74 @@
+import { CommandType, ICommandData } from "../CommandData.js";
+import { JsonPatchDocument, JsonPatchOperation } from "../../Operations/JsonPatchDocument.js";
+import { throwError } from "../../../Exceptions/index.js";
+import { InMemoryDocumentSessionOperations } from "../../Session/InMemoryDocumentSessionOperations.js";
+import { DocumentConventions } from "../../Conventions/DocumentConventions.js";
+
+/**
+ * Applies an RFC 6902 JsonPatch document to a single document as part of session.saveChanges().
+ * Unlike PatchCommandData no JavaScript runs on the server; the operations are applied directly.
+ */
+export class JsonPatchCommandData implements ICommandData {
+    public readonly id: string;
+    public readonly name: string = null;
+    public readonly changeVector: string = null;
+    public readonly jsonPatch: JsonPatchDocument;
+    public readonly type: CommandType = "JsonPatch";
+    public returnDocument: boolean = false;
+
+    public constructor(id: string, jsonPatch: JsonPatchDocument) {
+        if (!id) {
+            throwError("InvalidArgumentException", "Id cannot be null");
+        }
+
+        if (!jsonPatch) {
+            throwError("InvalidArgumentException", "JsonPatch cannot be null");
+        }
+
+        this.id = id;
+        this.jsonPatch = jsonPatch;
+    }
+
+    public serialize(conventions: DocumentConventions): object {
+        return {
+            Id: this.id,
+            ChangeVector: null,
+            JsonPatch: {
+                Operations: this.jsonPatch.operations.map(operation => JsonPatchCommandData._serializeOperation(operation, conventions))
+            },
+            ReturnDocument: this.returnDocument,
+            Type: this.type
+        };
+    }
+
+    public onBeforeSaveChanges(session: InMemoryDocumentSessionOperations): void {
+        this.returnDocument = session.isLoaded(this.id);
+    }
+
+    private static _serializeOperation(operation: JsonPatchOperation, conventions: DocumentConventions): Record<string, unknown> {
+        const serialized: Record<string, unknown> = { op: operation.op };
+
+        if (operation.from !== undefined) {
+            serialized.from = operation.from;
+        }
+
+        serialized.path = operation.path;
+
+        if (operation.op === "add" || operation.op === "replace" || operation.op === "test") {
+            // undefined is not representable in JSON; the server requires a "value" for these ops
+            serialized.value = JsonPatchCommandData._serializeValue(operation.value ?? null, conventions);
+        }
+
+        return serialized;
+    }
+
+    private static _serializeValue(value: unknown, conventions: DocumentConventions): unknown {
+        if (value === null || typeof value !== "object") {
+            return value;
+        }
+
+        // same treatment as PatchRequest.serialize() gives to script arguments
+        const literal = conventions.objectMapper.toObjectLiteral(value);
+        return conventions.transformObjectKeysToRemoteFieldNameConvention(literal);
+    }
+}

--- a/src/Documents/Conventions/DocumentConventions.ts
+++ b/src/Documents/Conventions/DocumentConventions.ts
@@ -9,6 +9,7 @@ import {
 } from "../../Types/index.js";
 import { ClientConfiguration } from "../Operations/Configuration/ClientConfiguration.js";
 import { ReadBalanceBehavior } from "../../Http/ReadBalanceBehavior.js";
+import { SessionPatchBehavior } from "./SessionPatchBehavior.js";
 import { throwError } from "../../Exceptions/index.js";
 import { CONSTANTS } from "../../Constants.js";
 import { TypeUtil } from "../../Utility/TypeUtil.js";
@@ -93,6 +94,7 @@ export class DocumentConventions {
     private _loadBalancerContextSeed: number;
     private _loadBalanceBehavior: LoadBalanceBehavior;
     private _readBalanceBehavior: ReadBalanceBehavior;
+    private _sessionPatchBehavior: SessionPatchBehavior;
     private _maxHttpCacheSize: number;
 
     private readonly _knownEntityTypes: Map<string, ObjectTypeDescriptor>;
@@ -142,6 +144,7 @@ export class DocumentConventions {
 
     public constructor() {
         this._readBalanceBehavior = "None";
+        this._sessionPatchBehavior = "JsonPatch";
         this._identityPartsSeparator = "/";
         this._identityProperty = CONSTANTS.Documents.Metadata.ID_PROPERTY;
 
@@ -316,6 +319,21 @@ export class DocumentConventions {
     public set readBalanceBehavior(value: ReadBalanceBehavior) {
         this._assertNotFrozen();
         this._readBalanceBehavior = value;
+    }
+
+    /**
+     * Determines whether the session patch methods (session.advanced.patch(), patchArray(), patchObject())
+     * emit RFC 6902 JsonPatch commands ("JsonPatch", the default) or legacy JavaScript patch commands
+     * ("JavaScript"). Set to "JavaScript" to opt out of the JsonPatch code path entirely and restore the
+     * previous behavior.
+     */
+    public get sessionPatchBehavior(): SessionPatchBehavior {
+        return this._sessionPatchBehavior;
+    }
+
+    public set sessionPatchBehavior(value: SessionPatchBehavior) {
+        this._assertNotFrozen();
+        this._sessionPatchBehavior = value;
     }
 
     public get loadBalancerContextSeed() {

--- a/src/Documents/Conventions/SessionPatchBehavior.ts
+++ b/src/Documents/Conventions/SessionPatchBehavior.ts
@@ -1,0 +1,11 @@
+/**
+ * Controls the patch command format used by the session patch methods
+ * (session.advanced.patch(), patchArray(), patchObject()).
+ *
+ * - "JsonPatch": generate RFC 6902 JsonPatch commands where possible (default). Operations without a
+ *   JsonPatch equivalent (object / Date values, increment(), unparsable paths) still fall back to
+ *   JavaScript-based patch commands.
+ * - "JavaScript": always generate JavaScript-based patch commands (the behavior prior to JsonPatch support).
+ *   Use this to opt out of the JsonPatch code path entirely.
+ */
+export type SessionPatchBehavior = "JsonPatch" | "JavaScript";

--- a/src/Documents/Operations/AI/Agents/RunConversationOperation.ts
+++ b/src/Documents/Operations/AI/Agents/RunConversationOperation.ts
@@ -5,6 +5,7 @@ import type { AiAgentActionResponse, AiAgentArtificialActionResponse } from "./A
 import type { AiConversationCreationOptions } from "./AiConversationCreationOptions.js";
 import type { ConversationResult } from "./ConversationResult.js";
 import type { AiStreamCallback } from "../AiStreamCallback.js";
+import type { AiOutputOptions } from "../AiOutputOptions.js";
 import type { AiAttachmentCommand } from "../AiConversation.js";
 import { ContentPart, TextPart } from "../ContentPart.js";
 import { RavenCommand } from "../../../../Http/RavenCommand.js";
@@ -31,6 +32,7 @@ export class RunConversationOperation<TAnswer> implements IMaintenanceOperation<
     private readonly _attachmentCommands?: AiAttachmentCommand[];
     private readonly _streamPropertyPath?: string;
     private readonly _streamCallback?: AiStreamCallback;
+    private readonly _outputOptions?: AiOutputOptions;
 
     public constructor(
         agentId: string,
@@ -42,7 +44,8 @@ export class RunConversationOperation<TAnswer> implements IMaintenanceOperation<
         changeVector?: string,
         attachmentCommands?: AiAttachmentCommand[],
         streamPropertyPath?: string,
-        streamCallback?: AiStreamCallback
+        streamCallback?: AiStreamCallback,
+        outputOptions?: AiOutputOptions
     ) {
         if (StringUtil.isNullOrEmpty(agentId)) {
             throwError("InvalidArgumentException", "agentId cannot be null or empty.");
@@ -73,6 +76,7 @@ export class RunConversationOperation<TAnswer> implements IMaintenanceOperation<
         this._attachmentCommands = attachmentCommands;
         this._streamPropertyPath = streamPropertyPath;
         this._streamCallback = streamCallback;
+        this._outputOptions = outputOptions;
     }
 
     public get resultType(): OperationResultType {
@@ -91,7 +95,8 @@ export class RunConversationOperation<TAnswer> implements IMaintenanceOperation<
             this._attachmentCommands,
             conventions,
             this._streamPropertyPath,
-            this._streamCallback
+            this._streamCallback,
+            this._outputOptions
         );
     }
 }
@@ -109,6 +114,8 @@ class RunConversationCommand<TAnswer>
     private readonly _attachmentCommands?: AiAttachmentCommand[];
     private readonly _streamPropertyPath?: string;
     private readonly _streamCallback?: AiStreamCallback;
+    private readonly _outputOptions?: AiOutputOptions;
+    private readonly _conventions: DocumentConventions;
     private _raftId: string;
 
     public constructor(
@@ -122,7 +129,8 @@ class RunConversationCommand<TAnswer>
         attachmentCommands: AiAttachmentCommand[] | undefined,
         conventions: DocumentConventions,
         streamPropertyPath?: string,
-        streamCallback?: AiStreamCallback
+        streamCallback?: AiStreamCallback,
+        outputOptions?: AiOutputOptions
     ) {
         super();
         this._conversationId = conversationId;
@@ -135,9 +143,12 @@ class RunConversationCommand<TAnswer>
         this._attachmentCommands = attachmentCommands;
         this._streamPropertyPath = streamPropertyPath;
         this._streamCallback = streamCallback;
+        this._outputOptions = outputOptions;
+        this._conventions = conventions;
 
-        // When streaming is enabled, we need to handle raw response
-        if (this._streamPropertyPath && this._streamCallback) {
+        // When streaming is enabled, we need to handle raw response.
+        // The property path may be an empty string when streaming raw text (noSchema), so check for null only.
+        if (this._streamPropertyPath != null && this._streamCallback) {
             this._responseType = "Raw";
         }
 
@@ -164,7 +175,8 @@ class RunConversationCommand<TAnswer>
             uriParams.append("changeVector", this._changeVector);
         }
 
-        if (this._streamPropertyPath) {
+        // An empty property path is valid when streaming raw text (noSchema); the server ignores it then.
+        if (this._streamPropertyPath != null) {
             uriParams.append("streaming", "true");
             uriParams.append("streamPropertyPath", this._streamPropertyPath);
         }
@@ -184,6 +196,8 @@ class RunConversationCommand<TAnswer>
                     [name, { Value: parameter.value, SendToModel: parameter.sendToModel }]))
             : undefined;
 
+        const outputOptionsPayload = this._serializeOutputOptions();
+
         const bodyObj = {
             ActionResponses: this._actionResponses,
             ArtificialActions: this._artificialActions,
@@ -191,18 +205,20 @@ class RunConversationCommand<TAnswer>
             CreationOptions: {
                 ...otherCreationOptions,
                 ...(parametersPayload ? { parameters: parametersPayload } : {})
-            }
+            },
+            ...(outputOptionsPayload ? { OutputOptions: outputOptionsPayload } : {})
         };
 
         const headers = this._headers().typeAppJson().build();
 
-        // Serialize properties to PascalCase, except the user prompt content parts and
-        // everything under CreationOptions.Parameters (already in its wire shape above).
+        // Serialize properties to PascalCase, except the user prompt content parts,
+        // everything under CreationOptions.Parameters and OutputOptions (already in their wire shape above).
         const serialized = ObjectUtil.transformObjectKeys(bodyObj, {
             defaultTransform: ObjectUtil.pascalCase,
             ignorePaths: [
                 new RegExp("^UserPrompt\\..*$"),
-                new RegExp("^CreationOptions\\.Parameters\\..*$")
+                new RegExp("^CreationOptions\\.Parameters\\..*$"),
+                new RegExp("^OutputOptions\\..*$")
             ]
         });
 
@@ -284,11 +300,40 @@ class RunConversationCommand<TAnswer>
             this._throwInvalidResponse();
         }
 
-        if (this._streamPropertyPath && this._streamCallback) {
+        if (this._streamPropertyPath != null && this._streamCallback) {
             return await this._processStreamingResponse(bodyStream as Readable);
         }
 
         return await this._parseResponseDefaultAsync(bodyStream);
+    }
+
+    /**
+     * Wire shape of AiOutputOptions (mirrors the C# client's AiOutputOptions.ToJson):
+     * SampleObject travels as a JSON *string* (the server derives the schema from it),
+     * OutputSchema as a string, NoSchema only when true.
+     */
+    private _serializeOutputOptions(): Record<string, unknown> | null {
+        const options = this._outputOptions;
+        if (!options) {
+            return null;
+        }
+
+        const payload: Record<string, unknown> = {};
+
+        if (options.sampleObject != null) {
+            const literal = this._conventions.objectMapper.toObjectLiteral(options.sampleObject);
+            payload.SampleObject = JsonSerializer.getDefault().serialize(literal);
+        }
+
+        if (options.outputSchema != null) {
+            payload.OutputSchema = options.outputSchema;
+        }
+
+        if (options.noSchema) {
+            payload.NoSchema = true;
+        }
+
+        return payload;
     }
 
     private async _processStreamingResponse(bodyStream: Readable): Promise<string> {

--- a/src/Documents/Operations/AI/AiConversation.ts
+++ b/src/Documents/Operations/AI/AiConversation.ts
@@ -4,6 +4,7 @@ import type { AiAgentActionResponse, AiAgentArtificialActionResponse } from "./A
 import type { AiConversationCreationOptions } from "./Agents/AiConversationCreationOptions.js";
 import type { AiAnswer } from "./AiAnswer.js";
 import type { AiStreamCallback } from "./AiStreamCallback.js";
+import type { AiOutputOptions } from "./AiOutputOptions.js";
 import type { IDocumentStore } from "../../IDocumentStore.js";
 import type { UnhandledActionEventArgs } from "./UnhandledActionEventArgs.js";
 import { ContentPart, TextPart } from "./ContentPart.js";
@@ -199,6 +200,15 @@ export class AiConversation {
         this._attachmentCommands.push({ kind: "copy", sourceDocumentId, fileName });
     }
 
+    /**
+     * Registers a handler for an action tool. The handler's return value is sent back to the model
+     * as the tool result (use {@link receive} to send the response manually).
+     *
+     * The handler may take `(args)`, `(request, args)`, or no parameters at all for a no-args action tool:
+     * ```typescript
+     * chat.handle("get-current-time", async () => ({ now: new Date().toISOString() }));
+     * ```
+     */
     public handle<TArgs = any, TResult extends object = object>(
         actionName: string,
         action: (args: TArgs) => Promise<TResult>,
@@ -240,6 +250,15 @@ export class AiConversation {
         }, aiHandleError);
     }
 
+    /**
+     * Registers a receiver for an action tool. Unlike {@link handle}, the receiver is responsible for
+     * sending the tool result itself via {@link addActionResponse}.
+     *
+     * For a no-args action tool the receiver may take just `(request)`:
+     * ```typescript
+     * chat.receive("ping", request => chat.addActionResponse(request.toolId, "pong"));
+     * ```
+     */
     public receive<TArgs = any>(actionName: string, action: (request: AiAgentActionRequest, args: TArgs) => Promise<void> | void, aiHandleError: AiHandleErrorStrategy = AiHandleErrorStrategy.SendErrorsToModel): void {
         if (this._invocations.has(actionName)) {
             throwError("InvalidOperationException", `Action '${actionName}' already exists.`);
@@ -259,17 +278,88 @@ export class AiConversation {
         this._invocations.set(actionName, inv);
     }
 
-    public async run<TAnswer>(): Promise<AiAnswer<TAnswer>> {
+    /**
+     * Executes one "turn" of the conversation: sends the current prompt, processes any required
+     * actions and returns the model's answer, shaped by the agent's default output schema.
+     */
+    public run<TAnswer>(): Promise<AiAnswer<TAnswer>>;
+    /**
+     * Executes one "turn" of the conversation without structured output.
+     * The model returns free-form text, available as `answer` (a string).
+     *
+     * @example
+     * ```typescript
+     * const { answer } = await chat.run({ noSchema: true });
+     * ```
+     */
+    public run(outputOptions: AiOutputOptions & { noSchema: true }): Promise<AiAnswer<string>>;
+    /**
+     * Executes one "turn" of the conversation with output format options, allowing the caller to
+     * override the agent's default output schema (`sampleObject` / `outputSchema`) or disable
+     * structured output (`noSchema`) for this turn only.
+     *
+     * @param outputOptions - Options controlling the output format for this turn
+     */
+    public run<TAnswer>(outputOptions: AiOutputOptions): Promise<AiAnswer<TAnswer>>;
+    public async run<TAnswer>(outputOptions?: AiOutputOptions): Promise<AiAnswer<TAnswer>> {
+        if (outputOptions != null) {
+            this._validateOutputOptions(outputOptions);
+        }
+
         this._dispatchedToolIds.clear();
         // eslint-disable-next-line no-constant-condition
         while (true) {
-            const r = await this._runInternal<TAnswer>();
+            const r = await this._runInternal<TAnswer>(undefined, undefined, outputOptions);
             if (r.status === "Done" || !await this._dispatchPendingActions(r)) {
                 return r;
             }
         }
     }
 
+    /**
+     * Executes one "turn" of the conversation with an explicit JSON schema override for this turn only.
+     *
+     * @param outputSchema - A JSON schema string sent to the model for this turn
+     */
+    public runWithSchema<TAnswer>(outputSchema: string): Promise<AiAnswer<TAnswer>>;
+    /**
+     * Executes one "turn" of the conversation with output format options for this turn only.
+     * Equivalent to {@link run} with `outputOptions`.
+     *
+     * @param outputOptions - Options controlling the output format for this turn
+     */
+    public runWithSchema<TAnswer>(outputOptions: AiOutputOptions): Promise<AiAnswer<TAnswer>>;
+    /**
+     * Executes one "turn" of the conversation, deriving the output schema from `sampleObject`
+     * for this turn only. The server converts the sample object to a JSON schema.
+     *
+     * An object whose keys are only `sampleObject`, `outputSchema` or `noSchema` is treated as
+     * {@link AiOutputOptions}; wrap such a sample explicitly as `{ sampleObject }`.
+     *
+     * @param sampleObject - A sample instance used to generate the JSON schema sent to the model
+     *
+     * @example
+     * ```typescript
+     * const answer = await chat.runWithSchema({ summary: "a short summary", score: 5 });
+     * ```
+     */
+    public runWithSchema<TAnswer extends object>(sampleObject: TAnswer): Promise<AiAnswer<TAnswer>>;
+    public runWithSchema<TAnswer>(schemaOrSampleObjectOrOptions: string | AiOutputOptions | TAnswer): Promise<AiAnswer<TAnswer>> {
+        return this.run<TAnswer>(this._toOutputOptions(schemaOrSampleObjectOrOptions));
+    }
+
+    /**
+     * Streams the model's answer as raw text without structured output: `streamCallback` receives
+     * each text chunk as it arrives, and the full text is returned as `answer` (a string).
+     *
+     * @param streamCallback - Callback invoked with each streamed text chunk
+     *
+     * @example
+     * ```typescript
+     * const { answer } = await chat.stream(chunk => process.stdout.write(chunk));
+     * ```
+     */
+    public stream(streamCallback: AiStreamCallback): Promise<AiAnswer<string>>;
     /**
      * Executes one "turn" of the conversation with streaming enabled.
      * Streams the specified property's value in real-time by invoking the callback with each chunk.
@@ -285,8 +375,41 @@ export class AiConversation {
      * });
      * ```
      */
-    public async stream<TAnswer>(streamPropertyPath: string, streamCallback: AiStreamCallback): Promise<AiAnswer<TAnswer>> {
-        if (StringUtil.isNullOrEmpty(streamPropertyPath)) {
+    public stream<TAnswer>(streamPropertyPath: string, streamCallback: AiStreamCallback): Promise<AiAnswer<TAnswer>>;
+    /**
+     * Streams the model's answer as raw text without structured output.
+     * `streamPropertyPath` is not used when `noSchema` is true.
+     */
+    public stream(streamPropertyPath: string, streamCallback: AiStreamCallback, outputOptions: AiOutputOptions & { noSchema: true }): Promise<AiAnswer<string>>;
+    /**
+     * Executes one "turn" of the conversation with streaming and output format options,
+     * allowing the caller to override the agent's default output schema for this turn only.
+     *
+     * @param streamPropertyPath - The property path of the answer to stream. Not used when `noSchema` is true
+     * @param streamCallback - Callback invoked with each streamed chunk
+     * @param outputOptions - Options controlling the output format for this turn
+     */
+    public stream<TAnswer>(streamPropertyPath: string, streamCallback: AiStreamCallback, outputOptions: AiOutputOptions): Promise<AiAnswer<TAnswer>>;
+    public async stream<TAnswer>(
+        streamPropertyPathOrCallback: string | AiStreamCallback,
+        streamCallback?: AiStreamCallback,
+        outputOptions?: AiOutputOptions
+    ): Promise<AiAnswer<TAnswer>> {
+        let streamPropertyPath: string;
+        if (typeof streamPropertyPathOrCallback === "function") {
+            // stream(callback): the whole answer is one text stream, no property path and no schema
+            streamPropertyPath = "";
+            streamCallback = streamPropertyPathOrCallback;
+            outputOptions = { noSchema: true };
+        } else {
+            streamPropertyPath = streamPropertyPathOrCallback;
+        }
+
+        if (outputOptions != null) {
+            this._validateOutputOptions(outputOptions);
+        }
+        // With noSchema the answer is plain text, so there is no property to point at
+        if (!outputOptions?.noSchema && StringUtil.isNullOrEmpty(streamPropertyPath)) {
             throwError("InvalidArgumentException", "streamPropertyPath cannot be empty");
         }
         if (!streamCallback) {
@@ -296,10 +419,80 @@ export class AiConversation {
         this._dispatchedToolIds.clear();
         // eslint-disable-next-line no-constant-condition
         while (true) {
-            const r = await this._runInternal<TAnswer>(streamPropertyPath, streamCallback);
+            const r = await this._runInternal<TAnswer>(streamPropertyPath ?? "", streamCallback, outputOptions);
             if (r.status === "Done" || !await this._dispatchPendingActions(r)) {
                 return r;
             }
+        }
+    }
+
+    /**
+     * Executes one "turn" of the conversation with streaming and an explicit JSON schema override for this turn only.
+     *
+     * @param streamPropertyPath - The property path of the answer to stream
+     * @param streamCallback - Callback invoked with each streamed chunk
+     * @param outputSchema - A JSON schema string sent to the model for this turn
+     */
+    public streamWithSchema<TAnswer>(streamPropertyPath: string, streamCallback: AiStreamCallback, outputSchema: string): Promise<AiAnswer<TAnswer>>;
+    /**
+     * Executes one "turn" of the conversation with streaming and output format options for this turn only.
+     * Equivalent to {@link stream} with `outputOptions`.
+     */
+    public streamWithSchema<TAnswer>(streamPropertyPath: string, streamCallback: AiStreamCallback, outputOptions: AiOutputOptions): Promise<AiAnswer<TAnswer>>;
+    /**
+     * Executes one "turn" of the conversation with streaming, deriving the output schema from
+     * `sampleObject` for this turn only.
+     *
+     * An object whose keys are only `sampleObject`, `outputSchema` or `noSchema` is treated as
+     * {@link AiOutputOptions}; wrap such a sample explicitly as `{ sampleObject }`.
+     */
+    public streamWithSchema<TAnswer extends object>(streamPropertyPath: string, streamCallback: AiStreamCallback, sampleObject: TAnswer): Promise<AiAnswer<TAnswer>>;
+    public streamWithSchema<TAnswer>(
+        streamPropertyPath: string,
+        streamCallback: AiStreamCallback,
+        schemaOrSampleObjectOrOptions: string | AiOutputOptions | TAnswer
+    ): Promise<AiAnswer<TAnswer>> {
+        return this.stream<TAnswer>(streamPropertyPath, streamCallback, this._toOutputOptions(schemaOrSampleObjectOrOptions));
+    }
+
+    private static readonly OUTPUT_OPTIONS_KEYS = new Set<string>(["sampleObject", "outputSchema", "noSchema"]);
+
+    private _toOutputOptions<TAnswer>(schemaOrSampleObjectOrOptions: string | AiOutputOptions | TAnswer): AiOutputOptions {
+        const value = schemaOrSampleObjectOrOptions;
+        if (typeof value === "string") {
+            return { outputSchema: value };
+        }
+        if (value == null || typeof value !== "object") {
+            throwError("InvalidArgumentException", "Expected a JSON schema string, a sample object or AiOutputOptions.");
+        }
+
+        // Only sampleObject / outputSchema / noSchema keys: this is AiOutputOptions, otherwise a sample object
+        const keys = Object.keys(value);
+        if (keys.every(key => AiConversation.OUTPUT_OPTIONS_KEYS.has(key))) {
+            return value as AiOutputOptions;
+        }
+
+        return { sampleObject: value as object };
+    }
+
+    private _validateOutputOptions(outputOptions: AiOutputOptions): void {
+        if (outputOptions == null || typeof outputOptions !== "object") {
+            throwError("InvalidArgumentException", "outputOptions cannot be null");
+        }
+
+        if (outputOptions.noSchema && (outputOptions.outputSchema != null || outputOptions.sampleObject != null)) {
+            throwError("InvalidOperationException",
+                "When noSchema is true the model is expected to return just a string, with no structure, " +
+                "so you cannot also set an output schema. Either set noSchema to false, or remove the outputSchema and sampleObject.");
+        }
+
+        if (outputOptions.outputSchema != null
+            && (typeof outputOptions.outputSchema !== "string" || outputOptions.outputSchema.trim().length === 0)) {
+            throwError("InvalidArgumentException", "outputSchema cannot be null or whitespace.");
+        }
+
+        if (outputOptions.sampleObject != null && typeof outputOptions.sampleObject !== "object") {
+            throwError("InvalidArgumentException", "sampleObject must be an object.");
         }
     }
 
@@ -333,7 +526,7 @@ export class AiConversation {
         return this._actionResponses.size > 0; // false = ActionsRequired, nothing to send back yet
     }
 
-    private async _runInternal<TAnswer>(streamPropertyPath?: string, streamCallback?: AiStreamCallback): Promise<AiAnswer<TAnswer>> {
+    private async _runInternal<TAnswer>(streamPropertyPath?: string, streamCallback?: AiStreamCallback, outputOptions?: AiOutputOptions): Promise<AiAnswer<TAnswer>> {
         if (this._actionRequests != null && this._promptParts.length === 0 && this._actionResponses.size === 0 && this._artificialActions.length === 0 && this._attachmentCommands.length === 0) {
             return {status: "Done" as const} as AiAnswer<TAnswer>;
         }
@@ -348,7 +541,8 @@ export class AiConversation {
             this._changeVector,
             this._attachmentCommands.length > 0 ? [...this._attachmentCommands] : undefined,
             streamPropertyPath,
-            streamCallback
+            streamCallback,
+            outputOptions
         );
 
         try {

--- a/src/Documents/Operations/AI/AiConversation.ts
+++ b/src/Documents/Operations/AI/AiConversation.ts
@@ -317,9 +317,10 @@ export class AiConversation {
     }
 
     /**
-     * Executes one "turn" of the conversation with an explicit JSON schema override for this turn only.
+     * Executes one "turn" of the conversation with an explicit output schema override for this turn only.
      *
-     * @param outputSchema - A JSON schema string sent to the model for this turn
+     * @param outputSchema - The OpenAI-style `{ name, strict, schema }` JSON string sent to the model for this turn
+     * (see {@link AiOutputOptions.outputSchema}); a bare JSON schema is not accepted by the model endpoint
      */
     public runWithSchema<TAnswer>(outputSchema: string): Promise<AiAnswer<TAnswer>>;
     /**
@@ -431,7 +432,8 @@ export class AiConversation {
      *
      * @param streamPropertyPath - The property path of the answer to stream
      * @param streamCallback - Callback invoked with each streamed chunk
-     * @param outputSchema - A JSON schema string sent to the model for this turn
+     * @param outputSchema - The OpenAI-style `{ name, strict, schema }` JSON string sent to the model for this turn
+     * (see {@link AiOutputOptions.outputSchema})
      */
     public streamWithSchema<TAnswer>(streamPropertyPath: string, streamCallback: AiStreamCallback, outputSchema: string): Promise<AiAnswer<TAnswer>>;
     /**

--- a/src/Documents/Operations/AI/AiOutputOptions.ts
+++ b/src/Documents/Operations/AI/AiOutputOptions.ts
@@ -1,0 +1,40 @@
+/**
+ * Controls the output format for a single AI conversation turn.
+ *
+ * A default output schema must still be provided when creating the agent (via `store.ai.createAgent()`).
+ * `AiOutputOptions` lets you override that default on a per-call basis: the options set here
+ * take precedence over the agent-level schema for the duration of that turn only.
+ *
+ * Set exactly one of `sampleObject`, `outputSchema` or `noSchema`. When several are set the server
+ * applies `noSchema` first, then `outputSchema`, then `sampleObject`.
+ *
+ * @example
+ * ```typescript
+ * // derive the schema from a sample object for this turn only
+ * const answer = await chat.run<Summary>({ sampleObject: { summary: "a short summary", score: 5 } });
+ *
+ * // free-form text answer, no structured output
+ * const text = await chat.run({ noSchema: true });
+ * ```
+ */
+export interface AiOutputOptions {
+    /**
+     * A sample object used to generate a JSON schema for structured output.
+     * The server converts it to a JSON schema at request time.
+     * Must match the `TAnswer` type used in the conversation call.
+     */
+    sampleObject?: object;
+
+    /**
+     * An explicit JSON schema string for structured output.
+     * Takes precedence over `sampleObject` if both are set.
+     */
+    outputSchema?: string;
+
+    /**
+     * When true, disables structured output entirely.
+     * The LLM returns free-form text instead of JSON conforming to a schema,
+     * and the answer is a plain string.
+     */
+    noSchema?: boolean;
+}

--- a/src/Documents/Operations/AI/AiOutputOptions.ts
+++ b/src/Documents/Operations/AI/AiOutputOptions.ts
@@ -26,8 +26,20 @@ export interface AiOutputOptions {
     sampleObject?: object;
 
     /**
-     * An explicit JSON schema string for structured output.
+     * An explicit output schema for structured output, as a JSON string.
+     * The server forwards it verbatim as the model's `response_format.json_schema`, so it must be the
+     * OpenAI-style wrapper `{ "name": "...", "strict": true, "schema": { ...JSON schema... } }`, not a bare
+     * JSON schema (a bare schema is ignored by the model and the turn fails to parse).
      * Takes precedence over `sampleObject` if both are set.
+     *
+     * @example
+     * ```typescript
+     * outputSchema: JSON.stringify({
+     *     name: "rating",
+     *     strict: true,
+     *     schema: { type: "object", properties: { score: { type: "number" } }, required: ["score"], additionalProperties: false }
+     * })
+     * ```
      */
     outputSchema?: string;
 

--- a/src/Documents/Operations/AI/EmbeddingsGenerationConfiguration.ts
+++ b/src/Documents/Operations/AI/EmbeddingsGenerationConfiguration.ts
@@ -69,6 +69,13 @@ export class EmbeddingsGenerationConfiguration extends AbstractAiIntegrationConf
     public embeddingsCacheForQueryingExpiration: number = DEFAULT_QUERY_CACHE_EXPIRATION_MS;
 
     /**
+     * Store the text of each chunk in the database alongside its embedding.
+     * Useful for debugging or highlighting, but increases storage requirements.
+     * @default false
+     */
+    public storeChunkText: boolean = false;
+
+    /**
      * Gets the transformation name based on the configuration approach.
      * @internal
      */
@@ -258,6 +265,7 @@ export class EmbeddingsGenerationConfiguration extends AbstractAiIntegrationConf
         result.EmbeddingsCacheForQueryingExpiration = TimeUtil.millisToTimeSpan(
             this.embeddingsCacheForQueryingExpiration
         );
+        result.StoreChunkText = this.storeChunkText;
 
         return result;
     }
@@ -282,6 +290,7 @@ export class EmbeddingsGenerationConfiguration extends AbstractAiIntegrationConf
 
         if (this.collection !== other.collection ||
             this.quantization !== other.quantization ||
+            !!this.storeChunkText !== !!other.storeChunkText ||
             this.embeddingsCacheExpiration !== other.embeddingsCacheExpiration ||
             this.embeddingsCacheForQueryingExpiration !== other.embeddingsCacheForQueryingExpiration) {
             return false;

--- a/src/Documents/Operations/AI/index.ts
+++ b/src/Documents/Operations/AI/index.ts
@@ -3,6 +3,7 @@ export * from "./AiConversationResult.js";
 export * from "./AiAnswer.js"
 export * from "./AiOperations.js"
 export * from "./AiStreamCallback.js";
+export * from "./AiOutputOptions.js";
 export * from "./UnhandledActionEventArgs.js";
 export * from "./ContentPart.js";
 export * from "./ConnectionStrings/index.js";

--- a/src/Documents/Operations/CdcSink/CdcSinkPostgresSettings.ts
+++ b/src/Documents/Operations/CdcSink/CdcSinkPostgresSettings.ts
@@ -6,14 +6,14 @@
 export interface CdcSinkPostgresSettings {
     /**
      * The PostgreSQL publication name used for logical replication.
-     * If null on creation, auto-filled with an auto-generated name (rvn_cdc_p_{guid}).
+     * If null on creation, auto-filled with an auto-generated name (rvn_cdc_p_{taskId}).
      * Must be a valid PostgreSQL identifier (alphanumeric + underscore, max 63 chars).
      */
     publicationName?: string;
 
     /**
      * The PostgreSQL logical replication slot name.
-     * If null on creation, auto-filled with an auto-generated name (rvn_cdc_s_{guid}).
+     * If null on creation, auto-filled with an auto-generated name (rvn_cdc_s_{taskId}).
      * Must be a valid PostgreSQL identifier (alphanumeric + underscore, max 63 chars).
      */
     slotName?: string;

--- a/src/Documents/Operations/JsonPatchDocument.ts
+++ b/src/Documents/Operations/JsonPatchDocument.ts
@@ -1,0 +1,51 @@
+export type JsonPatchOperationType = "add" | "remove" | "replace" | "move" | "copy" | "test";
+
+/**
+ * A single RFC 6902 operation. Property names match the wire format the server expects
+ * ("op", "path", "value", "from").
+ */
+export interface JsonPatchOperation {
+    op: JsonPatchOperationType;
+    path: string;
+    value?: unknown;
+    from?: string;
+}
+
+/**
+ * RFC 6902 JSON Patch document: an ordered list of operations applied to one document.
+ * Paths are RFC 6901 JSON pointers ("/tags/0", "/address/city"); "-" appends to an array ("/tags/-").
+ * Send it with `session.advanced.defer(new JsonPatchCommandData(id, document))`.
+ */
+export class JsonPatchDocument {
+    public readonly operations: JsonPatchOperation[] = [];
+
+    public add(path: string, value: unknown): this {
+        this.operations.push({ op: "add", path, value });
+        return this;
+    }
+
+    public remove(path: string): this {
+        this.operations.push({ op: "remove", path });
+        return this;
+    }
+
+    public replace(path: string, value: unknown): this {
+        this.operations.push({ op: "replace", path, value });
+        return this;
+    }
+
+    public move(from: string, path: string): this {
+        this.operations.push({ op: "move", from, path });
+        return this;
+    }
+
+    public copy(from: string, path: string): this {
+        this.operations.push({ op: "copy", from, path });
+        return this;
+    }
+
+    public test(path: string, value: unknown): this {
+        this.operations.push({ op: "test", path, value });
+        return this;
+    }
+}

--- a/src/Documents/Session/DocumentSession.ts
+++ b/src/Documents/Session/DocumentSession.ts
@@ -44,6 +44,9 @@ import { LazySessionOperations } from "./Operations/Lazy/LazySessionOperations.j
 import { JavaScriptArray } from "./JavaScriptArray.js";
 import { PatchRequest } from "../Operations/PatchRequest.js";
 import { PatchCommandData } from "../Commands/Batches/PatchCommandData.js";
+import { JsonPatchCommandData } from "../Commands/Batches/JsonPatchCommandData.js";
+import { JsonPatchDocument } from "../Operations/JsonPatchDocument.js";
+import { canUseJsonPatchValue, escapeJsonPointerSegment, isValidJsonPointerSegment, tryBuildJsonPointer } from "./JsonPatchPath.js";
 import { IdTypeAndName } from "../IdTypeAndName.js";
 import { IRevisionsSessionOperations } from "./IRevisionsSessionOperations.js";
 import { DocumentSessionRevisions } from "./DocumentSessionRevisions.js";
@@ -493,7 +496,7 @@ export class DocumentSession extends InMemoryDocumentSessionOperations
     }
 
     public addOrPatchArray<T extends object, UValue>(id: string, entity: T, pathToArray: string, arrayAdder: (array: JavaScriptArray<UValue>) => void) {
-        const scriptArray = new JavaScriptArray(this._customCount++, pathToArray);
+        const scriptArray = new JavaScriptArray<UValue>(this._customCount++, pathToArray);
 
         arrayAdder(scriptArray);
 
@@ -577,6 +580,10 @@ export class DocumentSession extends InMemoryDocumentSessionOperations
             id = metadata["@id"];
         }
 
+        if (this._tryPatchWithJsonPatch(id, path, value)) {
+            return;
+        }
+
         const patchRequest = new PatchRequest();
         patchRequest.script = "this." + path + " = args.val_" + this._valsCount + ";";
         const valKey = "val_" + this._valsCount;
@@ -606,8 +613,12 @@ export class DocumentSession extends InMemoryDocumentSessionOperations
             id = metadata["@id"];
         }
 
-        const scriptArray = new JavaScriptArray(this._customCount++, path);
+        const scriptArray = new JavaScriptArray<UValue>(this._customCount++, path);
         arrayAdder(scriptArray);
+
+        if (this._tryPatchArrayWithJsonPatch(id, path, scriptArray)) {
+            return;
+        }
 
         const patchRequest = new PatchRequest();
         patchRequest.script = scriptArray.script;
@@ -625,9 +636,13 @@ export class DocumentSession extends InMemoryDocumentSessionOperations
     patchObject<TEntity extends object, TKey, TValue>(
         idOrEntity: string | TEntity, pathToObject: string, mapAdder: (map: JavaScriptMap<TKey, TValue>) => void): void {
         if (TypeUtil.isString(idOrEntity)) {
-            const scriptMap = new JavaScriptMap(this._customCount++, pathToObject);
+            const scriptMap = new JavaScriptMap<TKey, TValue>(this._customCount++, pathToObject);
 
             mapAdder(scriptMap);
+
+            if (this._tryPatchObjectWithJsonPatch(idOrEntity, pathToObject, scriptMap)) {
+                return;
+            }
 
             const patchRequest = new PatchRequest();
             patchRequest.script = scriptMap.getScript();
@@ -641,6 +656,151 @@ export class DocumentSession extends InMemoryDocumentSessionOperations
             const id = metadata[CONSTANTS.Documents.Metadata.ID];
             this.patchObject(id, pathToObject, mapAdder);
         }
+    }
+
+    private get _useJsonPatchInSessionPatchMethods(): boolean {
+        return this.conventions.sessionPatchBehavior === "JsonPatch";
+    }
+
+    /**
+     * A JavaScript patch already deferred for this document has to run first; later operations join it
+     * (see _tryMergePatches) instead of being reordered into a separate JsonPatch command.
+     */
+    private _hasDeferredJavaScriptPatch(id: string): boolean {
+        return this.deferredCommandsMap.has(IdTypeAndName.keyFor(id, "PATCH", null));
+    }
+
+    /**
+     * Defers the JsonPatch, or appends its operations to the JsonPatch already deferred for the same
+     * document so one document gets one JsonPatch command per saveChanges().
+     */
+    private _deferJsonPatch(id: string, patch: JsonPatchDocument): void {
+        const existing = this.deferredCommandsMap.get(IdTypeAndName.keyFor(id, "JsonPatch", null)) as JsonPatchCommandData | undefined;
+        if (!existing) {
+            this.defer(new JsonPatchCommandData(id, patch));
+            return;
+        }
+
+        const commandIdx = this._deferredCommands.indexOf(existing);
+        if (commandIdx > -1) {
+            this._deferredCommands.splice(commandIdx, 1);
+        }
+
+        existing.jsonPatch.operations.push(...patch.operations);
+        this.defer(existing);
+    }
+
+    private _tryPatchWithJsonPatch(id: string, path: string, value: unknown): boolean {
+        if (!this._useJsonPatchInSessionPatchMethods
+            || this._hasDeferredJavaScriptPatch(id)
+            || !canUseJsonPatchValue(value)) {
+            return false;
+        }
+
+        const pointer = tryBuildJsonPointer(path);
+        if (!pointer) {
+            return false;
+        }
+
+        // Match the JavaScript "this.x = value" semantics: assigning to a named member creates it when
+        // absent (JsonPatch "add" creates-or-replaces an object member), while assigning to an existing
+        // positional element overwrites it in place (JsonPatch "replace"; "add" would insert before the index).
+        const patch = new JsonPatchDocument();
+        if (pointer.endsWithIndex) {
+            patch.replace(pointer.pointer, value);
+        } else {
+            patch.add(pointer.pointer, value);
+        }
+
+        this._deferJsonPatch(id, patch);
+        return true;
+    }
+
+    private _tryPatchArrayWithJsonPatch<UValue>(id: string, path: string, scriptArray: JavaScriptArray<UValue>): boolean {
+        if (!this._useJsonPatchInSessionPatchMethods || this._hasDeferredJavaScriptPatch(id)) {
+            return false;
+        }
+
+        const pointer = tryBuildJsonPointer(path);
+        if (!pointer) {
+            return false;
+        }
+
+        const patch = new JsonPatchDocument();
+        for (const operation of scriptArray.operations) {
+            switch (operation.type) {
+                case "push": {
+                    for (const value of operation.values) {
+                        if (!canUseJsonPatchValue(value)) {
+                            return false;
+                        }
+                        patch.add(`${pointer.pointer}/-`, value);
+                    }
+                    break;
+                }
+                case "removeAt": {
+                    if (!Number.isInteger(operation.index) || operation.index < 0) {
+                        return false;
+                    }
+                    patch.remove(`${pointer.pointer}/${operation.index}`);
+                    break;
+                }
+                default: {
+                    return false;
+                }
+            }
+        }
+
+        if (patch.operations.length === 0) {
+            return false;
+        }
+
+        this._deferJsonPatch(id, patch);
+        return true;
+    }
+
+    private _tryPatchObjectWithJsonPatch<TKey, TValue>(id: string, path: string, scriptMap: JavaScriptMap<TKey, TValue>): boolean {
+        if (!this._useJsonPatchInSessionPatchMethods || this._hasDeferredJavaScriptPatch(id)) {
+            return false;
+        }
+
+        const pointer = tryBuildJsonPointer(path);
+        if (!pointer) {
+            return false;
+        }
+
+        const patch = new JsonPatchDocument();
+        for (const operation of scriptMap.operations) {
+            const key = operation.key == null ? null : String(operation.key);
+            if (!isValidJsonPointerSegment(key)) {
+                return false;
+            }
+
+            const keyPointer = `${pointer.pointer}/${escapeJsonPointerSegment(key)}`;
+            switch (operation.type) {
+                case "set": {
+                    if (!canUseJsonPatchValue(operation.value)) {
+                        return false;
+                    }
+                    patch.add(keyPointer, operation.value);
+                    break;
+                }
+                case "remove": {
+                    patch.remove(keyPointer);
+                    break;
+                }
+                default: {
+                    return false;
+                }
+            }
+        }
+
+        if (patch.operations.length === 0) {
+            return false;
+        }
+
+        this._deferJsonPatch(id, patch);
+        return true;
     }
 
     private _tryMergePatches(id: string, patchRequest: PatchRequest): boolean {

--- a/src/Documents/Session/JavaScriptArray.ts
+++ b/src/Documents/Session/JavaScriptArray.ts
@@ -1,3 +1,7 @@
+export type JavaScriptArrayOperation<U> =
+    | { type: "push"; values: U[] }
+    | { type: "removeAt"; index: number };
+
 export class JavaScriptArray<U> {
     private readonly _suffix: number;
     private _argCounter: number = 0;
@@ -6,6 +10,7 @@ export class JavaScriptArray<U> {
 
     private _scriptLines: string[] = [];
     private _parameters = {};
+    private readonly _operations: JavaScriptArrayOperation<U>[] = [];
 
     constructor(suffix: number, pathToArray: string) {
         this._suffix = suffix;
@@ -14,7 +19,7 @@ export class JavaScriptArray<U> {
 
     public push(...u: U[]): this {
         if (!u || u.length === 0) {
-            return;
+            return this;
         }
 
         const args = u.map(value => {
@@ -24,6 +29,7 @@ export class JavaScriptArray<U> {
         }).join(",");
 
         this._scriptLines.push("this." + this._pathToArray + ".push(" + args + ");");
+        this._operations.push({ type: "push", values: [...u] });
         return this;
     }
 
@@ -32,6 +38,7 @@ export class JavaScriptArray<U> {
 
         this._scriptLines.push("this." + this._pathToArray + ".splice(args." + argumentName + ", 1);");
         this._parameters[argumentName] = index;
+        this._operations.push({ type: "removeAt", index });
         return this;
     }
 
@@ -45,5 +52,13 @@ export class JavaScriptArray<U> {
 
     get parameters() {
         return this._parameters;
+    }
+
+    /**
+     * The operations requested so far, in call order. The session uses them to emit an
+     * RFC 6902 JsonPatch instead of the script when every operation has a JsonPatch equivalent.
+     */
+    get operations(): ReadonlyArray<JavaScriptArrayOperation<U>> {
+        return this._operations;
     }
 }

--- a/src/Documents/Session/JavaScriptMap.ts
+++ b/src/Documents/Session/JavaScriptMap.ts
@@ -1,5 +1,9 @@
 import { EOL } from "../../Utility/OsUtil.js";
 
+export type JavaScriptMapOperation<TKey, TValue> =
+    | { type: "set"; key: TKey; value: TValue }
+    | { type: "remove"; key: TKey };
+
 export class JavaScriptMap<TKey, TValue> {
     private readonly _suffix: number;
     private _argCounter: number = 0;
@@ -8,6 +12,7 @@ export class JavaScriptMap<TKey, TValue> {
 
     private readonly _scriptLines = [];
     private readonly _parameters: Record<string, any> = {};
+    private readonly _operations: JavaScriptMapOperation<TKey, TValue>[] = [];
 
     constructor(suffix: number, pathToMap: string) {
         this._suffix = suffix;
@@ -17,15 +22,23 @@ export class JavaScriptMap<TKey, TValue> {
     public set(key: TKey, value: TValue) {
         const argumentName = this._getNextArgumentName();
 
-        this._scriptLines.push("this." + this._pathToMap + "." + key + " = args." + argumentName + ";");
+        this._scriptLines.push("this." + this._pathToMap + "[" + JavaScriptMap._quoteKey(key) + "] = args." + argumentName + ";");
         this._parameters[argumentName] = value;
+        this._operations.push({ type: "set", key, value });
 
         return this;
     }
 
     public remove(key: TKey) {
-        this._scriptLines.push("delete this." + this._pathToMap + "." + key + ";");
+        this._scriptLines.push("delete this." + this._pathToMap + "[" + JavaScriptMap._quoteKey(key) + "];");
+        this._operations.push({ type: "remove", key });
         return this;
+    }
+
+    // Bracket notation with a JSON string literal keeps the script valid for any key
+    // (whitespace, dots, quotes), same as the C# client's FormatKeyForJavaScript.
+    private static _quoteKey(key: unknown): string {
+        return JSON.stringify(String(key));
     }
 
     private _getNextArgumentName() {
@@ -38,5 +51,13 @@ export class JavaScriptMap<TKey, TValue> {
 
     get parameters() {
         return this._parameters;
+    }
+
+    /**
+     * The operations requested so far, in call order. The session uses them to emit an
+     * RFC 6902 JsonPatch instead of the script when every operation has a JsonPatch equivalent.
+     */
+    get operations(): ReadonlyArray<JavaScriptMapOperation<TKey, TValue>> {
+        return this._operations;
     }
 }

--- a/src/Documents/Session/JsonPatchPath.ts
+++ b/src/Documents/Session/JsonPatchPath.ts
@@ -1,0 +1,99 @@
+/**
+ * Turns the JavaScript-style paths accepted by session.advanced.patch() / patchArray() / patchObject()
+ * ("address.city", "tags[1]", "stuff[0].key") into RFC 6901 JSON pointers ("/address/city", "/tags/1", "/stuff/0/key").
+ *
+ * Grammar: identifier ( "." identifier | "[" integer "]" )*, identifier = [A-Za-z_$][A-Za-z0-9_$]*.
+ * Anything else (quotes, expressions, whitespace) yields null so the caller keeps the JavaScript patch.
+ */
+
+export interface JsonPointerInfo {
+    /** RFC 6901 pointer, e.g. "/stuff/0/key" */
+    pointer: string;
+    /** true when the last segment is an array index ("tags[1]"), false for a named member ("address.city") */
+    endsWithIndex: boolean;
+}
+
+const IDENTIFIER = /^[A-Za-z_$][A-Za-z0-9_$]*/;
+const INDEX = /^\[(0|[1-9][0-9]*)\]/;
+
+export function escapeJsonPointerSegment(segment: string): string {
+    return segment.replace(/~/g, "~0").replace(/\//g, "~1");
+}
+
+/**
+ * The server-side JsonPatchCommand.Parse rejects whitespace-only path segments.
+ * Keys that would produce such segments must stay on the JavaScript path.
+ */
+export function isValidJsonPointerSegment(segment: string | null | undefined): boolean {
+    return segment != null && segment.trim().length > 0;
+}
+
+export function tryBuildJsonPointer(path: string): JsonPointerInfo | null {
+    if (!path) {
+        return null;
+    }
+
+    const segments: string[] = [];
+    let rest = path;
+    let endsWithIndex = false;
+    let expectIdentifier = true; // a path must start with an identifier, and one must follow every "."
+
+    while (rest.length > 0) {
+        if (expectIdentifier) {
+            const identifier = IDENTIFIER.exec(rest);
+            if (!identifier) {
+                return null;
+            }
+
+            // identifiers cannot contain "~" or "/" (see IDENTIFIER), escaping only keeps segments uniform with dictionary keys
+            segments.push(escapeJsonPointerSegment(identifier[0]));
+            rest = rest.substring(identifier[0].length);
+            endsWithIndex = false;
+            expectIdentifier = false;
+            continue;
+        }
+
+        if (rest.startsWith(".")) {
+            rest = rest.substring(1);
+            expectIdentifier = true;
+            continue;
+        }
+
+        const index = INDEX.exec(rest);
+        if (!index) {
+            return null;
+        }
+
+        segments.push(index[1]);
+        rest = rest.substring(index[0].length);
+        endsWithIndex = true;
+    }
+
+    if (expectIdentifier) {
+        // trailing "." (or nothing consumed)
+        return null;
+    }
+
+    return { pointer: "/" + segments.join("/"), endsWithIndex };
+}
+
+/**
+ * Mirrors the C# client: only null and JSON primitives travel as JsonPatch values.
+ * Objects, arrays and Dates keep using JavaScript patches, whose arguments go through
+ * the store's serialization conventions (PatchRequest.serialize()).
+ */
+export function canUseJsonPatchValue(value: unknown): boolean {
+    if (value === null) {
+        return true;
+    }
+
+    switch (typeof value) {
+        case "string":
+        case "boolean":
+            return true;
+        case "number":
+            return Number.isFinite(value);
+        default:
+            return false;
+    }
+}

--- a/src/Documents/Session/Operations/BatchOperation.ts
+++ b/src/Documents/Session/Operations/BatchOperation.ts
@@ -136,7 +136,9 @@ export class BatchOperation {
                     this._handleDelete(batchResult);
                     break;
                 }
-                case "PATCH": {
+                case "PATCH":
+                case "JsonPatch": {
+                    // JsonPatch replies carry the same PatchStatus / ModifiedDocument / ChangeVector / LastModified fields
                     this._handlePatch(batchResult);
                     break;
                 }

--- a/src/Documents/Session/Tokens/MoreLikeThisToken.ts
+++ b/src/Documents/Session/Tokens/MoreLikeThisToken.ts
@@ -13,6 +13,13 @@ export class MoreLikeThisToken extends WhereToken {
         super();
     }
 
+    /**
+     * moreLikeThis() has no field of its own, so aliasing the query does not change it.
+     */
+    public addAlias(alias: string): WhereToken {
+        return this;
+    }
+
     public writeTo(writer: StringBuilder): void {
         writer.append("moreLikeThis(");
 

--- a/src/Documents/Session/Tokens/WhereToken.ts
+++ b/src/Documents/Session/Tokens/WhereToken.ts
@@ -123,20 +123,18 @@ export class WhereToken extends QueryToken {
         return token;
     }
 
+    /**
+     * Prefixes the field name with the query alias (e.g. `from Orders as o` turns `Field` into `o.Field`).
+     * The token is updated in place and returned, so subclasses (vector search, moreLikeThis) keep their
+     * own state and can override this to customize aliasing. Tokens targeting `id()` are left untouched.
+     */
     public addAlias(alias: string): WhereToken {
         if (CONSTANTS.Documents.Indexing.Fields.DOCUMENT_ID_FIELD_NAME === this.fieldName) {
             return this;
         }
 
         this.fieldName = alias + "." + this.fieldName;
-
-        const whereToken = new WhereToken();
-        whereToken.fieldName = alias + "." + this.fieldName;
-        whereToken.parameterName = this.parameterName;
-        whereToken.whereOperator = this.whereOperator;
-        whereToken.options = this.options;
-
-        return whereToken;
+        return this;
     }
 
     private _writeMethod(writer): boolean {

--- a/src/Exceptions/index.ts
+++ b/src/Exceptions/index.ts
@@ -172,7 +172,16 @@ export type RavenErrorType = "RavenException"
     | "NotImplementedInCoraxException"
     | "CompareExchangeInvalidKeyException"
     | "BulkInsertInvalidOperationException"
-    | "BulkInsertClientException";
+    | "BulkInsertClientException"
+    | "AiException"
+    | "RefusedToAnswerException"
+    | "UnsuccessfulAiRequestException"
+    | "TooManyRequestsException"
+    | "RateLimitException"
+    | "InsufficientQuotaException"
+    | "TooManyTokensException"
+    | "MissingAiAgentParameterException"
+    | "QueryToolFailedException";
 
 export interface ExceptionSchema {
     url: string;

--- a/src/Http/RequestExecutor.ts
+++ b/src/Http/RequestExecutor.ts
@@ -167,7 +167,7 @@ export class RequestExecutor implements IDisposable {
 
     private _log: ILogger;
 
-    public static readonly CLIENT_VERSION = "7.2.5";
+    public static readonly CLIENT_VERSION = "7.2.6";
 
     private _updateDatabaseTopologySemaphore = new Semaphore();
     private _updateClientConfigurationSemaphore = new Semaphore();

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export { DocumentConventions } from "./Documents/Conventions/DocumentConventions.js";
 export { BulkInsertConventions } from "./Documents/Conventions/BulkInsertConventions.js";
+export * from "./Documents/Conventions/SessionPatchBehavior.js";
 export type { RavenErrorType } from "./Exceptions/index.js";
 export * from "./Types/index.js";
 
@@ -244,6 +245,8 @@ export * from "./Documents/Operations/GetDetailedStatisticsOperation.js";
 export * from "./Documents/Commands/Batches/BatchOptions.js";
 export * from "./Documents/Commands/Batches/DeleteAttachmentCommandData.js";
 export * from "./Documents/Commands/Batches/PatchCommandData.js";
+export * from "./Documents/Commands/Batches/JsonPatchCommandData.js";
+export * from "./Documents/Operations/JsonPatchDocument.js";
 export * from "./Documents/Commands/Batches/PutAttachmentCommandData.js";
 export * from "./Documents/Commands/Batches/PutAttachmentCommandHelper.js";
 export * from "./Documents/Commands/CommandData.js";
@@ -534,6 +537,7 @@ export * from "./Documents/Session/ISessionDocumentRollupTypedTimeSeries.js";
 export * from "./Documents/Session/ISessionDocumentTimeSeries.js";
 export * from "./Documents/Session/ISessionDocumentTypedAppendTimeSeriesBase.js";
 export * from "./Documents/Session/ISessionDocumentTypedTimeSeries.js";
+export * from "./Documents/Session/JavaScriptArray.js";
 export * from "./Documents/Session/JavaScriptMap.js";
 export * from "./Documents/Session/IMetadataDictionary.js";
 export type { MetadataAsDictionary } from "./Mapping/MetadataAsDictionary.js";

--- a/test/Documents/Commands/JsonPatchCommandDataTest.ts
+++ b/test/Documents/Commands/JsonPatchCommandDataTest.ts
@@ -1,0 +1,71 @@
+import assert from "node:assert";
+import { DocumentConventions, JsonPatchCommandData, JsonPatchDocument } from "../../../src/index.js";
+
+describe("JsonPatchCommandData", function () {
+
+    it("serializes to the batch wire format", () => {
+        const patch = new JsonPatchDocument()
+            .add("/name", "Updated")
+            .replace("/tags/1", "B")
+            .remove("/settings/lang")
+            .add("/tags/-", null)
+            .move("/a", "/b")
+            .copy("/c", "/d")
+            .test("/age", 25);
+
+        const command = new JsonPatchCommandData("users/1", patch);
+
+        assert.deepStrictEqual(command.serialize(new DocumentConventions()), {
+            Id: "users/1",
+            ChangeVector: null,
+            JsonPatch: {
+                Operations: [
+                    { op: "add", path: "/name", value: "Updated" },
+                    { op: "replace", path: "/tags/1", value: "B" },
+                    { op: "remove", path: "/settings/lang" },
+                    { op: "add", path: "/tags/-", value: null },
+                    { op: "move", from: "/a", path: "/b" },
+                    { op: "copy", from: "/c", path: "/d" },
+                    { op: "test", path: "/age", value: 25 }
+                ]
+            },
+            ReturnDocument: false,
+            Type: "JsonPatch"
+        });
+    });
+
+    it("serializes object values as plain object literals", () => {
+        class Address {
+            public city: string;
+            public country: string;
+        }
+
+        const command = new JsonPatchCommandData("users/1",
+            new JsonPatchDocument().add("/address", Object.assign(new Address(), { city: "Hadera", country: "IL" })));
+
+        const serialized = command.serialize(new DocumentConventions()) as any;
+        assert.deepStrictEqual(serialized.JsonPatch.Operations[0].value, { city: "Hadera", country: "IL" });
+    });
+
+    it("sends null for an undefined add/replace value", () => {
+        const command = new JsonPatchCommandData("users/1", new JsonPatchDocument().add("/name", undefined));
+
+        const serialized = command.serialize(new DocumentConventions()) as any;
+        assert.strictEqual(serialized.JsonPatch.Operations[0].value, null);
+    });
+
+    it("validates its arguments", () => {
+        assert.throws(() => new JsonPatchCommandData(null, new JsonPatchDocument()), /Id cannot be null/);
+        assert.throws(() => new JsonPatchCommandData("users/1", null), /JsonPatch cannot be null/);
+    });
+
+    it("returns the document only when the session tracks it", () => {
+        const command = new JsonPatchCommandData("users/1", new JsonPatchDocument().add("/name", "x"));
+
+        command.onBeforeSaveChanges({ isLoaded: (id: string) => id === "users/1" } as any);
+        assert.strictEqual(command.returnDocument, true);
+
+        command.onBeforeSaveChanges({ isLoaded: () => false } as any);
+        assert.strictEqual(command.returnDocument, false);
+    });
+});

--- a/test/Documents/Conventions/SessionPatchBehaviorTest.ts
+++ b/test/Documents/Conventions/SessionPatchBehaviorTest.ts
@@ -1,0 +1,23 @@
+import assert from "node:assert";
+import { DocumentConventions } from "../../../src/index.js";
+
+describe("DocumentConventions.sessionPatchBehavior", function () {
+
+    it("defaults to JsonPatch", () => {
+        assert.strictEqual(new DocumentConventions().sessionPatchBehavior, "JsonPatch");
+    });
+
+    it("can be switched to JavaScript before the conventions are frozen", () => {
+        const conventions = new DocumentConventions();
+        conventions.sessionPatchBehavior = "JavaScript";
+        assert.strictEqual(conventions.sessionPatchBehavior, "JavaScript");
+    });
+
+    it("cannot be changed after the conventions are frozen", () => {
+        const conventions = new DocumentConventions();
+        conventions.freeze();
+        assert.throws(() => {
+            conventions.sessionPatchBehavior = "JavaScript";
+        });
+    });
+});

--- a/test/Documents/Operations/AI/EmbeddingsGenerationConfigurationTest.ts
+++ b/test/Documents/Operations/AI/EmbeddingsGenerationConfigurationTest.ts
@@ -548,5 +548,60 @@ describe("EmbeddingsGenerationConfiguration", () => {
                 `Expected ContextPrefix to be undefined when not set, got: ${chunkingOpts.ContextPrefix}`);
         });
     });
+
+    describe("storeChunkText", () => {
+        function createConfig(): EmbeddingsGenerationConfiguration {
+            const config = new EmbeddingsGenerationConfiguration();
+            config.name = "Products Embeddings";
+            config.collection = "Products";
+            config.identifier = "products-embeddings";
+            config.embeddingsPathConfigurations = [
+                {
+                    path: "Description",
+                    chunkingOptions: {
+                        chunkingMethod: "PlainTextSplitParagraphs",
+                        maxTokensPerChunk: 256,
+                        overlapTokens: 32
+                    }
+                }
+            ];
+            config.chunkingOptionsForQuerying = {
+                chunkingMethod: "PlainTextSplit",
+                maxTokensPerChunk: 256,
+                overlapTokens: 0
+            };
+            return config;
+        }
+
+        it("defaults to false and is always serialized", () => {
+            const config = createConfig();
+
+            assert.strictEqual(config.storeChunkText, false);
+
+            const serialized = config.serialize(new DocumentConventions()) as any;
+            assert.strictEqual(serialized.StoreChunkText, false);
+        });
+
+        it("is serialized as StoreChunkText when enabled", () => {
+            const config = createConfig();
+            config.storeChunkText = true;
+
+            const serialized = config.serialize(new DocumentConventions()) as any;
+            assert.strictEqual(serialized.StoreChunkText, true);
+        });
+
+        it("is part of the equality comparison", () => {
+            const left = createConfig();
+            const right = createConfig();
+
+            assert.strictEqual(left.isEqual(right), true);
+
+            right.storeChunkText = true;
+            assert.strictEqual(left.isEqual(right), false);
+
+            left.storeChunkText = true;
+            assert.strictEqual(left.isEqual(right), true);
+        });
+    });
 });
 

--- a/test/Documents/Queries/VectorSearchTokenAliasTest.ts
+++ b/test/Documents/Queries/VectorSearchTokenAliasTest.ts
@@ -1,0 +1,107 @@
+import assert from "node:assert";
+import { IDocumentStore, IndexDefinition, PutIndexesOperation, QueryData } from "../../../src/index.js";
+import { disposeTestDocumentStore, RavenTestContext, testContext } from "../../Utils/TestUtil.js";
+import { INDEXES } from "../../../src/Constants.js";
+import { DocumentQuery } from "../../../src/Documents/Session/DocumentQuery.js";
+
+class VecDoc {
+    public id: string;
+    public vector: number[];
+    public name: string;
+}
+
+class VecResult {
+    public id: string;
+    public name: string;
+    public score: number;
+}
+
+(RavenTestContext.isRavenDbServerVersion("7.0") ? describe : describe.skip)("VectorSearchTokenAliasTest", function () {
+
+    let store: IDocumentStore;
+
+    beforeEach(async () => {
+        store = await testContext.getDocumentStore("VectorSearchTokenAlias", false, null, record => {
+            record.settings[INDEXES.INDEXING_AUTO_SEARCH_ENGINE_TYPE] = "Corax";
+            record.settings[INDEXES.INDEXING_STATIC_SEARCH_ENGINE_TYPE] = "Corax";
+            // vector search scores are only reported when explicitly enabled
+            record.settings["Indexing.Corax.IncludeDocumentScore"] = "true";
+        });
+    });
+
+    afterEach(async () => await disposeTestDocumentStore(store));
+
+    async function seedDocs(): Promise<void> {
+        {
+            const session = store.openSession();
+            await session.store(Object.assign(new VecDoc(), { vector: [0.1, 0.2], name: "match" }));
+            await session.store(Object.assign(new VecDoc(), { vector: [-0.9, -0.9], name: "nomatch" }));
+            await session.saveChanges();
+        }
+
+        const indexDefinition = new IndexDefinition();
+        indexDefinition.name = "VecIndex";
+        indexDefinition.maps = new Set([`
+            from doc in docs.VecDocs
+            select new
+            {
+                Vector = CreateVector(doc.vector),
+                name = doc.name
+            }`]);
+        indexDefinition.fields = {
+            Vector: {
+                vector: {
+                    sourceEmbeddingType: "Single",
+                    destinationEmbeddingType: "Single"
+                }
+            }
+        };
+        await store.maintenance.send(new PutIndexesOperation(indexDefinition));
+        await testContext.waitForIndexing(store);
+    }
+
+    function aliasedQuery(session: ReturnType<IDocumentStore["openSession"]>, isExact: boolean) {
+        const query = session.query<VecDoc>({ indexName: "VecIndex" })
+            .vectorSearch(f => f.withField("Vector"), v => v.byEmbedding([0.1, 0.2]), { similarity: 0.5, isExact })
+            .orderByScore()
+            .selectFields(QueryData.customFunction("d", "{ id: id(d), name: d.name, score: getMetadata(d)['@index-score'] }"), VecResult);
+
+        // the projection alias is applied to the where tokens; vector.search keeps its shape
+        (query as unknown as DocumentQuery<VecResult>).addFromAliasToWhereTokens("d");
+        return query;
+    }
+
+    it("vector search token survives the from-alias when the projection is a JS object", async () => {
+        await seedDocs();
+
+        const session = store.openSession();
+        const query = aliasedQuery(session, false);
+
+        const rql = query.toString();
+        assert.ok(rql.includes("vector.search(d.Vector,"), rql);
+        assert.ok(!rql.includes("d.Vector = "), rql);
+
+        const results = await query.all();
+
+        assert.strictEqual(results.length, 1);
+        assert.strictEqual(results[0].name, "match");
+        assert.ok(results[0].score > 0, `expected a positive score, got ${results[0].score}`);
+    });
+
+    it("exact vector search token survives the from-alias when the projection is a JS object", async () => {
+        await seedDocs();
+
+        const session = store.openSession();
+        const query = aliasedQuery(session, true);
+
+        const rql = query.toString();
+        assert.ok(rql.includes("exact(vector.search(d.Vector,"), rql);
+        assert.ok(!rql.includes("d.Vector = "), rql);
+
+        const results = await query.all();
+
+        assert.strictEqual(results.length, 1);
+        assert.strictEqual(results[0].name, "match");
+        assert.ok(results[0].score > 0, `expected a positive score, got ${results[0].score}`);
+    });
+});

--- a/test/Documents/Session/JavaScriptPatchBuildersTest.ts
+++ b/test/Documents/Session/JavaScriptPatchBuildersTest.ts
@@ -1,0 +1,58 @@
+import assert from "node:assert";
+import { JavaScriptArray } from "../../../src/Documents/Session/JavaScriptArray.js";
+import { JavaScriptMap } from "../../../src/Documents/Session/JavaScriptMap.js";
+
+describe("JavaScriptArray / JavaScriptMap operation recording", function () {
+
+    it("JavaScriptArray records push and removeAt in call order and keeps the script", () => {
+        const array = new JavaScriptArray<string>(3, "tags");
+
+        array.push("b", "c").removeAt(0).push("d");
+
+        assert.deepStrictEqual(array.operations, [
+            { type: "push", values: ["b", "c"] },
+            { type: "removeAt", index: 0 },
+            { type: "push", values: ["d"] }
+        ]);
+        assert.strictEqual(array.script,
+            "this.tags.push(args.val_0_3,args.val_1_3);\n" +
+            "this.tags.splice(args.val_2_3, 1);\n" +
+            "this.tags.push(args.val_3_3);");
+        assert.deepStrictEqual(array.parameters, { val_0_3: "b", val_1_3: "c", val_2_3: 0, val_3_3: "d" });
+    });
+
+    it("JavaScriptArray ignores an empty push and stays chainable", () => {
+        const array = new JavaScriptArray<string>(0, "tags");
+
+        assert.strictEqual(array.push(), array);
+        assert.deepStrictEqual(array.operations, []);
+        assert.strictEqual(array.script, "");
+    });
+
+    it("JavaScriptMap records set and remove in call order and keeps the script", () => {
+        const map = new JavaScriptMap<string, string>(2, "settings");
+
+        map.set("lang", "en").remove("theme");
+
+        assert.deepStrictEqual(map.operations, [
+            { type: "set", key: "lang", value: "en" },
+            { type: "remove", key: "theme" }
+        ]);
+        assert.ok(map.getScript().startsWith(`this.settings["lang"] = args.val_0_2;`));
+        assert.ok(map.getScript().endsWith(`delete this.settings["theme"];`));
+        assert.deepStrictEqual(map.parameters, { val_0_2: "en" });
+    });
+
+    it("JavaScriptMap quotes keys so whitespace, dots and quotes are valid JavaScript", () => {
+        const map = new JavaScriptMap<string, string>(0, "settings");
+
+        map.set("a b", "x").set("with.dot", "y").remove(`quo"te`);
+
+        const lines = map.getScript().split(/\r?\n/);
+        assert.deepStrictEqual(lines, [
+            `this.settings["a b"] = args.val_0_0;`,
+            `this.settings["with.dot"] = args.val_1_0;`,
+            `delete this.settings["quo\\"te"];`
+        ]);
+    });
+});

--- a/test/Documents/Session/JsonPatchPathTest.ts
+++ b/test/Documents/Session/JsonPatchPathTest.ts
@@ -1,0 +1,71 @@
+import assert from "node:assert";
+import {
+    canUseJsonPatchValue,
+    escapeJsonPointerSegment,
+    isValidJsonPointerSegment,
+    tryBuildJsonPointer
+} from "../../../src/Documents/Session/JsonPatchPath.js";
+
+describe("JsonPatchPath", function () {
+
+    describe("tryBuildJsonPointer", () => {
+        const valid: Array<[string, string, boolean]> = [
+            ["name", "/name", false],
+            ["address.city", "/address/city", false],
+            ["tags[1]", "/tags/1", true],
+            ["tags[0]", "/tags/0", true],
+            ["stuff[0].key", "/stuff/0/key", false],
+            ["matrix[1][2]", "/matrix/1/2", true],
+            ["$weird_Name1.__x", "/$weird_Name1/__x", false]
+        ];
+
+        for (const [path, pointer, endsWithIndex] of valid) {
+            it(`converts "${path}" to "${pointer}"`, () => {
+                assert.deepStrictEqual(tryBuildJsonPointer(path), { pointer, endsWithIndex });
+            });
+        }
+
+        const invalid = [
+            "", null, undefined, " ", "a b", "tags[i]", "tags[-1]", "tags[01]", "a['b']", "a[\"b\"]",
+            "items[items.length-1]", "a..b", ".a", "a.", "a[1", "a]", "1abc", "a-b", "a.b()"
+        ];
+
+        for (const path of invalid) {
+            it(`rejects ${JSON.stringify(path)}`, () => {
+                assert.strictEqual(tryBuildJsonPointer(path as string), null);
+            });
+        }
+    });
+
+    describe("escapeJsonPointerSegment", () => {
+        it("escapes ~ and / per RFC 6901", () => {
+            assert.strictEqual(escapeJsonPointerSegment("a/b~c"), "a~1b~0c");
+            assert.strictEqual(escapeJsonPointerSegment("plain"), "plain");
+        });
+    });
+
+    describe("isValidJsonPointerSegment", () => {
+        it("rejects empty and whitespace-only segments", () => {
+            assert.strictEqual(isValidJsonPointerSegment(""), false);
+            assert.strictEqual(isValidJsonPointerSegment("   "), false);
+            assert.strictEqual(isValidJsonPointerSegment(null), false);
+            assert.strictEqual(isValidJsonPointerSegment(undefined), false);
+            assert.strictEqual(isValidJsonPointerSegment("lang"), true);
+            assert.strictEqual(isValidJsonPointerSegment("a b"), true);
+        });
+    });
+
+    describe("canUseJsonPatchValue", () => {
+        it("accepts null and JSON primitives", () => {
+            for (const value of [null, "x", "", 0, 1.5, -3, true, false]) {
+                assert.strictEqual(canUseJsonPatchValue(value), true, `expected ${String(value)} to be eligible`);
+            }
+        });
+
+        it("rejects everything that needs the store's serialization conventions", () => {
+            for (const value of [undefined, {}, { a: 1 }, [], [1], new Date(), Number.NaN, Number.POSITIVE_INFINITY, () => 1, Symbol("s"), 10n]) {
+                assert.strictEqual(canUseJsonPatchValue(value), false, `expected ${String(value)} to be rejected`);
+            }
+        });
+    });
+});

--- a/test/Documents/Session/Tokens/WhereTokenAliasTest.ts
+++ b/test/Documents/Session/Tokens/WhereTokenAliasTest.ts
@@ -1,0 +1,71 @@
+import assert from "node:assert";
+import { WhereToken } from "../../../../src/Documents/Session/Tokens/WhereToken.js";
+import { VectorSearchToken } from "../../../../src/Documents/Session/Tokens/VectorSearchToken.js";
+import { MoreLikeThisToken } from "../../../../src/Documents/Session/Tokens/MoreLikeThisToken.js";
+import { StringBuilder } from "../../../../src/Utility/StringBuilder.js";
+import { CONSTANTS } from "../../../../src/Constants.js";
+import { vectorSearchConfigurationToMethodName } from "../../../../src/Utility/VectorSearchUtil.js";
+
+describe("WhereToken.addAlias", function () {
+
+    function write(token: WhereToken): string {
+        const writer = new StringBuilder();
+        token.writeTo(writer);
+        return writer.toString();
+    }
+
+    it("prefixes the field name once and returns the same token", () => {
+        const token = WhereToken.create("Equals", "Name", "p0");
+
+        const aliased = token.addAlias("u");
+
+        assert.strictEqual(aliased, token);
+        assert.strictEqual(token.fieldName, "u.Name");
+        assert.strictEqual(write(token), "u.Name = $p0");
+    });
+
+    it("leaves id() untouched", () => {
+        const token = WhereToken.create("Equals", CONSTANTS.Documents.Indexing.Fields.DOCUMENT_ID_FIELD_NAME, "p0");
+
+        const aliased = token.addAlias("u");
+
+        assert.strictEqual(aliased, token);
+        assert.strictEqual(token.fieldName, CONSTANTS.Documents.Indexing.Fields.DOCUMENT_ID_FIELD_NAME);
+    });
+
+    it("vector search token keeps vector.search() shape after aliasing", () => {
+        const token = new VectorSearchToken("Embedding", "p0", "Single", "Single", null, null, false, false, null, null);
+
+        const aliased = token.addAlias("o");
+
+        assert.ok(aliased instanceof VectorSearchToken);
+        assert.strictEqual(write(aliased), "vector.search(o.Embedding, $p0)");
+    });
+
+    it("vector search token keeps quantization, exact and similarity after aliasing", () => {
+        const token = new VectorSearchToken("Description", "p1", "Text", "Int8", 0.75, 20, true, false, null, null);
+
+        const aliased = token.addAlias("o");
+
+        const methodName = vectorSearchConfigurationToMethodName("Text", "Int8");
+        assert.strictEqual(write(aliased), `exact(vector.search(${methodName}(o.Description), $p1, 0.75, 20))`);
+    });
+
+    it("vector search on id() is not aliased", () => {
+        const token = new VectorSearchToken(CONSTANTS.Documents.Indexing.Fields.DOCUMENT_ID_FIELD_NAME, "p0", "Single", "Single", null, null, false, true, null, null);
+
+        token.addAlias("o");
+
+        assert.strictEqual(write(token), `vector.search(${CONSTANTS.Documents.Indexing.Fields.DOCUMENT_ID_FIELD_NAME}, ${VectorSearchToken.EMBEDDING_FOR_DOCUMENT}($p0))`);
+    });
+
+    it("moreLikeThis token is not aliased", () => {
+        const token = new MoreLikeThisToken();
+        token.documentParameterName = "p0";
+
+        const aliased = token.addAlias("o");
+
+        assert.strictEqual(aliased, token);
+        assert.strictEqual(write(token), "moreLikeThis($p0)");
+    });
+});

--- a/test/Ported/Documents/Operations/AiConversationTest.ts
+++ b/test/Ported/Documents/Operations/AiConversationTest.ts
@@ -1,9 +1,13 @@
+import assert from "node:assert";
 import {IDocumentStore} from "../../../../src/index.js";
 import {disposeTestDocumentStore, RavenTestContext, testContext} from "../../../Utils/TestUtil.js";
 import {assertThat, assertThrows} from "../../../Utils/AssertExtensions.js";
 
-import {AiHandleErrorStrategy} from "../../../../src/Documents/Operations/AI/AiConversation.js";
+import {AiConversation, AiHandleErrorStrategy} from "../../../../src/Documents/Operations/AI/AiConversation.js";
 import {AiUsage} from "../../../../src/Documents/Operations/AI/Agents/AiUsage.js";
+import type {AiAnswer} from "../../../../src/Documents/Operations/AI/AiAnswer.js";
+import type {AiOutputOptions} from "../../../../src/Documents/Operations/AI/AiOutputOptions.js";
+import type {AiStreamCallback} from "../../../../src/Documents/Operations/AI/AiStreamCallback.js";
 import {
     AiConversationCreationOptions
 } from "../../../../src/Documents/Operations/AI/Agents/AiConversationCreationOptions.js";
@@ -551,6 +555,180 @@ import {
                 assertThat(err.message).contains("previous usage cannot be null");
             }
         );
+    });
+
+    interface RunInternalCall {
+        streamPropertyPath?: string;
+        streamCallback?: AiStreamCallback;
+        outputOptions?: AiOutputOptions;
+    }
+
+    // Replaces the server round-trip with a recorder so the output options plumbing can be asserted offline
+    function stubRunInternal(conv: any, answer: unknown = { result: "ok" }): RunInternalCall[] {
+        const calls: RunInternalCall[] = [];
+        conv._runInternal = async (streamPropertyPath?: string, streamCallback?: AiStreamCallback, outputOptions?: AiOutputOptions) => {
+            calls.push({ streamPropertyPath, streamCallback, outputOptions });
+            return { answer, status: "Done" };
+        };
+        return calls;
+    }
+
+    it("run() passes output options through to the conversation turn", async () => {
+        const conv = store.ai.conversation("agents/1-A", "conversations/30|") as any;
+        const calls = stubRunInternal(conv, "free text");
+
+        const plain = await conv.run();
+        const noSchema = await conv.run({ noSchema: true });
+        const sample = await conv.run({ sampleObject: { summary: "x" } });
+
+        assertThat(plain.answer).isEqualTo("free text");
+        assertThat(noSchema.answer).isEqualTo("free text");
+        assertThat(sample.status).isEqualTo("Done");
+
+        assertThat(calls).hasSize(3);
+        assertThat(calls[0].outputOptions).isUndefined();
+        assertThat(calls[0].streamPropertyPath).isUndefined();
+        assertThat(calls[1].outputOptions.noSchema).isTrue();
+        assertThat((calls[2].outputOptions.sampleObject as any).summary).isEqualTo("x");
+    });
+
+    it("run() rejects noSchema combined with a schema or sample object", async () => {
+        const conv = store.ai.conversation("agents/1-A", "conversations/31|") as any;
+        stubRunInternal(conv);
+
+        await assertThrows(() => conv.run({ noSchema: true, outputSchema: "{}" }), err => {
+            assertThat(err.name).isEqualTo("InvalidOperationException");
+            assertThat(err.message).contains("noSchema");
+        });
+
+        await assertThrows(() => conv.run({ noSchema: true, sampleObject: { a: 1 } }), err => {
+            assertThat(err.name).isEqualTo("InvalidOperationException");
+            assertThat(err.message).contains("noSchema");
+        });
+
+        await assertThrows(() => conv.run({ outputSchema: "   " }), err => {
+            assertThat(err.name).isEqualTo("InvalidArgumentException");
+            assertThat(err.message).contains("outputSchema");
+        });
+
+        await assertThrows(() => conv.run({ sampleObject: "not an object" }), err => {
+            assertThat(err.name).isEqualTo("InvalidArgumentException");
+            assertThat(err.message).contains("sampleObject");
+        });
+
+        await assertThrows(() => conv.runWithSchema(null), err => {
+            assertThat(err.name).isEqualTo("InvalidArgumentException");
+        });
+    });
+
+    it("runWithSchema() accepts a schema string, a sample object or output options", async () => {
+        const conv = store.ai.conversation("agents/1-A", "conversations/32|") as any;
+        const calls = stubRunInternal(conv);
+
+        await conv.runWithSchema(`{"type":"object"}`);
+        await conv.runWithSchema({ summary: "a short summary", score: 5 });
+        await conv.runWithSchema({ sampleObject: { summary: "wrapped" } });
+        await conv.runWithSchema({ noSchema: true });
+        await conv.runWithSchema({});
+
+        assertThat(calls).hasSize(5);
+        assert.deepStrictEqual(calls[0].outputOptions, { outputSchema: `{"type":"object"}` });
+        assert.deepStrictEqual(calls[1].outputOptions, { sampleObject: { summary: "a short summary", score: 5 } });
+        assert.deepStrictEqual(calls[2].outputOptions, { sampleObject: { summary: "wrapped" } });
+        assert.deepStrictEqual(calls[3].outputOptions, { noSchema: true });
+        // an empty object carries no schema information, so it is passed through as (empty) options
+        assert.deepStrictEqual(calls[4].outputOptions, {});
+    });
+
+    it("stream(callback) streams raw text with an empty property path and noSchema", async () => {
+        const conv = store.ai.conversation("agents/1-A", "conversations/33|") as any;
+        const calls = stubRunInternal(conv, "the whole answer");
+        const callback: AiStreamCallback = async () => { /* no-op */ };
+
+        const answer = await conv.stream(callback);
+
+        assertThat(answer.answer).isEqualTo("the whole answer");
+        assertThat(calls).hasSize(1);
+        assertThat(calls[0].streamPropertyPath).isEqualTo("");
+        assertThat(calls[0].streamCallback).isSameAs(callback);
+        assert.deepStrictEqual(calls[0].outputOptions, { noSchema: true });
+    });
+
+    it("stream() requires a property path unless noSchema is set", async () => {
+        const conv = store.ai.conversation("agents/1-A", "conversations/34|") as any;
+        const calls = stubRunInternal(conv);
+        const callback: AiStreamCallback = async () => { /* no-op */ };
+
+        await assertThrows(() => conv.stream("", callback), err => {
+            assertThat(err.message).contains("streamPropertyPath cannot be empty");
+        });
+
+        await assertThrows(() => conv.stream("summary", null), err => {
+            assertThat(err.message).contains("streamCallback cannot be null");
+        });
+
+        await conv.stream("", callback, { noSchema: true });
+        await conv.stream("summary", callback, { outputSchema: `{"type":"object"}` });
+
+        assertThat(calls).hasSize(2);
+        assertThat(calls[0].streamPropertyPath).isEqualTo("");
+        assert.deepStrictEqual(calls[0].outputOptions, { noSchema: true });
+        assertThat(calls[1].streamPropertyPath).isEqualTo("summary");
+        assert.deepStrictEqual(calls[1].outputOptions, { outputSchema: `{"type":"object"}` });
+    });
+
+    it("streamWithSchema() accepts a schema string, a sample object or output options", async () => {
+        const conv = store.ai.conversation("agents/1-A", "conversations/35|") as any;
+        const calls = stubRunInternal(conv);
+        const callback: AiStreamCallback = async () => { /* no-op */ };
+
+        await conv.streamWithSchema("summary", callback, `{"type":"object"}`);
+        await conv.streamWithSchema("summary", callback, { summary: "a short summary", score: 5 });
+        await conv.streamWithSchema("summary", callback, { sampleObject: { summary: "wrapped" } });
+
+        assertThat(calls).hasSize(3);
+        assertThat(calls.every(c => c.streamPropertyPath === "summary" && c.streamCallback === callback)).isTrue();
+        assert.deepStrictEqual(calls[0].outputOptions, { outputSchema: `{"type":"object"}` });
+        assert.deepStrictEqual(calls[1].outputOptions, { sampleObject: { summary: "a short summary", score: 5 } });
+        assert.deepStrictEqual(calls[2].outputOptions, { sampleObject: { summary: "wrapped" } });
+    });
+
+    it("run/stream output options overloads are typed", async () => {
+        const conv = store.ai.conversation("agents/1-A", "conversations/36|");
+        stubRunInternal(conv, "text");
+
+        // compile-time check: noSchema turns the answer into a string, other options keep TAnswer
+        const text: AiAnswer<string> = await conv.run({ noSchema: true });
+        const streamed: AiAnswer<string> = await conv.stream(async () => { /* no-op */ });
+        const typed: AiAnswer<{ summary: string }> = await conv.run<{ summary: string }>({ sampleObject: { summary: "x" } });
+        const sample: AiAnswer<{ summary: string }> = await conv.runWithSchema({ summary: "x" });
+
+        assertThat(text.answer).isEqualTo("text");
+        assertThat(streamed.answer).isEqualTo("text");
+        assertThat(typed.status).isEqualTo("Done");
+        assertThat(sample.status).isEqualTo("Done");
+        assertThat(conv).isNotNull();
+    });
+
+    it("handle() and receive() accept handlers for no-args action tools", async () => {
+        const conv = store.ai.conversation("agents/1-A", "conversations/37|") as AiConversation;
+        const internals = conv as any;
+
+        let handled = false;
+        conv.handle("get-current-time", async () => {
+            handled = true;
+            return { now: "12:00" };
+        });
+        conv.receive("ping", request => {
+            conv.addActionResponse(request.toolId, "pong");
+        });
+
+        await internals._invocations.get("get-current-time")({ name: "get-current-time", toolId: "tool-1", arguments: "{}" });
+        await internals._invocations.get("ping")({ name: "ping", toolId: "tool-2", arguments: "" });
+
+        assertThat(handled).isTrue();
+        assertThat(internals._actionResponses.get("tool-1").content).isEqualTo(JSON.stringify({ now: "12:00" }));
+        assertThat(internals._actionResponses.get("tool-2").content).isEqualTo("pong");
     });
 
     it("AiUsage reasoning tokens calculation in getUsageDifference", async () => {

--- a/test/Ported/Documents/Operations/AiStreamingTest.ts
+++ b/test/Ported/Documents/Operations/AiStreamingTest.ts
@@ -1,8 +1,12 @@
+import assert from "node:assert";
 import {Readable} from "node:stream";
 import {assertThat} from "../../../Utils/AssertExtensions.js";
 import {DocumentConventions} from "../../../../src/Documents/Conventions/DocumentConventions.js";
 import {RunConversationOperation} from "../../../../src/Documents/Operations/AI/Agents/RunConversationOperation.js";
 import {RavenTestContext} from "../../../Utils/TestUtil.js";
+import {ServerNode} from "../../../../src/Http/ServerNode.js";
+import type {AiOutputOptions} from "../../../../src/Documents/Operations/AI/AiOutputOptions.js";
+import type {AiStreamCallback} from "../../../../src/Documents/Operations/AI/AiStreamCallback.js";
 
 (RavenTestContext.isRavenDbServerVersion("7.1") ? describe : describe.skip)("AiConversationTest", () => {
     it("should parse streaming response correctly", async () => {
@@ -104,5 +108,119 @@ import {RavenTestContext} from "../../../Utils/TestUtil.js";
         assertThat(receivedChunks).hasSize(2);
         assertThat(receivedChunks[0]).isEqualTo("Chunk1");
         assertThat(receivedChunks[1]).isEqualTo("Chunk2");
+    });
+
+    function requestFor(outputOptions?: AiOutputOptions, streamPropertyPath?: string, streamCallback?: AiStreamCallback) {
+        const operation = new RunConversationOperation<unknown>(
+            "agents/1-A",
+            "conv/4|",
+            "Test prompt",
+            [],
+            [],
+            undefined,
+            undefined,
+            undefined,
+            streamPropertyPath,
+            streamCallback,
+            outputOptions
+        );
+
+        const command = operation.getCommand(new DocumentConventions());
+        const request = command.createRequest(new ServerNode({ url: "http://localhost:8080", database: "db" }));
+        const body = JSON.parse(request.body as string);
+        return { command, request, body };
+    }
+
+    it("should not send OutputOptions when none are given", () => {
+        const { body } = requestFor();
+
+        assertThat(body.OutputOptions).isUndefined();
+    });
+
+    it("should send the sample object as a JSON string in OutputOptions", () => {
+        const { body } = requestFor({ sampleObject: { summary: "a short summary", score: 5 } });
+
+        assertThat(body.OutputOptions).isNotNull();
+        assertThat(typeof body.OutputOptions.SampleObject).isEqualTo("string");
+        assert.deepStrictEqual(JSON.parse(body.OutputOptions.SampleObject), { summary: "a short summary", score: 5 });
+        assertThat(body.OutputOptions.OutputSchema).isUndefined();
+        assertThat(body.OutputOptions.NoSchema).isUndefined();
+    });
+
+    it("should send an explicit output schema in OutputOptions", () => {
+        const schema = `{"type":"object","properties":{"summary":{"type":"string"}}}`;
+        const { body } = requestFor({ outputSchema: schema });
+
+        assertThat(body.OutputOptions.OutputSchema).isEqualTo(schema);
+        assertThat(body.OutputOptions.SampleObject).isUndefined();
+        assertThat(body.OutputOptions.NoSchema).isUndefined();
+    });
+
+    it("should send NoSchema only when true", () => {
+        const { body } = requestFor({ noSchema: true });
+
+        assertThat(body.OutputOptions.NoSchema).isTrue();
+        assertThat(body.OutputOptions.SampleObject).isUndefined();
+        assertThat(body.OutputOptions.OutputSchema).isUndefined();
+
+        const { body: notSet } = requestFor({ noSchema: false, outputSchema: "{}" });
+        assertThat(notSet.OutputOptions.NoSchema).isUndefined();
+    });
+
+    it("should enable streaming with an empty property path for raw text answers", () => {
+        const { request } = requestFor({ noSchema: true }, "", async () => { /* no-op */ });
+
+        const uri = new URL(request.uri);
+        assertThat(uri.searchParams.get("streaming")).isEqualTo("true");
+        assertThat(uri.searchParams.get("streamPropertyPath")).isEqualTo("");
+    });
+
+    it("should not enable streaming without a property path", () => {
+        const { request } = requestFor();
+
+        const uri = new URL(request.uri);
+        assertThat(uri.searchParams.has("streaming")).isFalse();
+        assertThat(uri.searchParams.has("streamPropertyPath")).isFalse();
+    });
+
+    it("should parse a raw string response", async () => {
+        const rawResponse = `{"conversationId":"conv/5-A","response":"plain text answer","changeVector":"A:5-xyz","actionRequests":[]}`;
+
+        const operation = new RunConversationOperation<string>(
+            "agents/1-A",
+            "conv/5|",
+            "Test prompt",
+            [],
+            [],
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            { noSchema: true }
+        );
+
+        const command = operation.getCommand(new DocumentConventions());
+        await command.setResponseAsync(Readable.from([rawResponse]), false);
+
+        assertThat(command.result.conversationId).isEqualTo("conv/5-A");
+        assertThat(command.result.response).isEqualTo("plain text answer");
+    });
+
+    it("should stream raw text chunks and return the full text as the response", async () => {
+        const streamingResponse = `"Hello"
+" world"
+{"conversationId":"conv/6-A","response":"Hello world","changeVector":"A:6-xyz","actionRequests":[]}
+`;
+
+        const receivedChunks: string[] = [];
+        const { command } = requestFor({ noSchema: true }, "", async chunk => {
+            receivedChunks.push(chunk);
+        });
+
+        await command.setResponseAsync(Readable.from([streamingResponse]), false);
+
+        assert.deepStrictEqual(receivedChunks, ["Hello", " world"]);
+        assertThat(command.result.response).isEqualTo("Hello world");
     });
 });

--- a/test/Ported/FirstClassPatchTest.ts
+++ b/test/Ported/FirstClassPatchTest.ts
@@ -83,8 +83,8 @@ describe("FirstClassPatchTest", function () {
                 await session.saveChanges();
                 assert.fail("it should have thrown");
             } catch (err) {
-                assert.strictEqual(err.message, 
-                    "Cannot perform save because document users/1-A has been modified by the session and is also taking part in deferred PATCH command");
+                assert.strictEqual(err.message,
+                    "Cannot perform save because document users/1-A has been modified by the session and is also taking part in deferred JsonPatch command");
                 assert.strictEqual(err.name, "InvalidOperationException");
             }
         }
@@ -328,17 +328,18 @@ describe("FirstClassPatchTest", function () {
 
         {
             const session = store.openSession();
+            // primitives go through JsonPatch, Date values stay JavaScript: one JsonPatch + one PATCH command per document
             session.advanced.patch(_docId, "numbers[0]", 31);
             assert.strictEqual((session as any as InMemoryDocumentSessionOperations).deferredCommandsCount, 1);
 
             session.advanced.patch(_docId, "lastLogin", now);
-            assert.strictEqual((session as any as InMemoryDocumentSessionOperations).deferredCommandsCount, 1);
+            assert.strictEqual((session as any as InMemoryDocumentSessionOperations).deferredCommandsCount, 2);
 
             session.advanced.patch(docId2, "numbers[0]", 123);
-            assert.strictEqual((session as any as InMemoryDocumentSessionOperations).deferredCommandsCount, 2);
+            assert.strictEqual((session as any as InMemoryDocumentSessionOperations).deferredCommandsCount, 3);
 
             session.advanced.patch(docId2, "lastLogin", now);
-            assert.strictEqual((session as any as InMemoryDocumentSessionOperations).deferredCommandsCount, 2);
+            assert.strictEqual((session as any as InMemoryDocumentSessionOperations).deferredCommandsCount, 4);
 
             await session.saveChanges();
         }

--- a/test/Ported/Issues/RavenDB_22293.ts
+++ b/test/Ported/Issues/RavenDB_22293.ts
@@ -1,0 +1,489 @@
+import assert from "node:assert";
+import {
+    IDocumentStore,
+    InMemoryDocumentSessionOperations,
+    JsonPatchCommandData,
+    JsonPatchDocument,
+    SessionPatchBehavior
+} from "../../../src/index.js";
+import { CommandType } from "../../../src/Documents/Commands/CommandData.js";
+import { IdTypeAndName } from "../../../src/Documents/IdTypeAndName.js";
+import { disposeTestDocumentStore, testContext } from "../../Utils/TestUtil.js";
+import { assertThat, assertThrows } from "../../Utils/AssertExtensions.js";
+
+class Address {
+    public city: string;
+    public country: string;
+}
+
+class UserWithTags {
+    public id: string;
+    public name: string;
+    public age: number;
+    public tags: string[];
+    public settings: Record<string, string>;
+    public address: Address;
+}
+
+const USER_ID = "users/1";
+
+describe("RavenDB-22293 JsonPatch session patching", function () {
+
+    let store: IDocumentStore;
+
+    beforeEach(async () => store = await testContext.getDocumentStore());
+
+    afterEach(async () => {
+        testContext.customizeStore = null;
+        await disposeTestDocumentStore(store);
+    });
+
+    // A second store whose conventions were set before initialize() (conventions freeze on initialize)
+    async function storeWithBehavior(behavior: SessionPatchBehavior): Promise<IDocumentStore> {
+        testContext.customizeStore = async s => {
+            s.conventions.sessionPatchBehavior = behavior;
+        };
+        try {
+            return await testContext.getDocumentStore();
+        } finally {
+            testContext.customizeStore = null;
+        }
+    }
+
+    async function storeUser(target: IDocumentStore, overrides: Partial<UserWithTags> = {}): Promise<void> {
+        const session = target.openSession();
+        const user = Object.assign(new UserWithTags(), {
+            name: "Test",
+            age: 25,
+            tags: ["a", "b", "c"],
+            settings: { theme: "light" },
+            address: Object.assign(new Address(), { city: "OldCity", country: "US" })
+        }, overrides);
+        await session.store(user, USER_ID);
+        await session.saveChanges();
+    }
+
+    async function loadUser(target: IDocumentStore): Promise<UserWithTags> {
+        const session = target.openSession();
+        return await session.load<UserWithTags>(USER_ID, UserWithTags);
+    }
+
+    function deferred(session: unknown): InMemoryDocumentSessionOperations {
+        return session as InMemoryDocumentSessionOperations;
+    }
+
+    function hasDeferred(session: unknown, type: CommandType): boolean {
+        return deferred(session).deferredCommandsMap.has(IdTypeAndName.keyFor(USER_ID, type, null));
+    }
+
+    it("deferred JsonPatchCommandData is applied and refreshes the tracked entity", async () => {
+        await storeUser(store);
+
+        const session = store.openSession();
+        const user = await session.load<UserWithTags>(USER_ID, UserWithTags);
+        const changeVectorBefore = session.advanced.getChangeVectorFor(user);
+
+        session.advanced.defer(new JsonPatchCommandData(USER_ID, new JsonPatchDocument()
+            .add("/name", "Updated")
+            .replace("/tags/1", "B")
+            .remove("/settings/theme")));
+        await session.saveChanges();
+
+        assert.strictEqual(user.name, "Updated");
+        assert.deepStrictEqual(user.tags, ["a", "B", "c"]);
+        assert.deepStrictEqual(user.settings, {});
+        assert.notStrictEqual(session.advanced.getChangeVectorFor(user), changeVectorBefore);
+
+        const reloaded = await loadUser(store);
+        assert.strictEqual(reloaded.name, "Updated");
+        assert.deepStrictEqual(reloaded.tags, ["a", "B", "c"]);
+    });
+
+    const behaviors: Array<[SessionPatchBehavior, CommandType]> = [
+        ["JsonPatch", "JsonPatch"],
+        ["JavaScript", "PATCH"]
+    ];
+
+    for (const [behavior, expectedType] of behaviors) {
+        it(`patch() on a simple property uses ${expectedType} under ${behavior}`, async () => {
+            const target = await storeWithBehavior(behavior);
+            try {
+                await storeUser(target);
+
+                const session = target.openSession();
+                session.advanced.patch(USER_ID, "name", "Updated");
+                assert.strictEqual(hasDeferred(session, expectedType), true);
+                await session.saveChanges();
+
+                const user = await loadUser(target);
+                assert.strictEqual(user.name, "Updated");
+                assert.strictEqual(user.age, 25);
+            } finally {
+                await disposeTestDocumentStore(target);
+            }
+        });
+    }
+
+    it("sessionPatchBehavior defaults to JsonPatch", () => {
+        assert.strictEqual(store.conventions.sessionPatchBehavior, "JsonPatch");
+    });
+
+    it("patch() on a nested property, null and number values uses JsonPatch", async () => {
+        await storeUser(store);
+
+        const session = store.openSession();
+        session.advanced.patch(USER_ID, "address.city", "NewCity");
+        session.advanced.patch(USER_ID, "name", null);
+        session.advanced.patch(USER_ID, "age", 30);
+        assert.strictEqual(hasDeferred(session, "JsonPatch"), true);
+        assert.strictEqual(hasDeferred(session, "PATCH"), false);
+        assert.strictEqual(deferred(session).deferredCommandsCount, 1); // merged into one command
+        await session.saveChanges();
+
+        const user = await loadUser(store);
+        assert.strictEqual(user.address.city, "NewCity");
+        assert.strictEqual(user.address.country, "US");
+        assert.strictEqual(user.name, null);
+        assert.strictEqual(user.age, 30);
+    });
+
+    it("patch() creates an absent property", async () => {
+        const session = store.openSession();
+        await session.store(Object.assign(new UserWithTags(), { name: "Test" }), USER_ID);
+        await session.saveChanges();
+
+        const patchSession = store.openSession();
+        patchSession.advanced.patch(USER_ID, "age", 30);
+        await patchSession.saveChanges();
+
+        const user = await loadUser(store);
+        assert.strictEqual(user.name, "Test");
+        assert.strictEqual(user.age, 30);
+    });
+
+    it("patch() on an array element by index replaces in place", async () => {
+        await storeUser(store);
+
+        const session = store.openSession();
+        session.advanced.patch(USER_ID, "tags[1]", "B");
+        assert.strictEqual(hasDeferred(session, "JsonPatch"), true);
+        await session.saveChanges();
+
+        const user = await loadUser(store);
+        assert.deepStrictEqual(user.tags, ["a", "B", "c"]); // replaced, not inserted
+    });
+
+    it("patch() falls back to JavaScript for object and Date values", async () => {
+        await storeUser(store);
+
+        const session = store.openSession();
+        session.advanced.patch(USER_ID, "address", Object.assign(new Address(), { city: "X", country: "PL" }));
+        session.advanced.patch(USER_ID, "lastLogin", new Date(2026, 0, 1));
+        assert.strictEqual(hasDeferred(session, "PATCH"), true);
+        assert.strictEqual(hasDeferred(session, "JsonPatch"), false);
+        await session.saveChanges();
+
+        const user = await loadUser(store);
+        assert.strictEqual(user.address.city, "X");
+        assert.strictEqual(user.address.country, "PL");
+        assert.ok((user as any).lastLogin);
+    });
+
+    it("patch() falls back to JavaScript for paths that are not plain member/index chains", async () => {
+        await storeUser(store);
+
+        const session = store.openSession();
+        session.advanced.patch(USER_ID, "tags[this.tags.length - 1]", "Z");
+        assert.strictEqual(hasDeferred(session, "PATCH"), true);
+        assert.strictEqual(hasDeferred(session, "JsonPatch"), false);
+        await session.saveChanges();
+
+        const user = await loadUser(store);
+        assert.deepStrictEqual(user.tags, ["a", "b", "Z"]);
+    });
+
+    it("patch() after increment() joins the JavaScript patch", async () => {
+        await storeUser(store);
+
+        const session = store.openSession();
+        session.advanced.increment(USER_ID, "age", 5);
+        session.advanced.patch(USER_ID, "name", "Updated");
+        assert.strictEqual(hasDeferred(session, "PATCH"), true);
+        assert.strictEqual(hasDeferred(session, "JsonPatch"), false);
+        assert.strictEqual(deferred(session).deferredCommandsCount, 1);
+        await session.saveChanges();
+
+        const user = await loadUser(store);
+        assert.strictEqual(user.name, "Updated");
+        assert.strictEqual(user.age, 30);
+    });
+
+    it("patch() then increment() keeps both commands", async () => {
+        await storeUser(store);
+
+        const session = store.openSession();
+        session.advanced.patch(USER_ID, "age", 10);
+        session.advanced.increment(USER_ID, "age", 5);
+        assert.strictEqual(hasDeferred(session, "JsonPatch"), true);
+        assert.strictEqual(hasDeferred(session, "PATCH"), true);
+        assert.strictEqual(deferred(session).deferredCommandsCount, 2);
+        await session.saveChanges();
+
+        const user = await loadUser(store);
+        assert.strictEqual(user.name, "Test");
+        assert.strictEqual(user.age, 15); // JsonPatch set 10, then the JavaScript increment added 5
+    });
+
+    it("patch() on a tracked entity refreshes it after saveChanges", async () => {
+        await storeUser(store);
+
+        const session = store.openSession();
+        const user = await session.load<UserWithTags>(USER_ID, UserWithTags);
+        const changeVectorBefore = session.advanced.getChangeVectorFor(user);
+
+        session.advanced.patch(user, "name", "Updated");
+        assert.strictEqual(hasDeferred(session, "JsonPatch"), true);
+        await session.saveChanges();
+
+        assert.strictEqual(user.name, "Updated");
+        assert.notStrictEqual(session.advanced.getChangeVectorFor(user), changeVectorBefore);
+    });
+
+    it("patch() does not send a change vector even with optimistic concurrency", async () => {
+        await storeUser(store);
+
+        const session = store.openSession();
+        session.advanced.useOptimisticConcurrency = true;
+        const user = await session.load<UserWithTags>(USER_ID, UserWithTags);
+        session.advanced.patch(user, "name", "Updated");
+
+        const command = deferred(session).deferredCommandsMap.get(IdTypeAndName.keyFor(USER_ID, "JsonPatch", null)) as JsonPatchCommandData;
+        assert.strictEqual(command.changeVector, null);
+
+        // concurrent write from another session must not make the patch fail
+        const other = store.openSession();
+        const otherUser = await other.load<UserWithTags>(USER_ID, UserWithTags);
+        otherUser.age = 99;
+        await other.saveChanges();
+
+        await session.saveChanges();
+
+        const reloaded = await loadUser(store);
+        assert.strictEqual(reloaded.name, "Updated");
+        assert.strictEqual(reloaded.age, 99);
+    });
+
+    for (const [behavior, expectedType] of behaviors) {
+        it(`patchArray() push uses ${expectedType} under ${behavior}`, async () => {
+            const target = await storeWithBehavior(behavior);
+            try {
+                await storeUser(target);
+
+                const session = target.openSession();
+                session.advanced.patchArray(USER_ID, "tags", tags => tags.push("d"));
+                assert.strictEqual(hasDeferred(session, expectedType), true);
+                await session.saveChanges();
+
+                const user = await loadUser(target);
+                assert.deepStrictEqual(user.tags, ["a", "b", "c", "d"]);
+            } finally {
+                await disposeTestDocumentStore(target);
+            }
+        });
+
+        it(`patchArray() removeAt uses ${expectedType} under ${behavior}`, async () => {
+            const target = await storeWithBehavior(behavior);
+            try {
+                await storeUser(target);
+
+                const session = target.openSession();
+                session.advanced.patchArray(USER_ID, "tags", tags => tags.removeAt(1));
+                assert.strictEqual(hasDeferred(session, expectedType), true);
+                await session.saveChanges();
+
+                const user = await loadUser(target);
+                assert.deepStrictEqual(user.tags, ["a", "c"]);
+            } finally {
+                await disposeTestDocumentStore(target);
+            }
+        });
+    }
+
+    it("patchArray() with several pushes and a removeAt becomes one JsonPatch", async () => {
+        await storeUser(store);
+
+        const session = store.openSession();
+        session.advanced.patchArray(USER_ID, "tags", tags => tags.push("d", "e").removeAt(0));
+        session.advanced.patch(USER_ID, "name", "Updated");
+        assert.strictEqual(hasDeferred(session, "JsonPatch"), true);
+        assert.strictEqual(deferred(session).deferredCommandsCount, 1);
+        await session.saveChanges();
+
+        const user = await loadUser(store);
+        assert.deepStrictEqual(user.tags, ["b", "c", "d", "e"]);
+        assert.strictEqual(user.name, "Updated");
+    });
+
+    it("patchArray() falls back to JavaScript when a pushed value is an object", async () => {
+        await storeUser(store, { tags: [] });
+
+        const session = store.openSession();
+        session.advanced.patchArray<UserWithTags, any>(USER_ID, "tags", tags => tags.push({ nested: true }));
+        assert.strictEqual(hasDeferred(session, "PATCH"), true);
+        assert.strictEqual(hasDeferred(session, "JsonPatch"), false);
+        await session.saveChanges();
+
+        const user = await loadUser(store);
+        assert.deepStrictEqual(user.tags, [{ nested: true }] as any);
+    });
+
+    it("patchArray() removeAt out of range throws under JsonPatch and is a no-op under JavaScript", async () => {
+        await storeUser(store);
+        {
+            const session = store.openSession();
+            session.advanced.patchArray(USER_ID, "tags", tags => tags.removeAt(10));
+            // assertThrows() without an error callback swallows its own failure, so always assert on the error
+            await assertThrows(() => session.saveChanges(), err => {
+                assertThat(err.message).contains("out of array bounds");
+            });
+        }
+
+        const legacy = await storeWithBehavior("JavaScript");
+        try {
+            await storeUser(legacy);
+            const session = legacy.openSession();
+            session.advanced.patchArray(USER_ID, "tags", tags => tags.removeAt(10));
+            await session.saveChanges(); // splice(10, 1) is a silent no-op
+
+            const user = await loadUser(legacy);
+            assert.deepStrictEqual(user.tags, ["a", "b", "c"]);
+        } finally {
+            await disposeTestDocumentStore(legacy);
+        }
+    });
+
+    it("patchArray() removeAt with a negative index falls back to JavaScript", async () => {
+        await storeUser(store);
+
+        const session = store.openSession();
+        session.advanced.patchArray(USER_ID, "tags", tags => tags.removeAt(-1));
+        assert.strictEqual(hasDeferred(session, "PATCH"), true);
+        assert.strictEqual(hasDeferred(session, "JsonPatch"), false);
+        await session.saveChanges(); // splice(-1, 1) removes the last element, as before
+
+        const user = await loadUser(store);
+        assert.deepStrictEqual(user.tags, ["a", "b"]);
+    });
+
+    it("patchArray() and patchObject() with no recorded operations stay on JavaScript", async () => {
+        await storeUser(store);
+
+        const session = store.openSession();
+        session.advanced.patchArray(USER_ID, "tags", () => { /* nothing recorded */ });
+        session.advanced.patchObject(USER_ID, "settings", () => { /* nothing recorded */ });
+        assert.strictEqual(hasDeferred(session, "PATCH"), true);
+        assert.strictEqual(hasDeferred(session, "JsonPatch"), false);
+        await session.saveChanges(); // empty scripts were a no-op before this change and still are
+
+        const user = await loadUser(store);
+        assert.deepStrictEqual(user.tags, ["a", "b", "c"]);
+        assert.deepStrictEqual(user.settings, { theme: "light" });
+    });
+
+    for (const [behavior, expectedType] of behaviors) {
+        it(`patchObject() set uses ${expectedType} under ${behavior}`, async () => {
+            const target = await storeWithBehavior(behavior);
+            try {
+                await storeUser(target);
+
+                const session = target.openSession();
+                session.advanced.patchObject(USER_ID, "settings", map => map.set("lang", "en"));
+                assert.strictEqual(hasDeferred(session, expectedType), true);
+                await session.saveChanges();
+
+                const user = await loadUser(target);
+                assert.deepStrictEqual(user.settings, { theme: "light", lang: "en" });
+            } finally {
+                await disposeTestDocumentStore(target);
+            }
+        });
+
+        it(`patchObject() remove uses ${expectedType} under ${behavior}`, async () => {
+            const target = await storeWithBehavior(behavior);
+            try {
+                await storeUser(target, { settings: { theme: "light", lang: "en" } });
+
+                const session = target.openSession();
+                session.advanced.patchObject(USER_ID, "settings", map => map.remove("lang"));
+                assert.strictEqual(hasDeferred(session, expectedType), true);
+                await session.saveChanges();
+
+                const user = await loadUser(target);
+                assert.deepStrictEqual(user.settings, { theme: "light" });
+            } finally {
+                await disposeTestDocumentStore(target);
+            }
+        });
+    }
+
+    it("patchObject() escapes keys containing / and ~", async () => {
+        await storeUser(store);
+
+        const session = store.openSession();
+        session.advanced.patchObject(USER_ID, "settings", map => map.set("a/b", "slash").set("c~d", "tilde"));
+        assert.strictEqual(hasDeferred(session, "JsonPatch"), true);
+        await session.saveChanges();
+
+        const user = await loadUser(store);
+        assert.deepStrictEqual(user.settings, { theme: "light", "a/b": "slash", "c~d": "tilde" });
+    });
+
+    it("patchObject() falls back to JavaScript for object values and whitespace keys", async () => {
+        await storeUser(store);
+
+        const session = store.openSession();
+        session.advanced.patchObject<UserWithTags, string, any>(USER_ID, "settings", map => map.set("nested", { deep: true }));
+        assert.strictEqual(hasDeferred(session, "PATCH"), true);
+        assert.strictEqual(hasDeferred(session, "JsonPatch"), false);
+        await session.saveChanges();
+
+        const user = await loadUser(store);
+        assert.deepStrictEqual((user.settings as any).nested, { deep: true });
+
+        // a whitespace-only key cannot be a JSON pointer segment, so the whole map call stays JavaScript
+        const whitespace = store.openSession();
+        whitespace.advanced.patchObject(USER_ID, "settings", map => map.set("   ", "x").set("with.dot", "y"));
+        assert.strictEqual(hasDeferred(whitespace, "PATCH"), true);
+        assert.strictEqual(hasDeferred(whitespace, "JsonPatch"), false);
+        await whitespace.saveChanges(); // bracket notation keeps the JavaScript fallback valid for any key
+
+        const afterWhitespace = await loadUser(store);
+        assert.strictEqual(afterWhitespace.settings["   "], "x");
+        assert.strictEqual(afterWhitespace.settings["with.dot"], "y");
+    });
+
+    it("patchObject() remove of a missing key throws under JsonPatch and is a no-op under JavaScript", async () => {
+        await storeUser(store);
+        {
+            const session = store.openSession();
+            session.advanced.patchObject(USER_ID, "settings", map => map.remove("missing"));
+            // assertThrows() without an error callback swallows its own failure, so always assert on the error
+            await assertThrows(() => session.saveChanges(), err => {
+                assertThat(err.message).contains("missing");
+            });
+        }
+
+        const legacy = await storeWithBehavior("JavaScript");
+        try {
+            await storeUser(legacy);
+            const session = legacy.openSession();
+            session.advanced.patchObject(USER_ID, "settings", map => map.remove("missing"));
+            await session.saveChanges(); // delete obj.missing is a silent no-op
+
+            const user = await loadUser(legacy);
+            assert.deepStrictEqual(user.settings, { theme: "light" });
+        } finally {
+            await disposeTestDocumentStore(legacy);
+        }
+    });
+});

--- a/test/Ported/Issues/RavenDB_22293.ts
+++ b/test/Ported/Issues/RavenDB_22293.ts
@@ -4,6 +4,7 @@ import {
     InMemoryDocumentSessionOperations,
     JsonPatchCommandData,
     JsonPatchDocument,
+    PatchCommandData,
     SessionPatchBehavior
 } from "../../../src/index.js";
 import { CommandType } from "../../../src/Documents/Commands/CommandData.js";
@@ -247,6 +248,14 @@ describe("RavenDB-22293 JsonPatch session patching", function () {
 
         assert.strictEqual(user.name, "Updated");
         assert.notStrictEqual(session.advanced.getChangeVectorFor(user), changeVectorBefore);
+
+        // the refreshed change vector lets the same session keep working with the entity
+        user.age = 30;
+        await session.saveChanges();
+
+        const reloaded = await loadUser(store);
+        assert.strictEqual(reloaded.name, "Updated");
+        assert.strictEqual(reloaded.age, 30);
     });
 
     it("patch() does not send a change vector even with optimistic concurrency", async () => {
@@ -271,6 +280,43 @@ describe("RavenDB-22293 JsonPatch session patching", function () {
         const reloaded = await loadUser(store);
         assert.strictEqual(reloaded.name, "Updated");
         assert.strictEqual(reloaded.age, 99);
+    });
+
+    it("increment() does not send a change vector even with optimistic concurrency", async () => {
+        await storeUser(store);
+
+        const session = store.openSession();
+        session.advanced.useOptimisticConcurrency = true;
+        const user = await session.load<UserWithTags>(USER_ID, UserWithTags);
+
+        // concurrent write from another session must not make the JavaScript patch fail either
+        const other = store.openSession();
+        const otherUser = await other.load<UserWithTags>(USER_ID, UserWithTags);
+        otherUser.age = 99;
+        await other.saveChanges();
+
+        session.advanced.increment(user, "age", 1);
+
+        const command = deferred(session).deferredCommandsMap.get(IdTypeAndName.keyFor(USER_ID, "PATCH", null)) as PatchCommandData;
+        assert.strictEqual(command.changeVector, null);
+
+        await session.saveChanges();
+
+        const reloaded = await loadUser(store);
+        assert.strictEqual(reloaded.age, 100); // 99 + 1
+    });
+
+    it("increment() stays on JavaScript", async () => {
+        await storeUser(store, { age: 10 });
+
+        const session = store.openSession();
+        session.advanced.increment(USER_ID, "age", 5);
+        assert.strictEqual(hasDeferred(session, "PATCH"), true);
+        assert.strictEqual(hasDeferred(session, "JsonPatch"), false);
+        await session.saveChanges();
+
+        const user = await loadUser(store);
+        assert.strictEqual(user.age, 15);
     });
 
     for (const [behavior, expectedType] of behaviors) {

--- a/test/Ported/Issues/RavenDB_22750.ts
+++ b/test/Ported/Issues/RavenDB_22750.ts
@@ -1,0 +1,77 @@
+import assert from "node:assert";
+import {
+    AbstractJavaScriptIndexCreationTask,
+    IDocumentStore,
+    QueryStatistics,
+    StopIndexingOperation,
+    StreamQueryStatistics
+} from "../../../src/index.js";
+import { disposeTestDocumentStore, testContext } from "../../Utils/TestUtil.js";
+import { finishedAsync } from "../../../src/Utility/StreamUtil.js";
+import { Company } from "../../Assets/Entities.js";
+
+class Companies_ByName extends AbstractJavaScriptIndexCreationTask<Company, Pick<Company, "name">> {
+    constructor() {
+        super();
+        this.map(Company, c => ({ name: c.name }));
+    }
+}
+
+// The server reports DateTime.MinValue as the index timestamp of an index that has not run a batch yet.
+// The client has to hand that back as a valid Date, the same way it does for a real timestamp.
+describe("RavenDB-22750 query statistics of an index that has not run yet", function () {
+
+    let store: IDocumentStore;
+
+    beforeEach(async () => store = await testContext.getDocumentStore());
+
+    afterEach(async () => await disposeTestDocumentStore(store));
+
+    function assertValidDate(value: Date, name: string): void {
+        assert.ok(value instanceof Date, `${name} should be a Date, got ${typeof value}`);
+        assert.ok(!Number.isNaN(value.getTime()), `${name} should be a valid Date`);
+    }
+
+    it("indexTimestamp and lastQueryTime are valid dates when the index did not run any batch yet", async () => {
+        // stopping indexing before the index is deployed guarantees it never runs a batch
+        await store.maintenance.send(new StopIndexingOperation());
+        await new Companies_ByName().execute(store);
+
+        const session = store.openSession();
+        let stats: QueryStatistics;
+        await session.query(Company, Companies_ByName)
+            .statistics(s => stats = s)
+            .all();
+
+        assertValidDate(stats.indexTimestamp, "indexTimestamp");
+        assertValidDate(stats.lastQueryTime, "lastQueryTime");
+    });
+
+    it("indexTimestamp and lastQueryTime are valid dates for a collection query", async () => {
+        const session = store.openSession();
+        let stats: QueryStatistics;
+        await session.query(Company)
+            .statistics(s => stats = s)
+            .all();
+
+        assertValidDate(stats.indexTimestamp, "indexTimestamp");
+        assertValidDate(stats.lastQueryTime, "lastQueryTime");
+    });
+
+    it("streaming indexTimestamp is a valid date when the index did not run any batch yet", async () => {
+        await store.maintenance.send(new StopIndexingOperation());
+        await new Companies_ByName().execute(store);
+
+        const session = store.openSession();
+        const query = session.query(Company, Companies_ByName);
+
+        let stats: StreamQueryStatistics;
+        const reader = await session.advanced.stream(query, s => stats = s);
+        reader.on("data", () => { /* drain */ });
+        await finishedAsync(reader);
+
+        assert.ok(stats, "stream statistics were not reported");
+        // StreamQueryStatistics carries only indexTimestamp, no lastQueryTime
+        assertValidDate(stats.indexTimestamp, "indexTimestamp");
+    });
+});

--- a/test/Ported/MoreLikeThis/MoreLikeThisTokenAliasTest.ts
+++ b/test/Ported/MoreLikeThis/MoreLikeThisTokenAliasTest.ts
@@ -1,0 +1,75 @@
+import assert from "node:assert";
+import { AbstractJavaScriptIndexCreationTask, IDocumentStore, MoreLikeThisOptions, QueryData } from "../../../src/index.js";
+import { disposeTestDocumentStore, testContext } from "../../Utils/TestUtil.js";
+import { DocumentQuery } from "../../../src/Documents/Session/DocumentQuery.js";
+
+class Article {
+    public id: string;
+    public body: string;
+
+    constructor(body?: string) {
+        this.body = body;
+    }
+}
+
+class ArticleIndex extends AbstractJavaScriptIndexCreationTask<Article, Pick<Article, "body">> {
+    constructor() {
+        super();
+        this.map(Article, a => ({ body: a.body }));
+        this.index("body", "Search");
+        this.termVector("body", "Yes");
+    }
+}
+
+class ArticleResult {
+    public id: string;
+    public body: string;
+    public meta: string;
+}
+
+describe("MoreLikeThisTokenAliasTest", function () {
+
+    let store: IDocumentStore;
+
+    beforeEach(async () => store = await testContext.getDocumentStore());
+
+    afterEach(async () => await disposeTestDocumentStore(store));
+
+    it("moreLikeThis token survives the from-alias when the projection is a JS object", async () => {
+        {
+            const session = store.openSession();
+            await session.store(new Article("test test test"));
+            await session.store(new Article("cake is great"));
+            await session.saveChanges();
+        }
+
+        await new ArticleIndex().execute(store);
+        await testContext.waitForIndexing(store);
+
+        const session = store.openSession();
+
+        const options: MoreLikeThisOptions = {
+            minimumTermFrequency: 1,
+            minimumDocumentFrequency: 1,
+            minimumWordLength: 0
+        };
+
+        const query = session.query(Article, ArticleIndex)
+            .moreLikeThis(f => f.usingDocument(JSON.stringify({ body: "test" })).withOptions(options))
+            .selectFields(QueryData.customFunction("d", "{ id: id(d), body: d.body, meta: getMetadata(d)['@last-modified'] }"), ArticleResult);
+
+        // the projection alias is applied to the where tokens; moreLikeThis() has no field to prefix
+        (query as unknown as DocumentQuery<ArticleResult>).addFromAliasToWhereTokens("d");
+
+        const rql = query.toString();
+        assert.ok(rql.includes("moreLikeThis("), rql);
+        assert.ok(rql.includes(" as d "), rql);
+        assert.ok(!rql.includes("d.moreLikeThis") && !rql.includes("d.undefined"), rql);
+
+        const results = await query.all();
+
+        assert.strictEqual(results.length, 1);
+        assert.strictEqual(results[0].body, "test test test");
+        assert.ok(results[0].meta);
+    });
+});


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RDBC-1107

### Description

Sync of the Node.js client with the C# client `7.2.5` -> `7.2.6` (`CLIENT_VERSION` `7.2.6`, npm `7.2.8`), plus the RavenDB-22293 change from the same C# release: session patches are emitted as RFC 6902 JsonPatch batch commands.

**Synced from the C# 7.2.6 patch**

- `AiOutputOptions`: per-turn output schema override for AI conversations. `run()` / `stream()` accept `{ sampleObject | outputSchema | noSchema }`, `stream(callback)` streams a plain text answer (empty `streamPropertyPath`), `runWithSchema()` / `streamWithSchema()` mirror the C# convenience overloads. `OutputOptions` is sent in the conversation request body. `noSchema` combined with a schema throws `InvalidOperationException` before contacting the server.
- `outputSchema` (per turn and agent level) is forwarded to the model verbatim as `response_format.json_schema`, so it has to be the OpenAI-style `{ name, strict, schema }` wrapper. Documented in JSDoc and README (a bare JSON schema makes the model answer in prose and the turn fails to parse).
- No-args action tool handlers for `handle()` / `receive()` documented and tested.
- `storeChunkText` on `EmbeddingsGenerationConfiguration` (serialized as `StoreChunkText`, part of `isEqual`).
- AI exception names added to `RavenErrorType` (incl. `QueryToolFailedException`).
- `WhereToken.addAlias()` no longer returns a copy with the alias applied twice; it updates the token in place and returns it, so `VectorSearchToken` keeps its shape. `MoreLikeThisToken` overrides `addAlias()` as a no-op (no field to prefix).
- `CdcSinkPostgresSettings` doc comments.
- Not ported: expression-tree (`preferInterpretation`) and Newtonsoft-only changes, no Node.js counterpart.

**JsonPatch session patching (RavenDB-22293, C# `SessionPatchBehavior`)**

- New convention `conventions.sessionPatchBehavior: "JsonPatch" | "JavaScript"`, default `"JsonPatch"` (same default as the C# client).
- `session.advanced.patch()`, `patchArray()` and `patchObject()` emit a `JsonPatch` batch command when the path is a plain member/index chain and every value is `null` or a JSON primitive. One document gets one merged JsonPatch command per `saveChanges()`. Batch results are applied to tracked entities (change vector / metadata refresh) the same way as for JavaScript patches.
- JavaScript fallback is kept for: object / `Date` values, `increment()`, `addOrIncrement()`, `addOrPatch()`, paths that are not plain member/index chains (e.g. `tags[this.tags.length - 1]`), `removeAt()` with a negative index, keys that are not valid JSON pointer segments, empty builders, and any operation queued after a JavaScript patch on the same document (order is preserved).
- New public types: `JsonPatchDocument` (add / replace / remove / move / copy / test), `JsonPatchCommandData` (usable with `session.advanced.defer()`), `SessionPatchBehavior`. `JavaScriptArray` / `JavaScriptMap` record their `operations`; `JavaScriptMap` now uses bracket notation `this.path["key"]` in the JavaScript fallback so keys with spaces or dots work.
- Ported tests: `RavenDB_22293` (all client-portable cases), `RavenDB_22750`, `MoreLikeThisTokenAliasTests`, `VectorSearchTokenAliasTests`, `RavenDB-24824` (offline: options plumbing and request body; the live OpenAI cases have no Node.js infrastructure). `FirstClassPatchTest` adjusted to the new default (deferred command counts, `deferred JsonPatch command` in the error message).

**Notes for reviewers**

- The Node.js client never aliases where tokens on its own: `addFromAliasToWhereTokens()` has no internal callers (public on `DocumentQuery` only). The end-to-end alias tests call it explicitly, which is the only path that exercises the `WhereToken.addAlias()` fix.
- JsonPatch is strict on the server: `removeAt()` past the end of the array or `remove()` of a missing key now makes `saveChanges()` throw where the JavaScript variants were silent no-ops. Covered by tests for both behaviors.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature
- [x] Sync with the C# client (version `7.2.5` -> `7.2.6`)
- [ ] Dependency / tooling / CI update

### Target branch and backports

- [x] This PR targets the correct release branch (e.g. `v7.2`, `v7.1`, `v7.0`, `v6.0`)
- [ ] The change needs to be ported to other release branches. Please list them.
- [x] No other release branch is affected

### How risky is the change?

- [ ] Low
- [x] Moderate
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [x] Breaking change (public API, exported types, default behavior). Please describe the migration path.
- [ ] Not relevant

`session.advanced.patch()` / `patchArray()` / `patchObject()` send `JsonPatch` commands by default instead of JavaScript scripts, and JsonPatch is strict (out-of-range `removeAt()`, `remove()` of a missing key and `patch()` on a non-existing array index throw instead of being no-ops). Migration path: set `store.conventions.sessionPatchBehavior = "JavaScript"` before `store.initialize()` to keep the previous behavior. `WhereToken.addAlias()` now returns the same token instance instead of a copy.

### Server compatibility

- [x] Works with all RavenDB server versions covered by CI
- [ ] Requires a minimum server version. Please specify which one and make sure the tests are gated accordingly.
- [ ] Not relevant

JsonPatch batch commands are supported by every server version in the CI matrix. `AiOutputOptions` is only honored by a 7.2 server that includes RavenDB-24824 (7.2.6+); the AI tests stay gated to 7.1+ and the new ones run offline. Verified locally against 7.2.6 only; behavior of older servers receiving `OutputOptions` was not checked.

### Affected runtimes

- [ ] Node.js
- [ ] Bun
- [ ] Deno
- [ ] Cloudflare Workers
- [x] Not runtime specific

### Public API

- [x] New or changed public API. New types are exported from `src/index.ts` (`npm run check-exports` passes).
- [x] Version bump: `package.json` and `CLIENT_VERSION` in `src/Http/RequestExecutor.ts` (sync / release PRs only)
- [ ] No public API changes

New exports: `SessionPatchBehavior`, `JsonPatchCommandData`, `JsonPatchDocument`, `JavaScriptArray` (`AiOutputOptions` via `Documents/Operations/AI/index.ts`). New methods: `AiConversation.runWithSchema()`, `streamWithSchema()`, `stream(callback)`; `run()` / `stream()` accept `AiOutputOptions`. New convention `sessionPatchBehavior`, new field `EmbeddingsGenerationConfiguration.storeChunkText`. `package.json` `7.2.7` -> `7.2.8`, `CLIENT_VERSION` `7.2.5` -> `7.2.6`.

### Documentation update

- [x] `README.md` has been updated
- [ ] No documentation update is needed

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Existing tests verify the correct behavior
- [x] It has been verified by manual testing
- [x] `npm run lint`, `npm run build`, `npm run check-exports` and `npm run check-imports` pass locally
- [x] Tests have been run locally against a RavenDB server (`RAVENDB_TEST_SERVER_PATH` / `RAVENDB_SERVER_VERSION`)
- [ ] Runtime-specific changes have been verified on the affected runtime (Bun / Deno / Cloudflare Workers)

- Added: `test/Ported/Issues/RavenDB_22293.ts`, `test/Ported/Issues/RavenDB_22750.ts`, `test/Ported/MoreLikeThis/MoreLikeThisTokenAliasTest.ts`, `test/Documents/Queries/VectorSearchTokenAliasTest.ts`, `test/Documents/Session/Tokens/WhereTokenAliasTest.ts`, `test/Documents/Commands/JsonPatchCommandDataTest.ts`, `test/Documents/Conventions/SessionPatchBehaviorTest.ts`, `test/Documents/Session/JavaScriptPatchBuildersTest.ts`, `test/Documents/Session/JsonPatchPathTest.ts`, `test/Ported/Documents/Operations/AiStreamingTest.ts`; extended `AiConversationTest.ts`, `EmbeddingsGenerationConfigurationTest.ts`, `FirstClassPatchTest.ts`.
- Run locally against RavenDB 7.2.6 (`RAVENDB_SERVER_VERSION=7.2`): the files above plus `PatchTest`, `MoreLikeThisTest`: 203 passing, 0 failing.
- Manual testing: `AiOutputOptions` (sample object, explicit schema, `noSchema`, streaming) against a 7.2.6 server with Ollama (llama3.2).
- `npm run lint` reports only pre-existing findings unrelated to this PR: gitignored `test/cloudflare-nitro/.nitro/*.d.ts` leftovers of a local Nitro build and the `no-console` warning in `src/Auth/Certificate.ts`. There is no `build` script; `tshy` (the `prepare` step) completes without errors. `check-exports` and `check-imports` pass.

### Dependencies

- [ ] New or updated runtime dependency. Please explain why it is needed and confirm it works on all affected runtimes.
- [ ] Dev dependency only
- [x] No dependency changes

### Is there any existing behavior change of other features due to this change?

- [x] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

- Session patching (`session.advanced.patch()` / `patchArray()` / `patchObject()`): `JsonPatch` commands by default, strict semantics, one merged command per document; `increment()` and friends unchanged. The "document modified by the session and also taking part in a deferred command" error now names the `JsonPatch` command.
- Query aliasing: `WhereToken.addAlias()` mutates and returns the same token; `MoreLikeThisToken` is no longer aliased.
- AI conversations: `stream()` accepts an empty property path when `noSchema` is set; the request body carries `OutputOptions` only when options are given.