### PR TITLE
RDBC-1107 Follow-up to #578: order-by aliasing, empty output options, patchObject key docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2303,6 +2303,11 @@ the legacy JavaScript behaviour:
 store.conventions.sessionPatchBehavior = "JavaScript"; // default: "JsonPatch"
 ```
 
+`patchObject` keys always name a single property of the target object, in both modes: `map.set("a.b", value)`
+writes the `"a.b"` key (JsonPatch `/settings/a.b`, JavaScript `this.settings["a.b"]`), not the nested `settings.a.b`
+member that versions before 7.2.7 reached with `this.settings.a.b`. Use `session.advanced.patch(id, "settings.a.b", value)`
+for a nested member.
+
 >##### Related tests:
 > <small>[can use advanced.patch](https://github.com/ravendb/ravendb-nodejs-client/blob/5c14565d0c307d22e134530c8d63b09dfddcfb5b/test/Documents/ReadmeSamples.ts#L708)</small>  
 > <small>[can patch](https://github.com/ravendb/ravendb-nodejs-client/blob/5c14565d0c307d22e134530c8d63b09dfddcfb5b/test/Ported/FirstClassPatchTest.ts#L18)</small>  

--- a/src/Documents/Operations/AI/Agents/RunConversationOperation.ts
+++ b/src/Documents/Operations/AI/Agents/RunConversationOperation.ts
@@ -333,7 +333,8 @@ class RunConversationCommand<TAnswer>
             payload.NoSchema = true;
         }
 
-        return payload;
+        // Nothing set means "use the agent default", which is exactly what omitting OutputOptions does
+        return Object.keys(payload).length > 0 ? payload : null;
     }
 
     private async _processStreamingResponse(bodyStream: Readable): Promise<string> {

--- a/src/Documents/Operations/AI/AiConversation.ts
+++ b/src/Documents/Operations/AI/AiConversation.ts
@@ -336,6 +336,7 @@ export class AiConversation {
      *
      * An object whose keys are only `sampleObject`, `outputSchema` or `noSchema` is treated as
      * {@link AiOutputOptions}; wrap such a sample explicitly as `{ sampleObject }`.
+     * Options with none of the three set (e.g. `{}`) throw an `InvalidArgumentException`.
      *
      * @param sampleObject - A sample instance used to generate the JSON schema sent to the model
      *
@@ -447,6 +448,7 @@ export class AiConversation {
      *
      * An object whose keys are only `sampleObject`, `outputSchema` or `noSchema` is treated as
      * {@link AiOutputOptions}; wrap such a sample explicitly as `{ sampleObject }`.
+     * Options with none of the three set (e.g. `{}`) throw an `InvalidArgumentException`.
      */
     public streamWithSchema<TAnswer extends object>(streamPropertyPath: string, streamCallback: AiStreamCallback, sampleObject: TAnswer): Promise<AiAnswer<TAnswer>>;
     public streamWithSchema<TAnswer>(
@@ -471,7 +473,14 @@ export class AiConversation {
         // Only sampleObject / outputSchema / noSchema keys: this is AiOutputOptions, otherwise a sample object
         const keys = Object.keys(value);
         if (keys.every(key => AiConversation.OUTPUT_OPTIONS_KEYS.has(key))) {
-            return value as AiOutputOptions;
+            const options = value as AiOutputOptions;
+            // {} would otherwise travel as empty OutputOptions and silently keep the agent default schema
+            if (options.sampleObject == null && options.outputSchema == null && !options.noSchema) {
+                throwError("InvalidArgumentException",
+                    "Output options must set sampleObject, outputSchema or noSchema. " +
+                    "To derive the schema from a sample object pass it as { sampleObject }.");
+            }
+            return options;
         }
 
         return { sampleObject: value as object };

--- a/src/Documents/Session/AbstractDocumentQuery.ts
+++ b/src/Documents/Session/AbstractDocumentQuery.ts
@@ -2584,12 +2584,13 @@ export abstract class AbstractDocumentQuery<T extends object, TSelf extends Abst
             throwError("InvalidArgumentException", "Alias cannot be null or empty.");
         }
 
-        for (const token of tokens) {
+        for (let i = 0; i < tokens.length; i++) {
+            const token = tokens[i];
             if (token instanceof WhereToken) {
                 token.addAlias(fromAlias);
-            }
-            if (token instanceof OrderByToken) {
-                token.addAlias(fromAlias);
+            } else if (token instanceof OrderByToken) {
+                // OrderByToken is immutable: addAlias() returns a new token that has to be stored back
+                tokens[i] = token.addAlias(fromAlias);
             }
         }
     }

--- a/src/Documents/Session/DocumentQuery.ts
+++ b/src/Documents/Session/DocumentQuery.ts
@@ -381,7 +381,7 @@ export class DocumentQuery<T extends object>
 
     public whereEquals(fieldName: Field<T>, method: MethodCall): IDocumentQuery<T>;
     public whereEquals(fieldName: Field<T>, method: MethodCall, exact: boolean): IDocumentQuery<T>;
-    public whereEquals(fieldName: Field<T>, value: any): void;
+    public whereEquals(fieldName: Field<T>, value: any): IDocumentQuery<T>;
     public whereEquals(fieldName: Field<T>, value: any, exact: boolean): IDocumentQuery<T>;
     public whereEquals(whereParams: WhereParams): IDocumentQuery<T>;
     public whereEquals(...args: any[]): IDocumentQuery<T> {
@@ -391,7 +391,7 @@ export class DocumentQuery<T extends object>
 
     public whereNotEquals(fieldName: Field<T>, method: MethodCall): IDocumentQuery<T>;
     public whereNotEquals(fieldName: Field<T>, method: MethodCall, exact: boolean): IDocumentQuery<T>;
-    public whereNotEquals(fieldName: Field<T>, value: any): void;
+    public whereNotEquals(fieldName: Field<T>, value: any): IDocumentQuery<T>;
     public whereNotEquals(fieldName: Field<T>, value: any, exact: boolean): IDocumentQuery<T>;
     public whereNotEquals(whereParams: WhereParams): IDocumentQuery<T>;
     public whereNotEquals(...args: any[]): IDocumentQuery<T> {

--- a/test/Documents/Queries/OrderByAliasTest.ts
+++ b/test/Documents/Queries/OrderByAliasTest.ts
@@ -1,0 +1,60 @@
+import assert from "node:assert";
+import { DocumentStore } from "../../../src/index.js";
+import { DocumentQuery } from "../../../src/Documents/Session/DocumentQuery.js";
+
+class Order {
+    public id: string;
+    public company: string;
+    public freight: number;
+    public name: string;
+}
+
+// Offline: builds the RQL only, nothing is sent to a server.
+describe("addFromAliasToOrderByTokens", function () {
+
+    let store: DocumentStore;
+
+    beforeEach(() => {
+        store = new DocumentStore("http://localhost:8080", "db");
+        store.initialize();
+    });
+
+    afterEach(() => store.dispose());
+
+    function query(): DocumentQuery<Order> {
+        return store.openSession().query<Order>({ collection: "Orders" }) as DocumentQuery<Order>;
+    }
+
+    it("prefixes order by fields with the alias, keeping ordering and direction", () => {
+        const q = query()
+            .whereEquals("company", "companies/1")
+            .orderBy("freight", "Double")
+            .orderByDescending("name") as DocumentQuery<Order>;
+
+        q.addFromAliasToWhereTokens("o");
+        q.addFromAliasToOrderByTokens("o");
+
+        assert.strictEqual(q.toString(),
+            "from 'Orders' where o.company = $p0 order by o.freight as double, o.name desc");
+    });
+
+    it("keeps the ordering type and nulls ordering after aliasing", () => {
+        const q = query()
+            .orderBy("name", "First", "AlphaNumeric") as DocumentQuery<Order>;
+
+        q.addFromAliasToOrderByTokens("o");
+
+        assert.strictEqual(q.toString(), "from 'Orders' order by o.name as alphaNumeric nulls first");
+    });
+
+    it("leaves id() and RQL methods untouched", () => {
+        const q = query()
+            .orderBy("id()")
+            .orderByScore()
+            .randomOrdering() as DocumentQuery<Order>;
+
+        q.addFromAliasToOrderByTokens("o");
+
+        assert.strictEqual(q.toString(), "from 'Orders' order by id(), score(), random()");
+    });
+});

--- a/test/Ported/Documents/Operations/AiConversationTest.ts
+++ b/test/Ported/Documents/Operations/AiConversationTest.ts
@@ -629,15 +629,29 @@ import {
         await conv.runWithSchema({ summary: "a short summary", score: 5 });
         await conv.runWithSchema({ sampleObject: { summary: "wrapped" } });
         await conv.runWithSchema({ noSchema: true });
-        await conv.runWithSchema({});
 
-        assertThat(calls).hasSize(5);
+        assertThat(calls).hasSize(4);
         assert.deepStrictEqual(calls[0].outputOptions, { outputSchema: `{"type":"object"}` });
         assert.deepStrictEqual(calls[1].outputOptions, { sampleObject: { summary: "a short summary", score: 5 } });
         assert.deepStrictEqual(calls[2].outputOptions, { sampleObject: { summary: "wrapped" } });
         assert.deepStrictEqual(calls[3].outputOptions, { noSchema: true });
-        // an empty object carries no schema information, so it is passed through as (empty) options
-        assert.deepStrictEqual(calls[4].outputOptions, {});
+    });
+
+    it("runWithSchema() and streamWithSchema() reject an options object with nothing set", async () => {
+        const conv = store.ai.conversation("agents/1-A", "conversations/34|") as any;
+        const calls = stubRunInternal(conv);
+
+        for (const empty of [{}, { sampleObject: undefined }, { outputSchema: null, noSchema: false }]) {
+            await assertThrows(() => conv.runWithSchema(empty), err => {
+                assertThat(err.name).isEqualTo("InvalidArgumentException");
+                assertThat(err.message).contains("sampleObject");
+            });
+            await assertThrows(() => conv.streamWithSchema("summary", () => {}, empty), err => {
+                assertThat(err.name).isEqualTo("InvalidArgumentException");
+            });
+        }
+
+        assertThat(calls).hasSize(0);
     });
 
     it("stream(callback) streams raw text with an empty property path and noSchema", async () => {

--- a/test/Ported/Documents/Operations/AiStreamingTest.ts
+++ b/test/Ported/Documents/Operations/AiStreamingTest.ts
@@ -137,6 +137,12 @@ import type {AiStreamCallback} from "../../../../src/Documents/Operations/AI/AiS
         assertThat(body.OutputOptions).isUndefined();
     });
 
+    it("should not send OutputOptions when the options object has nothing set", () => {
+        const { body } = requestFor({});
+
+        assertThat(body.OutputOptions).isUndefined();
+    });
+
     it("should send the sample object as a JSON string in OutputOptions", () => {
         const { body } = requestFor({ sampleObject: { summary: "a short summary", score: 5 } });
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RDBC-1107

### Description

Follow-up to the review of #578 (three items).

**`addFromAliasToOrderByTokens()` never aliased order-by tokens** (pre-existing)

`OrderByToken.addAlias()` returns a new token (the token is immutable) and `_addFromAliasToTokens` discarded the result, so `addFromAliasToOrderByTokens("o")` produced `order by freight as double` instead of `order by o.freight as double`. The C# client stores the returned token back into the list; the Node.js client now does the same. `WhereToken` was already correct because it is aliased in place. New offline test `test/Documents/Queries/OrderByAliasTest.ts` covers ordering type, direction, nulls ordering and the `id()` / RQL-method exclusions.

**`runWithSchema({})` / `streamWithSchema({})` silently did nothing**

An object whose keys are all in `sampleObject` / `outputSchema` / `noSchema` is classified as `AiOutputOptions`, and `every()` over the keys of `{}` is `true`, so `{}` passed validation and went out as `OutputOptions: {}`, keeping the agent's default schema where the caller expected a schema derived from the sample. Both `WithSchema` methods now throw `InvalidArgumentException` when none of the three fields is set (`{}`, `{ sampleObject: undefined }`, `{ outputSchema: null, noSchema: false }`).

`run({})` stays allowed to match the C# client's `RunAsync(new AiOutputOptions())` and the conditionally-built-options pattern, but an empty payload is no longer serialized: omitting `OutputOptions` already means "use the agent default", so the server result is identical.

**`patchObject` keys always name a single property** (docs only)

Since the bracket-notation / JsonPatch change a key such as `"a.b"` addresses the `"a.b"` property in both patch modes (`/settings/a.b`, `this.settings["a.b"]`), where earlier versions emitted `this.settings.a.b` and reached the nested member. This matches the C# client's `FormatKeyForJavaScript` and has no opt-out there either, so the behavior is kept and the README patch section now states it and points at `session.advanced.patch(id, "settings.a.b", value)` for nested members.

**`whereEquals()` / `whereNotEquals()` two-argument overloads typed as `void`** (pre-existing, found by the new test)

The `(fieldName, value)` overloads on `DocumentQuery` returned `void` while the interface and implementation return the query, so chaining on a `DocumentQuery`-typed value failed with TS2339 in the IDE. Type-only fix. Note that `tsconfig.json` only lists `src/index.ts`, so `tsc` never type-checks `test/**`; mocha runs them transpile-only.

**Notes for reviewers**

- The review also noted that the `WhereToken.addAlias()` commit message in #578 overstated the change (the only caller discarded the return value, so the double alias never reached a query). Correct; that commit is already merged, so the wording is left as-is and the release notes describe it as a cleanup.
- `addFromAliasToOrderByTokens()` has no internal callers (public on `DocumentQuery` only), so the fix has no regression surface beyond that method.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature
- [ ] Sync with the C# client (version `x.y.z` -> `x.y.z`)
- [ ] Dependency / tooling / CI update

### Target branch and backports

- [x] This PR targets the correct release branch (e.g. `v7.2`, `v7.1`, `v7.0`, `v6.0`)
- [x] The change needs to be ported to other release branches. Please list them: the `addFromAliasToOrderByTokens()` fix predates `v7.2` (the discard dates back to the Java sync) and applies to every maintained release branch; the other two changes only exist on `v7.2`.
- [ ] No other release branch is affected

### How risky is the change?

- [x] Low
- [ ] Moderate
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [x] Breaking change (public API, exported types, default behavior). Please describe the migration path: `runWithSchema({})` / `streamWithSchema({})` now throw instead of sending empty `OutputOptions`. Pass a schema string, a sample object or options with one of `sampleObject` / `outputSchema` / `noSchema` set, or call `run()` / `stream()` without options to use the agent default. `run({})` is unchanged apart from no longer sending the empty object.
- [ ] Not relevant

### Server compatibility

- [x] Works with all RavenDB server versions covered by CI
- [ ] Requires a minimum server version. Please specify which one and make sure the tests are gated accordingly.
- [ ] Not relevant

### Affected runtimes

- [ ] Node.js
- [ ] Bun
- [ ] Deno
- [ ] Cloudflare Workers
- [x] Not runtime specific

### Public API

- [ ] New or changed public API. New types are exported from `src/index.ts` (`npm run check-exports` passes).
- [ ] Version bump: `package.json` and `CLIENT_VERSION` in `src/Http/RequestExecutor.ts` (sync / release PRs only)
- [x] No public API changes

### Documentation update

- [x] `README.md` has been updated
- [ ] No documentation update is needed

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Existing tests verify the correct behavior
- [ ] It has been verified by manual testing
- [x] `npm run lint`, `npm run build`, `npm run check-exports` and `npm run check-imports` pass locally (eslint on the changed files, `tsc --noEmit`, `npm run prepare` and `check-exports` pass; `check-imports` not run)
- [x] Tests have been run locally against a RavenDB server (`RAVENDB_TEST_SERVER_PATH` / `RAVENDB_SERVER_VERSION`): 7.2.6, AI conversation/streaming tests, alias tests and all of `test/Documents/Queries`
- [ ] Runtime-specific changes have been verified on the affected runtime (Bun / Deno / Cloudflare Workers)

### Dependencies

- [ ] New or updated runtime dependency. Please explain why it is needed and confirm it works on all affected runtimes.
- [ ] Dev dependency only
- [x] No dependency changes

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No
