### PR TITLE
RDBC-1111 Drop the Node.js nightly job from the node-latest workflow

### DIFF
--- a/.github/workflows/NodeLatest.yml
+++ b/.github/workflows/NodeLatest.yml
@@ -6,7 +6,7 @@ name: tests/node-latest
 # releases of the current line roughly every 2-4 weeks, so a weekly run is
 # enough to catch a breaking release within days. The regular test matrix
 # (RavenClient.yml) pins concrete lines; this workflow always resolves the
-# newest available versions instead.
+# newest available release instead.
 
 permissions:
   contents: read
@@ -19,10 +19,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-
-    # `nightly` is allowed to fail: it exists to spot upstream breaks early
-    # (like the undici dispatch handler protocol changes), not to gate anything.
-    continue-on-error: ${{ matrix.node-version == 'nightly' }}
 
     env:
       RAVENDB_TEST_SERVER_PATH: ./RavenDB/Server/Raven.Server
@@ -37,8 +33,7 @@ jobs:
 
     strategy:
       matrix:
-        # `latest` = newest stable release (any line), `nightly` = tip of main.
-        node-version: [latest, nightly]
+        node-version: [latest]
         serverVersion: ["7.2"]
       fail-fast: false
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RDBC-1111

### Description

The `nightly` entry of the `tests/node-latest` matrix has failed at the `actions/setup-node` step on every run since the workflow was added in #569 (RDBC-1095), with:

```
Unable to find Node version 'nightly' for platform linux and architecture x64.
```

`continue-on-error` kept the runs green, so this never surfaced.

**Root cause**: `actions/setup-node` has no bare `nightly` alias. The version spec is split on `-` (`splitVersionSpec`), so for a lone `nightly` there is no prerelease part and the spec is used verbatim as the semver range. `semver.satisfies(version, "nightly")` is always `false`, so no build ever matches even though linux-x64 nightlies exist. Only `<major>-nightly`, `<x.y.z>-nightly` and exact `<x.y.z>-nightly<date><sha>` specs are supported (see setup-node `docs/advanced-usage.md` and `__tests__/nightly-installer.test.ts`).

**Change**: remove `nightly` from the matrix and the `continue-on-error` expression that existed only for it; the workflow keeps the weekly `latest` canary. The remaining `nightly` in the file is `RAVENDB_BUILD_TYPE: nightly` (RavenDB server build type), unrelated.

An alternative was to resolve the newest nightly major in a pre-step and pass `<major>-nightly` to setup-node; it was verified locally against the nightly index but dropped in favor of removing the job, as requested in the issue.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature
- [ ] Sync with the C# client (version `x.y.z` -> `x.y.z`)
- [x] Dependency / tooling / CI update

### Target branch and backports

- [x] This PR targets the correct release branch (e.g. `v7.2`, `v7.1`, `v7.0`, `v6.0`)
- [ ] The change needs to be ported to other release branches. Please list them.
- [x] No other release branch is affected (`NodeLatest.yml` exists only on `v7.2`)

### How risky is the change?

- [x] Low
- [ ] Moderate
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change (public API, exported types, default behavior). Please describe the migration path.
- [x] Not relevant

### Server compatibility

- [ ] Works with all RavenDB server versions covered by CI
- [ ] Requires a minimum server version. Please specify which one and make sure the tests are gated accordingly.
- [x] Not relevant

### Affected runtimes

- [ ] Node.js
- [ ] Bun
- [ ] Deno
- [ ] Cloudflare Workers
- [x] Not runtime specific

### Public API

- [ ] New or changed public API. New types are exported from `src/index.ts` (`npm run check-exports` passes).
- [ ] Version bump: `package.json` and `CLIENT_VERSION` in `src/Http/RequestExecutor.ts` (sync / release PRs only)
- [x] No public API changes

### Documentation update

- [ ] `README.md` has been updated
- [x] No documentation update is needed

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Existing tests verify the correct behavior
- [x] It has been verified by manual testing (workflow YAML parsed with js-yaml; matrix is `[latest]`; setup-node matching reproduced locally against `nodejs.org/download/nightly/index.json`: bare `nightly` matches nothing, `27-nightly` resolves)
- [ ] `npm run lint`, `npm run build`, `npm run check-exports` and `npm run check-imports` pass locally
- [ ] Tests have been run locally against a RavenDB server (`RAVENDB_TEST_SERVER_PATH` / `RAVENDB_SERVER_VERSION`)
- [ ] Runtime-specific changes have been verified on the affected runtime (Bun / Deno / Cloudflare Workers)

### Dependencies

- [ ] New or updated runtime dependency. Please explain why it is needed and confirm it works on all affected runtimes.
- [ ] Dev dependency only
- [x] No dependency changes

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

