### PR TITLE
RDBC-1092 Support PKCS#12 client certificates on Bun

### DIFF
--- a/README.md
+++ b/README.md
@@ -2729,6 +2729,48 @@ Deno-specific notes:
 
 An end-to-end smoke test lives in [`test/deno`](./test/deno).
 
+## Bun
+
+The client runs on [Bun](https://bun.com), including X.509 client-certificate
+authentication with either a **PEM** bundle or a **PKCS#12 (PFX)** archive - configure
+`authOptions` exactly like on Node.
+
+```javascript
+import { DocumentStore } from "ravendb";
+import { readFileSync } from "node:fs";
+
+const authOptions = {
+    type: "pfx",
+    certificate: readFileSync("client.pfx"), // a Buffer, as on Node
+    password: "secret",                      // optional
+    ca: readFileSync("ca.pem")               // optional, for a private CA
+};
+
+const store = new DocumentStore("https://a.free.example.ravendb.cloud", "MyDatabase", authOptions);
+store.initialize();
+```
+
+Bun-specific notes:
+
+- **A PEM certificate is presented through Bun's `tls` fetch option**, a PKCS#12 archive
+  through a `node:https` transport the client installs for it. Bun's `fetch` silently
+  ignores `tls.pfx` ([oven-sh/bun#41958](https://github.com/oven-sh/bun/issues/41958),
+  [oven-sh/bun#17543](https://github.com/oven-sh/bun/issues/17543)), which would send the
+  request uncertified; its `node:https` implementation does honour `pfx`
+  ([oven-sh/bun#14417](https://github.com/oven-sh/bun/issues/14417)).
+- **A PKCS#12 archive needs Bun 1.4.0 or newer.** Earlier versions present no client
+  certificate on either transport, so the client throws an actionable error at
+  `initialize()` instead of sending uncertified requests. Convert the archive with
+  `openssl pkcs12 -in cert.pfx -out cert.pem -nodes` and use `type: "pem"` to stay on an
+  older Bun.
+- **HTTP decompression is off by default on Bun** (`conventions.useHttpDecompression`),
+  unchanged by the above - the `node:https` transport decodes `gzip`, `deflate` and `br`
+  responses when you turn it on.
+- **The Changes API does not work over TLS on Bun.** Bun replaces the `ws` package with
+  its own WebSocket, which ignores the Node TLS options the client passes (certificate,
+  `ca`, even `rejectUnauthorized`), so the connection fails the TLS handshake against a
+  secured server. Run Changes API consumers on Node.
+
 ## Custom fetch: bring your own transport
 
 On runtimes where the client cannot provide authentication itself,

--- a/src/Auth/Certificate.ts
+++ b/src/Auth/Certificate.ts
@@ -269,13 +269,13 @@ export class PfxCertificate extends Certificate {
         });
     }
 
+    /**
+     * Kept for completeness, but note that Bun's fetch ignores `tls.pfx` - the client
+     * presents a PKCS#12 archive on Bun through a node:https transport instead
+     * (see Utility/BunHttpUtil.ts), which is why nothing here warns any more.
+     */
     public toBunTlsOptions(): BunTlsOptions {
         const options = super.toBunTlsOptions();
-
-        console.warn(
-            "WARNING: PFX certificates are not currently supported in Bun runtime. " +
-            "The connection may fail. Please use PEM certificates instead. "
-        );
 
         return {
             ...options,

--- a/src/Http/RavenCommand.ts
+++ b/src/Http/RavenCommand.ts
@@ -158,7 +158,7 @@ export abstract class RavenCommand<TResult> {
 
         log.info(`Send command ${this.constructor.name} to ${uri}${body ? " with body " + body : ""}.`);
 
-        const bodyToUse = fetcher ? RavenCommand.maybeWrapBody(body) : body;
+        const bodyToUse = fetcher ? RavenCommand.maybeWrapBody(body, fetcher) : body;
 
         let optionsToUse: RequestInit | BunFetchRequestInit;
 
@@ -244,8 +244,10 @@ export abstract class RavenCommand<TResult> {
         return err;
     }
 
-    private static maybeWrapBody(body: any) {
-        if (body instanceof Readable) {
+    private static maybeWrapBody(body: any, fetcher: any) {
+        // A fetcher that declares it can take one gets the stream as-is (the Bun node:https
+        // transport pipes it); the global fetch and a user-supplied customFetch cannot.
+        if (body instanceof Readable && !fetcher?.acceptsNodeStreamBody) {
             throw new Error("Requests using stream.Readable as payload are not yet supported!");
         }
 

--- a/src/Http/RequestExecutor.ts
+++ b/src/Http/RequestExecutor.ts
@@ -51,6 +51,12 @@ import { EOL } from "../Utility/OsUtil.js";
 import { importFix } from "../Utility/ImportUtil.js";
 import { RuntimeUtil } from "../Utility/RuntimeUtil.js";
 import { createDenoHttpClient, DenoHttpClient, validateDenoCertificateSupport } from "../Utility/DenoHttpUtil.js";
+import {
+    BunHttpTransport,
+    createNodeHttpsTransport,
+    requiresNodeHttpsTransport,
+    validateBunCertificateSupport
+} from "../Utility/BunHttpUtil.js";
 
 const DEFAULT_REQUEST_OPTIONS = {};
 
@@ -247,6 +253,9 @@ export class RequestExecutor implements IDisposable {
     /** Deno only: the Deno.HttpClient presenting the client certificate, built lazily in _getDenoHttpClient(). */
     private _denoHttpClient: DenoHttpClient = null;
 
+    /** Bun only: the node:https transport presenting a PKCS#12 certificate, built lazily in _getBunHttpTransport(). */
+    private _bunHttpTransport: BunHttpTransport = null;
+
     public static requestPostProcessor: (req: HttpRequestParameters) => void = null;
 
     public get customHttpRequestOptions(): HttpRequestParametersWithoutUri {
@@ -363,8 +372,9 @@ export class RequestExecutor implements IDisposable {
         // Runtimes whose fetch has no undici dispatcher (Bun, Cloudflare Workers, Deno)
         // can't use an http agent -- there is nothing to build. A configured certificate
         // is presented another way there: Bun via the `tls` request option (set in
-        // _setDefaultRequestOptions), Deno via a Deno.HttpClient `client` request option
-        // (set in _createRequest).
+        // _setDefaultRequestOptions) or, for a PKCS#12 archive Bun's fetch cannot present,
+        // a node:https `fetcher` (set in _createRequest); Deno via a Deno.HttpClient
+        // `client` request option (also set in _createRequest).
         if (!RuntimeUtil.supportsUndiciDispatcher()) {
             // On workerd a client certificate can never be presented from user-space
             // unless mTLS is wired through conventions.customFetch (checked above).
@@ -424,6 +434,10 @@ export class RequestExecutor implements IDisposable {
 
         if (RuntimeUtil.isDeno()) {
             validateDenoCertificateSupport(Certificate.createFromOptions(authOptions));
+        }
+
+        if (RuntimeUtil.isBun()) {
+            validateBunCertificateSupport(Certificate.createFromOptions(authOptions));
         }
     }
 
@@ -1508,6 +1522,16 @@ export class RequestExecutor implements IDisposable {
             req.client = this._getDenoHttpClient();
         }
 
+        // Bun only: a PKCS#12 archive cannot be presented through Bun's fetch (its `tls`
+        // option ignores `pfx`), so those requests are issued by a node:https-backed
+        // fetcher instead - Bun's node:https does honour `pfx`. Built lazily, once per
+        // executor, closed in dispose(), and skipped when conventions.customFetch owns
+        // the transport - the same rules the Deno client follows.
+        if (RuntimeUtil.isBun() && this._certificate && !this.conventions.customFetch
+            && requiresNodeHttpsTransport(this._certificate)) {
+            req.fetcher = this._getBunHttpTransport().fetch;
+        }
+
         urlRef(req.uri);
         req.headers = req.headers || {};
 
@@ -2033,7 +2057,9 @@ export class RequestExecutor implements IDisposable {
             DEFAULT_REQUEST_OPTIONS,
             this._customHttpRequestOptions);
 
-        if (RuntimeUtil.isBun() && this._certificate) {
+        // A PKCS#12 archive is deliberately left out: Bun's fetch ignores `tls.pfx`, so it
+        // is presented through the node:https fetcher installed in _createRequest instead.
+        if (RuntimeUtil.isBun() && this._certificate && !requiresNodeHttpsTransport(this._certificate)) {
             this._defaultRequestOptions.tls = this._certificate.toBunTlsOptions();
         }
     }
@@ -2044,6 +2070,14 @@ export class RequestExecutor implements IDisposable {
         }
 
         return this._denoHttpClient;
+    }
+
+    private _getBunHttpTransport(): BunHttpTransport {
+        if (!this._bunHttpTransport) {
+            this._bunHttpTransport = createNodeHttpsTransport(this._certificate);
+        }
+
+        return this._bunHttpTransport;
     }
 
     public dispose(): void {
@@ -2071,6 +2105,10 @@ export class RequestExecutor implements IDisposable {
         // Deno only: release the connection pool behind the client certificate.
         this._denoHttpClient?.close();
         this._denoHttpClient = null;
+
+        // Bun only: the same, for the node:https transport presenting a PKCS#12 archive.
+        this._bunHttpTransport?.close();
+        this._bunHttpTransport = null;
     }
 
     public async getRequestedNode(nodeTag: string, throwIfContainsFailures = false): Promise<CurrentIndexAndNode> {

--- a/src/Types/BunTypes.ts
+++ b/src/Types/BunTypes.ts
@@ -107,8 +107,10 @@ export interface BunTlsOptions {
     /**
      * PFX or PKCS12 encoded certificate and private key
      *
-     * @warning This property is included for Node.js compatibility, but PFX certificates
-     * are NOT currently supported in Bun runtime. Use PEM certificates (cert/key/ca) instead.
+     * @warning Bun's fetch silently IGNORES this option - only PEM material (cert/key/ca)
+     * is honoured there (oven-sh/bun#41958, oven-sh/bun#17543). The client therefore
+     * presents a PKCS#12 archive through a node:https transport (Utility/BunHttpUtil.ts),
+     * whose Agent does honour `pfx`; this property is kept for shape compatibility.
      */
     pfx?: Buffer;
 }

--- a/src/Utility/BunHttpUtil.ts
+++ b/src/Utility/BunHttpUtil.ts
@@ -1,0 +1,403 @@
+import type { Agent as HttpAgent, IncomingMessage, RequestOptions } from "node:http";
+import type { Agent as HttpsAgent } from "node:https";
+import type { Readable, Transform } from "node:stream";
+import type { ConnectionOptions } from "node:tls";
+import { ICertificate } from "../Auth/Certificate.js";
+import { throwError } from "../Exceptions/index.js";
+import { RuntimeUtil } from "./RuntimeUtil.js";
+
+/**
+ * A `fetch` replacement backed by `node:https`, plus the connection pool behind it.
+ * The caller owns the transport and must `close()` it.
+ */
+export interface BunHttpTransport {
+    fetch: NodeHttpsFetch;
+    close(): void;
+}
+
+export interface NodeHttpsFetch {
+    (url: string, init?: RequestInit): Promise<Response>;
+
+    /**
+     * Marks this fetcher as accepting a `node:stream` Readable request body, which the
+     * global `fetch` does not. RavenCommand.send checks it before rejecting the streamed
+     * attachment payloads PutAttachmentOperation produces.
+     */
+    acceptsNodeStreamBody: true;
+}
+
+export type NodeHttpsAgentOptions = ConnectionOptions & { keepAlive: boolean };
+
+/**
+ * First Bun whose `node:https` presents a client certificate (and honours `ca`) at all.
+ * Bun 1.3.x ignores both, so the PKCS#12 path has nothing to fall back to there.
+ */
+const MIN_BUN_MAJOR_MINOR_FOR_PFX = [1, 4];
+
+/** Responses that must not carry a body - the `Response` constructor rejects one. */
+const NULL_BODY_STATUSES = new Set([204, 205, 304]);
+
+interface NodeHttpModules {
+    request: typeof import("node:http").request;
+    secureRequest: typeof import("node:https").request;
+    zlib: typeof import("node:zlib");
+    httpAgent: HttpAgent;
+    httpsAgent: HttpsAgent;
+}
+
+/**
+ * Whether the configured certificate has to be presented through `node:https` instead of
+ * Bun's own `fetch`. Bun's `fetch` accepts only PEM material in its `tls` option (`cert`,
+ * `key`, `ca`) - a `pfx` there is silently ignored, so the request goes out uncertified
+ * and comes back as a bare 401/403 (oven-sh/bun#41958, oven-sh/bun#17543). Its
+ * `node:https` implementation does honour `pfx` (oven-sh/bun#14417, fixed in Bun 1.4.x),
+ * which is why a PKCS#12 archive is routed there and PEM material is not.
+ *
+ * Decided on the TLS options the certificate produces rather than `instanceof
+ * PfxCertificate`: the package ships both a CommonJS and an ESM build, and a certificate
+ * built from the other one would silently fail the identity check and go out uncertified.
+ */
+export function requiresNodeHttpsTransport(certificate: ICertificate): boolean {
+    return !!certificate && !!(certificate.toSocketOptions() as { pfx?: unknown }).pfx;
+}
+
+/**
+ * Throws when a PKCS#12 archive is configured on a Bun too old to present it: before
+ * Bun 1.4.0 neither transport works - `fetch` ignores `tls.pfx` and `node:https` drops
+ * the client certificate (and the `ca`) as well. Called from
+ * RequestExecutor.validateCertificateRuntimeSupport at DocumentStore.initialize(), so the
+ * misconfiguration surfaces at startup instead of as an opaque TLS failure per request.
+ */
+export function validateBunCertificateSupport(certificate: ICertificate): void {
+    if (!requiresNodeHttpsTransport(certificate)) {
+        return;
+    }
+
+    const version = RuntimeUtil.getBunVersion();
+
+    if (!version || supportsNodeHttpsClientCertificates(version)) {
+        return;
+    }
+
+    throwError("InvalidOperationException",
+        `A PKCS#12 (PFX) client certificate was configured via authOptions, but Bun ${version} `
+        + "cannot present one: its fetch ignores the `tls.pfx` option and its node:https ignored "
+        + `client certificates before Bun ${MIN_BUN_MAJOR_MINOR_FOR_PFX.join(".")}.0. `
+        + `Upgrade to Bun ${MIN_BUN_MAJOR_MINOR_FOR_PFX.join(".")}.0 or newer, or convert the archive `
+        + "to PEM (e.g. openssl pkcs12 -in cert.pfx -out cert.pem -nodes) and configure authOptions "
+        + "with type \"pem\".");
+}
+
+function supportsNodeHttpsClientCertificates(version: string): boolean {
+    const [major, minor] = version.split(".").map(part => Number.parseInt(part, 10));
+
+    if (!Number.isInteger(major) || !Number.isInteger(minor)) {
+        // An unreadable version is not evidence of an old runtime - let the request path
+        // decide rather than refusing to start.
+        return true;
+    }
+
+    const [minMajor, minMinor] = MIN_BUN_MAJOR_MINOR_FOR_PFX;
+    return major > minMajor || (major === minMajor && minor >= minMinor);
+}
+
+/**
+ * The `node:https.Agent` options presenting the configured client certificate.
+ * `toSocketOptions()` already produces exactly the TLS shape an Agent takes.
+ */
+export function buildNodeHttpsAgentOptions(certificate: ICertificate): NodeHttpsAgentOptions {
+    return {
+        ...certificate.toSocketOptions(),
+        keepAlive: true
+    };
+}
+
+/**
+ * Builds a `fetch`-compatible transport that issues requests through `node:https`, so a
+ * PKCS#12 client certificate is actually presented on Bun (see requiresNodeHttpsTransport).
+ * It is installed as the request `fetcher`, the same seam `conventions.customFetch` uses.
+ *
+ * Covers what the client asks of `fetch`: methods, headers, string/binary/FormData bodies,
+ * streamed response bodies, `AbortSignal`, and content-encoding decompression. It does NOT
+ * follow redirects - the RavenDB API does not use them, and silently re-issuing a request
+ * elsewhere is worse than surfacing the 3xx.
+ */
+export function createNodeHttpsTransport(certificate: ICertificate): BunHttpTransport {
+    const agentOptions = buildNodeHttpsAgentOptions(certificate);
+
+    let loading: Promise<NodeHttpModules> = null;
+    let loaded: NodeHttpModules = null;
+    let closed = false;
+
+    function load(): Promise<NodeHttpModules> {
+        if (!loading) {
+            loading = (async () => {
+                const http = await import("node:http");
+                const https = await import("node:https");
+                const zlib = await import("node:zlib");
+
+                loaded = {
+                    request: http.request,
+                    secureRequest: https.request,
+                    zlib,
+                    httpAgent: new http.Agent({ keepAlive: true }),
+                    httpsAgent: new https.Agent(agentOptions)
+                };
+
+                // close() may have run while the imports were in flight.
+                if (closed) {
+                    destroyAgents(loaded);
+                }
+
+                return loaded;
+            })();
+        }
+
+        return loading;
+    }
+
+    const transportFetch: NodeHttpsFetch = Object.assign(
+        async (url: string, init?: RequestInit) => nodeHttpsFetch(await load(), url, init),
+        { acceptsNodeStreamBody: true as const });
+
+    return {
+        fetch: transportFetch,
+        close: () => {
+            closed = true;
+            if (loaded) {
+                destroyAgents(loaded);
+            }
+        }
+    };
+}
+
+function destroyAgents(modules: NodeHttpModules): void {
+    modules.httpAgent.destroy();
+    modules.httpsAgent.destroy();
+}
+
+async function nodeHttpsFetch(modules: NodeHttpModules, url: string, init?: RequestInit): Promise<Response> {
+    const target = new URL(url);
+    const secure = target.protocol !== "http:";
+    const method = (init?.method ?? "GET").toUpperCase();
+    const signal = init?.signal;
+
+    if (signal?.aborted) {
+        throw toAbortError(signal);
+    }
+
+    const { payload, stream, headers } = await encodeRequestBody(init, method);
+
+    const requestOptions: RequestOptions = {
+        method,
+        headers,
+        agent: secure ? modules.httpsAgent : modules.httpAgent
+    };
+
+    return new Promise<Response>((resolve, reject) => {
+        const request = (secure ? modules.secureRequest : modules.request)(target, requestOptions, res => {
+            try {
+                resolve(toResponse(modules, res, method));
+            } catch (err) {
+                res.destroy();
+                reject(err);
+            }
+        });
+
+        const onAbort = () => request.destroy(toAbortError(signal));
+        signal?.addEventListener("abort", onAbort, { once: true });
+        // Kept for the whole request, not just until the headers land: an abort during a
+        // streamed response body must tear the connection down too.
+        request.on("close", () => signal?.removeEventListener("abort", onAbort));
+
+        request.on("error", reject);
+
+        if (stream) {
+            stream.on("error", err => request.destroy(err));
+            stream.pipe(request);
+        } else if (payload) {
+            request.end(payload);
+        } else {
+            request.end();
+        }
+    });
+}
+
+/**
+ * Turns the `fetch` body shapes the client uses into bytes: strings and binary go
+ * straight through, everything else (FormData with attachment blobs, Blob,
+ * URLSearchParams, a web stream) is encoded by the platform `Response`, which also
+ * yields the `content-type` - including the multipart boundary the batch command relies
+ * on fetch to generate.
+ *
+ * A `node:stream` Readable (an attachment payload) is piped instead, so uploading a large
+ * file does not have to fit in memory first.
+ */
+async function encodeRequestBody(
+    init: RequestInit | undefined,
+    method: string): Promise<{ payload: Buffer, stream: Readable, headers: Record<string, string> }> {
+
+    const headers = new Headers(init?.headers ?? {});
+    const body = init?.body;
+    let payload: Buffer = null;
+    let stream: Readable = null;
+
+    if (body !== null && body !== undefined) {
+        if (isNodeReadable(body)) {
+            stream = body;
+        } else if (typeof body === "string") {
+            payload = Buffer.from(body, "utf8");
+        } else if (Buffer.isBuffer(body)) {
+            payload = body;
+        } else if (ArrayBuffer.isView(body)) {
+            payload = Buffer.from(body.buffer, body.byteOffset, body.byteLength);
+        } else if (body instanceof ArrayBuffer) {
+            payload = Buffer.from(body);
+        } else {
+            const encoded = new Response(body);
+            payload = Buffer.from(await encoded.arrayBuffer());
+
+            const contentType = encoded.headers.get("content-type");
+            if (contentType && !headers.has("content-type")) {
+                headers.set("content-type", contentType);
+            }
+        }
+    }
+
+    // node:http would otherwise fall back to chunked transfer encoding; fetch always
+    // sends a length, and RavenDB's 0-length POSTs need the explicit zero. A streamed body
+    // has no length to send - that one stays chunked, exactly as undici sends it on Node.
+    if (payload) {
+        headers.set("content-length", String(payload.length));
+    } else if (!stream && method !== "GET" && method !== "HEAD") {
+        headers.set("content-length", "0");
+    }
+
+    const outgoing: Record<string, string> = {};
+    headers.forEach((value, name) => outgoing[name] = value);
+
+    return { payload, stream, headers: outgoing };
+}
+
+// Duck-typed on purpose: this module holds no runtime dependency on node:stream, and an
+// attachment Readable can come from a different copy of it (CommonJS vs ESM build).
+function isNodeReadable(body: unknown): body is Readable {
+    const candidate = body as Readable;
+    return !!candidate && typeof candidate.pipe === "function" && typeof candidate.on === "function";
+}
+
+function toResponse(modules: NodeHttpModules, res: IncomingMessage, method: string): Response {
+    const status = res.statusCode;
+    const headers = new Headers();
+
+    for (const [name, value] of Object.entries(res.headers)) {
+        if (value === undefined) {
+            continue;
+        }
+
+        if (Array.isArray(value)) {
+            value.forEach(entry => headers.append(name, entry));
+        } else {
+            headers.append(name, value);
+        }
+    }
+
+    const decompressor = createDecompressor(modules.zlib, res.headers["content-encoding"]);
+    let stream: Readable = res;
+
+    if (decompressor) {
+        // Mirror fetch: the caller sees the decoded body, so the encoding headers that
+        // described the wire bytes must not survive.
+        headers.delete("content-encoding");
+        headers.delete("content-length");
+        stream = res.pipe(decompressor);
+    }
+
+    if (method === "HEAD" || NULL_BODY_STATUSES.has(status)) {
+        res.resume(); // release the socket back to the keep-alive pool
+        return new Response(null, { status, statusText: res.statusMessage, headers });
+    }
+
+    return new Response(toWebStream(stream), { status, statusText: res.statusMessage, headers });
+}
+
+function createDecompressor(zlib: typeof import("node:zlib"), encoding: string | string[]): Transform {
+    const name = (Array.isArray(encoding) ? encoding[0] : encoding ?? "").trim().toLowerCase();
+
+    switch (name) {
+        case "gzip":
+        case "x-gzip":
+            return zlib.createGunzip();
+        case "deflate":
+            return zlib.createInflate();
+        case "br":
+            return zlib.createBrotliDecompress();
+        case "zstd":
+            // Node >= 22.15 / Bun >= 1.2; an older runtime simply gets the raw bytes,
+            // which is what it would have got before this transport existed.
+            return typeof zlib.createZstdDecompress === "function" ? zlib.createZstdDecompress() : null;
+        default:
+            return null;
+    }
+}
+
+function toWebStream(stream: Readable): ReadableStream<Uint8Array> {
+    let finished = false;
+
+    return new ReadableStream<Uint8Array>({
+        start(controller) {
+            stream.on("data", (chunk: Buffer) => {
+                if (finished) {
+                    return;
+                }
+
+                try {
+                    controller.enqueue(new Uint8Array(chunk));
+                } catch {
+                    // the consumer cancelled between two chunks
+                    finished = true;
+                    stream.destroy();
+                    return;
+                }
+
+                if (controller.desiredSize !== null && controller.desiredSize <= 0) {
+                    stream.pause();
+                }
+            });
+
+            stream.on("end", () => {
+                if (!finished) {
+                    finished = true;
+                    controller.close();
+                }
+            });
+
+            stream.on("error", err => {
+                if (!finished) {
+                    finished = true;
+                    controller.error(err);
+                }
+            });
+        },
+        pull() {
+            stream.resume();
+        },
+        cancel() {
+            finished = true;
+            stream.destroy();
+        }
+    });
+}
+
+function toAbortError(signal: AbortSignal): Error {
+    const reason = signal?.reason;
+
+    if (reason instanceof Error) {
+        return reason;
+    }
+
+    // RequestExecutor branches on error.name === "AbortError" (its request timeout path).
+    const error = new Error("The operation was aborted");
+    error.name = "AbortError";
+    return error;
+}

--- a/src/Utility/RuntimeUtil.ts
+++ b/src/Utility/RuntimeUtil.ts
@@ -20,6 +20,14 @@ export class RuntimeUtil {
     }
 
     /**
+     * The running Bun version (e.g. "1.4.2"), or null off Bun. Not cached: capability
+     * checks read it rarely, and tests stub it around single calls.
+     */
+    public static getBunVersion(): string {
+        return (typeof process !== "undefined" && process.versions?.bun) || null;
+    }
+
+    /**
      * Detects if the code is running in the Cloudflare Workers (workerd) runtime.
      *
      * workerd exposes the Web `navigator.userAgent` as the string

--- a/test/Executor/RequestExecutorBunTests.ts
+++ b/test/Executor/RequestExecutorBunTests.ts
@@ -1,0 +1,145 @@
+import sinon from "sinon";
+import assert from "node:assert";
+import { RequestExecutor } from "../../src/Http/RequestExecutor.js";
+import { DocumentConventions } from "../../src/Documents/Conventions/DocumentConventions.js";
+import { GetNextOperationIdCommand } from "../../src/Documents/Commands/GetNextOperationIdCommand.js";
+import { IAuthOptions } from "../../src/Auth/AuthOptions.js";
+import { HttpRequestParameters } from "../../src/Primitives/Http.js";
+import { RuntimeUtil } from "../../src/Utility/RuntimeUtil.js";
+import { TypeUtil } from "../../src/Utility/TypeUtil.js";
+
+const PEM_BUNDLE = "-----BEGIN CERTIFICATE-----\nMIIcert\n-----END CERTIFICATE-----\n"
+    + "-----BEGIN RSA PRIVATE KEY-----\nMIIkey\n-----END RSA PRIVATE KEY-----\n";
+const PEM_AUTH: IAuthOptions = { type: "pem", certificate: PEM_BUNDLE };
+const PFX_AUTH: IAuthOptions = { type: "pfx", certificate: Buffer.from("pfx-bytes"), password: "secret" };
+
+function createExecutor(authOptions?: IAuthOptions, conventions = new DocumentConventions()): RequestExecutor {
+    return RequestExecutor.createForSingleNodeWithoutConfigurationUpdates(
+        "https://localhost:8080", "db", { authOptions, documentConventions: conventions });
+}
+
+function createRequest(executor: RequestExecutor): HttpRequestParameters {
+    const node = executor.getTopologyNodes()[0];
+    return (executor as any)._createRequest(node, new GetNextOperationIdCommand(), TypeUtil.NOOP);
+}
+
+describe("RequestExecutor on Bun", function () {
+
+    let isBun: sinon.SinonStub;
+    let bunVersion: sinon.SinonStub;
+
+    beforeEach(() => {
+        isBun = sinon.stub(RuntimeUtil, "isBun").returns(true);
+        bunVersion = sinon.stub(RuntimeUtil, "getBunVersion").returns("1.4.2");
+    });
+
+    afterEach(() => {
+        isBun.restore();
+        bunVersion.restore();
+    });
+
+    describe("PKCS#12 client certificate", function () {
+
+        it("presents it through one node:https fetcher per executor, released on dispose", function () {
+            const executor = createExecutor(PFX_AUTH);
+
+            const first = createRequest(executor);
+            const second = createRequest(executor);
+
+            assert.strictEqual(typeof first.fetcher, "function", "request carries the node:https fetcher");
+            assert.strictEqual(second.fetcher, first.fetcher, "one transport per executor");
+
+            executor.dispose();
+            assert.strictEqual(executor["_bunHttpTransport"], null, "dispose() releases the transport");
+        });
+
+        it("does not put the archive in Bun's tls option - fetch would ignore it", function () {
+            const executor = createExecutor(PFX_AUTH);
+
+            try {
+                assert.strictEqual(createRequest(executor).tls, undefined);
+            } finally {
+                executor.dispose();
+            }
+        });
+
+        it("leaves the transport to conventions.customFetch when one is configured", function () {
+            const conventions = new DocumentConventions();
+            const customFetch = () => Promise.resolve(new Response());
+            conventions.customFetch = customFetch;
+
+            const executor = createExecutor(PFX_AUTH, conventions);
+
+            try {
+                assert.strictEqual(createRequest(executor).fetcher, customFetch);
+                assert.strictEqual(executor["_bunHttpTransport"], null, "no node:https transport is built");
+            } finally {
+                executor.dispose();
+            }
+        });
+    });
+
+    describe("PEM client certificate", function () {
+
+        it("keeps using Bun's tls request option - its fetch honours cert/key", function () {
+            const executor = createExecutor(PEM_AUTH);
+
+            try {
+                const request = createRequest(executor);
+
+                assert.match(request.tls.cert as string, /BEGIN CERTIFICATE/);
+                assert.match(request.tls.key as string, /BEGIN RSA PRIVATE KEY/);
+                assert.strictEqual(request.fetcher, undefined, "no node:https fetcher is installed");
+                assert.strictEqual(executor["_bunHttpTransport"], null);
+            } finally {
+                executor.dispose();
+            }
+        });
+    });
+
+    describe("validateCertificateRuntimeSupport", function () {
+
+        it("accepts a PKCS#12 archive on a Bun that can present it", function () {
+            RequestExecutor.validateCertificateRuntimeSupport(PFX_AUTH, new DocumentConventions());
+        });
+
+        it("throws at initialize() time on a Bun that cannot present one", function () {
+            bunVersion.returns("1.3.8");
+
+            assert.throws(
+                () => RequestExecutor.validateCertificateRuntimeSupport(PFX_AUTH, new DocumentConventions()),
+                /PKCS#12/);
+        });
+
+        it("accepts a PEM certificate on any Bun", function () {
+            bunVersion.returns("1.3.8");
+            RequestExecutor.validateCertificateRuntimeSupport(PEM_AUTH, new DocumentConventions());
+        });
+
+        it("skips the check when conventions.customFetch owns the transport", function () {
+            bunVersion.returns("1.3.8");
+            const conventions = new DocumentConventions();
+            conventions.customFetch = () => Promise.resolve(new Response());
+
+            RequestExecutor.validateCertificateRuntimeSupport(PFX_AUTH, conventions);
+        });
+    });
+
+    describe("outside Bun", function () {
+
+        it("installs nothing for a PKCS#12 certificate - Node presents it through the undici agent", function () {
+            isBun.returns(false);
+            const executor = createExecutor(PFX_AUTH);
+
+            try {
+                const request = createRequest(executor);
+
+                assert.strictEqual(request.fetcher, undefined);
+                assert.strictEqual(request.tls, undefined);
+                assert.strictEqual(executor["_bunHttpTransport"], null);
+            } finally {
+                executor.dispose();
+            }
+        });
+    });
+});

--- a/test/Utility/BunHttpUtilTest.ts
+++ b/test/Utility/BunHttpUtilTest.ts
@@ -1,0 +1,338 @@
+import sinon from "sinon";
+import { createServer, IncomingMessage, Server, ServerResponse } from "node:http";
+import { Readable } from "node:stream";
+import { AddressInfo } from "node:net";
+import { gzipSync } from "node:zlib";
+import assert from "node:assert";
+import { Certificate } from "../../src/Auth/Certificate.js";
+import {
+    BunHttpTransport,
+    buildNodeHttpsAgentOptions,
+    createNodeHttpsTransport,
+    requiresNodeHttpsTransport,
+    validateBunCertificateSupport
+} from "../../src/Utility/BunHttpUtil.js";
+import { RuntimeUtil } from "../../src/Utility/RuntimeUtil.js";
+
+const PEM_BUNDLE = "-----BEGIN CERTIFICATE-----\nMIIcert\n-----END CERTIFICATE-----\n"
+    + "-----BEGIN RSA PRIVATE KEY-----\nMIIkey\n-----END RSA PRIVATE KEY-----\n";
+const PFX_BYTES = Buffer.from("pfx-bytes");
+
+type Handler = (req: IncomingMessage, res: ServerResponse, body: Buffer) => void;
+
+describe("BunHttpUtil", function () {
+
+    describe("requiresNodeHttpsTransport", function () {
+
+        it("is true for a PFX certificate - Bun's fetch ignores tls.pfx", function () {
+            assert.strictEqual(requiresNodeHttpsTransport(Certificate.createPfx(PFX_BYTES)), true);
+        });
+
+        it("is false for a PEM certificate - Bun's fetch honours tls.cert/key", function () {
+            assert.strictEqual(requiresNodeHttpsTransport(Certificate.createPem(PEM_BUNDLE)), false);
+        });
+
+        it("is false without a certificate", function () {
+            assert.strictEqual(requiresNodeHttpsTransport(null), false);
+        });
+    });
+
+    describe("buildNodeHttpsAgentOptions", function () {
+
+        it("carries the PKCS#12 archive, its passphrase and the CA", function () {
+            const ca = Buffer.from("ca-bytes");
+            const options = buildNodeHttpsAgentOptions(Certificate.createPfx(PFX_BYTES, "secret", ca));
+
+            assert.strictEqual(options.pfx, PFX_BYTES);
+            assert.strictEqual(options.passphrase, "secret");
+            assert.strictEqual(options.ca, ca);
+            assert.strictEqual(options.keepAlive, true);
+        });
+    });
+
+    describe("validateBunCertificateSupport", function () {
+
+        let bunVersion: sinon.SinonStub;
+
+        beforeEach(() => {
+            bunVersion = sinon.stub(RuntimeUtil, "getBunVersion");
+        });
+
+        afterEach(() => {
+            bunVersion.restore();
+        });
+
+        it("accepts a PKCS#12 archive on a Bun whose node:https presents it", function () {
+            bunVersion.returns("1.4.0");
+            validateBunCertificateSupport(Certificate.createPfx(PFX_BYTES));
+
+            bunVersion.returns("1.5.2");
+            validateBunCertificateSupport(Certificate.createPfx(PFX_BYTES));
+        });
+
+        it("rejects a PKCS#12 archive on a Bun that cannot present one, with a way out", function () {
+            bunVersion.returns("1.3.8");
+
+            assert.throws(() => validateBunCertificateSupport(Certificate.createPfx(PFX_BYTES)),
+                (err: Error) => {
+                    assert.match(err.message, /1\.3\.8/);
+                    assert.match(err.message, /1\.4\.0 or newer/);
+                    assert.match(err.message, /openssl pkcs12/);
+                    return true;
+                });
+        });
+
+        it("accepts a PEM certificate on any Bun", function () {
+            bunVersion.returns("1.3.8");
+            validateBunCertificateSupport(Certificate.createPem(PEM_BUNDLE));
+        });
+
+        it("does not apply off Bun", function () {
+            bunVersion.returns(null);
+            validateBunCertificateSupport(Certificate.createPfx(PFX_BYTES));
+        });
+
+        it("does not refuse to start on an unreadable version", function () {
+            bunVersion.returns("not-a-version");
+            validateBunCertificateSupport(Certificate.createPfx(PFX_BYTES));
+        });
+    });
+
+    describe("createNodeHttpsTransport", function () {
+
+        let server: Server;
+        let baseUrl: string;
+        let handler: Handler;
+        let transport: BunHttpTransport;
+
+        beforeEach(async function () {
+            handler = (req, res) => res.end("ok");
+            server = createServer((req, res) => {
+                const chunks: Buffer[] = [];
+                req.on("data", c => chunks.push(c));
+                req.on("end", () => handler(req, res, Buffer.concat(chunks)));
+            });
+
+            await new Promise<void>(resolve => server.listen(0, "127.0.0.1", resolve));
+            baseUrl = "http://127.0.0.1:" + (server.address() as AddressInfo).port;
+            transport = createNodeHttpsTransport(Certificate.createPfx(PFX_BYTES));
+        });
+
+        afterEach(async function () {
+            transport.close();
+            await new Promise<void>(resolve => server.close(() => resolve()));
+        });
+
+        it("maps status, status text, headers and body onto a Response", async function () {
+            handler = (req, res) => {
+                res.writeHead(201, "Created Here", { "Custom-Header": "custom-value" });
+                res.end("hello");
+            };
+
+            const response = await transport.fetch(baseUrl + "/docs");
+
+            assert.strictEqual(response.status, 201);
+            assert.strictEqual(response.statusText, "Created Here");
+            assert.strictEqual(response.headers.get("custom-header"), "custom-value");
+            assert.strictEqual(await response.text(), "hello");
+        });
+
+        it("sends the method, path, query and request headers", async function () {
+            let seen: { method: string, url: string, header: string };
+            handler = (req, res) => {
+                seen = { method: req.method, url: req.url, header: req.headers["x-raven"] as string };
+                res.end("ok");
+            };
+
+            await transport.fetch(baseUrl + "/databases/db/docs?id=users%2F1", {
+                method: "DELETE",
+                headers: { "X-Raven": "yes" }
+            });
+
+            assert.strictEqual(seen.method, "DELETE");
+            assert.strictEqual(seen.url, "/databases/db/docs?id=users%2F1");
+            assert.strictEqual(seen.header, "yes");
+        });
+
+        it("sends a string body with the caller's content type", async function () {
+            let seen: { body: string, contentType: string };
+            handler = (req, res, body) => {
+                seen = { body: body.toString(), contentType: req.headers["content-type"] };
+                res.end("ok");
+            };
+
+            await transport.fetch(baseUrl + "/bulk_docs", {
+                method: "POST",
+                body: "{\"Commands\":[]}",
+                headers: { "Content-Type": "application/json" }
+            });
+
+            assert.strictEqual(seen.body, "{\"Commands\":[]}");
+            assert.strictEqual(seen.contentType, "application/json");
+        });
+
+        it("sends a Buffer body", async function () {
+            let seen: Buffer;
+            handler = (req, res, body) => {
+                seen = body;
+                res.end("ok");
+            };
+
+            await transport.fetch(baseUrl + "/attachments", { method: "PUT", body: Buffer.from([1, 2, 3]) });
+
+            assert.deepStrictEqual([...seen], [1, 2, 3]);
+        });
+
+        it("streams a node:stream Readable body instead of buffering it", async function () {
+            let seen: { body: string, transferEncoding: string, contentLength: string };
+            handler = (req, res, body) => {
+                seen = {
+                    body: body.toString(),
+                    transferEncoding: req.headers["transfer-encoding"],
+                    contentLength: req.headers["content-length"]
+                };
+                res.end("ok");
+            };
+
+            await transport.fetch(baseUrl + "/attachments", {
+                method: "PUT",
+                body: Readable.from([Buffer.from("chunk-one"), Buffer.from("chunk-two")]) as any
+            });
+
+            assert.strictEqual(seen.body, "chunk-onechunk-two");
+            assert.strictEqual(seen.transferEncoding, "chunked");
+            assert.strictEqual(seen.contentLength, undefined);
+        });
+
+        it("declares that it accepts a node:stream Readable body", function () {
+            assert.strictEqual(transport.fetch.acceptsNodeStreamBody, true);
+        });
+
+        it("encodes a FormData body and derives its multipart content type", async function () {
+            let seen: { body: string, contentType: string };
+            handler = (req, res, body) => {
+                seen = { body: body.toString(), contentType: req.headers["content-type"] };
+                res.end("ok");
+            };
+
+            const form = new FormData();
+            form.append("main", new Blob(["{}"], { type: "application/json" }));
+
+            await transport.fetch(baseUrl + "/bulk_docs", { method: "POST", body: form });
+
+            assert.match(seen.contentType, /^multipart\/form-data; boundary=/);
+            assert.match(seen.body, /name="main"/);
+        });
+
+        it("decompresses a gzip response and drops the encoding headers", async function () {
+            const payload = gzipSync(Buffer.from("{\"Results\":[]}"));
+            handler = (req, res) => {
+                res.writeHead(200, { "Content-Encoding": "gzip", "Content-Length": String(payload.length) });
+                res.end(payload);
+            };
+
+            const response = await transport.fetch(baseUrl + "/docs");
+
+            assert.strictEqual(await response.text(), "{\"Results\":[]}");
+            assert.strictEqual(response.headers.get("content-encoding"), null);
+            assert.strictEqual(response.headers.get("content-length"), null);
+        });
+
+        it("gives a 304 a null body instead of failing to build the Response", async function () {
+            handler = (req, res) => {
+                res.writeHead(304, { ETag: "\"5\"" });
+                res.end();
+            };
+
+            const response = await transport.fetch(baseUrl + "/docs");
+
+            assert.strictEqual(response.status, 304);
+            assert.strictEqual(response.body, null);
+            assert.strictEqual(response.headers.get("etag"), "\"5\"");
+        });
+
+        it("streams the response body instead of buffering it", async function () {
+            let release: () => void;
+            const released = new Promise<void>(resolve => release = resolve);
+
+            handler = async (req, res) => {
+                res.writeHead(200);
+                res.write("first");
+                await released;
+                res.end("second");
+            };
+
+            const response = await transport.fetch(baseUrl + "/stream");
+            const reader = response.body.getReader();
+
+            const first = await reader.read();
+            assert.strictEqual(Buffer.from(first.value).toString(), "first");
+
+            release();
+
+            const rest: string[] = [];
+            for (; ;) {
+                const chunk = await reader.read();
+                if (chunk.done) {
+                    break;
+                }
+                rest.push(Buffer.from(chunk.value).toString());
+            }
+            assert.strictEqual(rest.join(""), "second");
+        });
+
+        it("rejects with an AbortError when the signal is aborted mid-request", async function () {
+            const controller = new AbortController();
+            handler = (req, res) => {
+                controller.abort();
+                // never responds - only the abort can settle the request
+            };
+
+            await assert.rejects(
+                transport.fetch(baseUrl + "/docs", { signal: controller.signal }),
+                (err: Error) => {
+                    assert.strictEqual(err.name, "AbortError");
+                    return true;
+                });
+        });
+
+        it("rejects with an AbortError when the signal is already aborted", async function () {
+            await assert.rejects(
+                transport.fetch(baseUrl + "/docs", { signal: AbortSignal.abort() }),
+                (err: Error) => {
+                    assert.strictEqual(err.name, "AbortError");
+                    return true;
+                });
+        });
+
+        it("rejects when the connection fails", async function () {
+            await assert.rejects(transport.fetch("http://127.0.0.1:1/docs"));
+        });
+
+        it("closes the pooled connections on close()", async function () {
+            const closedSockets: Promise<void>[] = [];
+            handler = (req, res) => {
+                closedSockets.push(new Promise<void>(resolve => req.socket.on("close", () => resolve())));
+                res.end("ok");
+            };
+
+            await (await transport.fetch(baseUrl + "/docs")).text();
+            transport.close();
+
+            await Promise.all(closedSockets);
+        });
+
+        it("reuses one keep-alive connection across requests", async function () {
+            const sockets = new Set<unknown>();
+            handler = (req, res) => {
+                sockets.add(req.socket);
+                res.end("ok");
+            };
+
+            await (await transport.fetch(baseUrl + "/one")).text();
+            await (await transport.fetch(baseUrl + "/two")).text();
+
+            assert.strictEqual(sockets.size, 1);
+        });
+    });
+});


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RDBC-1092

### Description

Bun's `fetch` silently ignores the `tls.pfx` option ([oven-sh/bun#41958](https://github.com/oven-sh/bun/issues/41958), [oven-sh/bun#17543](https://github.com/oven-sh/bun/issues/17543)), so a PKCS#12 certificate configured through `authOptions` was never presented and the request went out uncertified. Its `node:https` implementation does honour `pfx` ([oven-sh/bun#14417](https://github.com/oven-sh/bun/issues/14417)), so those requests are routed there instead.

`src/Utility/BunHttpUtil.ts` installs a fetch-compatible transport backed by `node:https` as the request `fetcher` (the same seam `conventions.customFetch` uses) when a PKCS#12 archive is configured on Bun. PEM material keeps using Bun's `tls` fetch option, which works. The transport is built lazily, once per executor, closed in `dispose()`, and not installed when `conventions.customFetch` owns the transport, the same rules the Deno `Deno.HttpClient` path follows. Whether the certificate needs it is decided once, in the executor constructor, not per request.

Before Bun 1.4.0 neither transport presents a client certificate (`node:https` ignored the certificate and the `ca` as well; verified on 1.3.6 vs 1.4.0), so `DocumentStore.initialize()` now throws an actionable error there instead of failing per request. An unparseable `process.versions.bun` is not treated as an old runtime; the request path decides.

`RavenCommand.send` passes a `node:stream` `Readable` body through when the fetcher declares `acceptsNodeStreamBody`, so streamed attachment uploads keep working on that path. The global `fetch` and a user-supplied `customFetch` do not declare it, so their behaviour is unchanged.

Also drops the `console.warn` from `PfxCertificate.toBunTlsOptions` (the method itself stays: it is public API, and the executor no longer calls it for a PKCS#12 archive on Bun) and documents the Bun runtime in `README.md`, including the pre-existing Changes API gap (Bun's built-in WebSocket ignores the `ws` package's TLS options — upstream [oven-sh/bun#31396](https://github.com/oven-sh/bun/issues/31396), and for the PKCS#12 half [oven-sh/bun#42322](https://github.com/oven-sh/bun/issues/42322)).

#### Transport design notes

- **PKCS#12 detection** reads `certificate.toSocketOptions().pfx` rather than `instanceof PfxCertificate`: the package ships CommonJS and ESM builds with separate class identities, and a certificate created from the other build would silently fail the `instanceof` check and go out uncertified. The `node:stream` `Readable` check on request bodies is duck-typed for the same reason.
- **Request bodies**: strings and binary go straight through; `FormData`, `Blob`, `URLSearchParams` and web streams are encoded by the platform `Response`, which also yields the `content-type` (including the multipart boundary the batch command relies on `fetch` to generate). A `node:stream` `Readable` is piped, so a large attachment does not have to fit in memory first.
- **`content-length`**: `node:http` would otherwise fall back to chunked transfer encoding. The transport mirrors `fetch` and always sends a length, including an explicit `content-length: 0` for body-less non-GET/HEAD requests. A streamed body has no length and stays chunked, exactly as undici sends it on Node.
- **`accept-encoding`** is built from what the runtime's `zlib` can decode: `gzip`, `deflate`, `br`, plus `zstd` where `createZstdDecompress` exists (Node >= 22.15, Bun >= 1.2; an older runtime gets the raw bytes). A decoded response drops `content-encoding` and `content-length`, as `fetch` does. Decompression runs through `stream.pipeline`, so a source error tears the decompressor down instead of leaving the body hanging.
- **Body-less responses** (HEAD, 204, 205, 304) are decided before any decompressor exists: the `Response` constructor rejects a body for those statuses, and a gunzip on empty input is an unhandled `Z_BUF_ERROR`.
- **Abort**: the `abort` listener stays registered until the request closes, not just until the headers land, so an abort during a streamed response body tears the connection down too. The body then fails with the signal's `AbortError` (`RequestExecutor` branches on `error.name === "AbortError"` for its timeout path) rather than an `ECONNRESET`.
- **Redirects are not followed**: the RavenDB API does not use them, and silently re-issuing a request elsewhere is worse than surfacing the 3xx.
- `BunTlsOptions.pfx` stays in the type for shape compatibility with Node's TLS options; its doc now only warns that Bun's `fetch` ignores it.

**Verification run locally:** `tsc --noEmit` clean; `test/Utility/BunHttpUtilTest.ts` + `test/Executor/RequestExecutorBunTests.ts` 38 passing across 5 consecutive runs (the transport tests no longer use timers); `eslint` clean on every file this PR touches; `npm run check-exports` passes. `npm run lint` over the whole repo reports 4 errors, all in the generated, gitignored `test/cloudflare-nitro/.nitro/types/` output — unrelated to this change. There is no `npm run build` script (`prepare` runs tshy); `npm run check-imports` was not run because it rewrites `src/index.ts`. End-to-end verified on Bun 1.4.3 against RavenDB 7.2.6 over a PFX certificate (HttpsTest, and a `DocumentStore` with `useHttpDecompression = true` receiving `content-encoding: zstd`).

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature
- [ ] Sync with the C# client (version `x.y.z` -> `x.y.z`)
- [ ] Dependency / tooling / CI update

### Target branch and backports

- [x] This PR targets the correct release branch (e.g. `v7.2`, `v7.1`, `v7.0`, `v6.0`)
- [ ] The change needs to be ported to other release branches. Please list them.
- [x] No other release branch is affected

### How risky is the change?

- [x] Low
- [ ] Moderate
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change (public API, exported types, default behavior). Please describe the migration path.
- [ ] Not relevant

### Server compatibility

- [x] Works with all RavenDB server versions covered by CI
- [ ] Requires a minimum server version. Please specify which one and make sure the tests are gated accordingly.
- [ ] Not relevant

### Affected runtimes

- [ ] Node.js
- [x] Bun
- [ ] Deno
- [ ] Cloudflare Workers
- [ ] Not runtime specific

### Public API

- [ ] New or changed public API. New types are exported from `src/index.ts` (`npm run check-exports` passes).
- [ ] Version bump: `package.json` and `CLIENT_VERSION` in `src/Http/RequestExecutor.ts` (sync / release PRs only)
- [x] No public API changes

### Documentation update

- [x] `README.md` has been updated
- [ ] No documentation update is needed

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Existing tests verify the correct behavior
- [x] It has been verified by manual testing
- [ ] `npm run lint`, `npm run build`, `npm run check-exports` and `npm run check-imports` pass locally
- [x] Tests have been run locally against a RavenDB server (`RAVENDB_TEST_SERVER_PATH` / `RAVENDB_SERVER_VERSION`)
- [x] Runtime-specific changes have been verified on the affected runtime (Bun / Deno / Cloudflare Workers)

### Dependencies

- [ ] New or updated runtime dependency. Please explain why it is needed and confirm it works on all affected runtimes.
- [ ] Dev dependency only
- [x] No dependency changes

### Is there any existing behavior change of other features due to this change?

- [x] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

Two, both on Bun only:

1. **PKCS#12 on Bun now goes through `node:https` rather than `fetch`.** Previously the request went out with no client certificate and the server rejected it; it now authenticates. PEM on Bun is unchanged.
2. **PKCS#12 on Bun older than 1.4.0 now throws at `DocumentStore.initialize()`.** Previously every request silently went out uncertified. The error names the `openssl pkcs12 -in cert.pfx -out cert.pem -nodes` conversion and `type: "pem"` as the way to stay on an older Bun.
